### PR TITLE
Add return type to Closure::__invoke()

### DIFF
--- a/Core_c.php
+++ b/Core_c.php
@@ -311,6 +311,9 @@ final class Closure {
      */
     private function __construct() { }
 
+    /**
+     * @return mixed
+     */
     public function __invoke() { }
 
     /**


### PR DESCRIPTION
This is necessary to avoid this inspection message:

> 'void' method '__invoke' result used

When calling `__invoke()` directly:

    $function = function() {};
    $function->__invoke();


