### PR TITLE
Using @since (related to WI-16509)

### DIFF
--- a/Core.php
+++ b/Core.php
@@ -10,7 +10,8 @@
 function zend_version () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Returns the number of arguments passed to the function
  * @link http://php.net/manual/en/function.func-num-args.php
  * @return int the number of arguments passed into the current user-defined
@@ -19,7 +20,8 @@ function zend_version () {}
 function func_num_args () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Return an item from the argument list
  * @link http://php.net/manual/en/function.func-get-arg.php
  * @param int $arg_num <p>
@@ -31,7 +33,8 @@ function func_num_args () {}
 function func_get_arg ($arg_num) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Returns an array comprising a function's argument list
  * @link http://php.net/manual/en/function.func-get-args.php
  * @return array an array in which each element is a copy of the corresponding
@@ -40,7 +43,8 @@ function func_get_arg ($arg_num) {}
 function func_get_args () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get string length
  * @link http://php.net/manual/en/function.strlen.php
  * @param string $string <p>
@@ -52,7 +56,8 @@ function func_get_args () {}
 function strlen ($string) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Binary safe string comparison
  * @link http://php.net/manual/en/function.strcmp.php
  * @param string $str1 <p>
@@ -69,7 +74,8 @@ function strlen ($string) {}
 function strcmp ($str1, $str2) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Binary safe string comparison of the first n characters
  * @link http://php.net/manual/en/function.strncmp.php
  * @param string $str1 <p>
@@ -89,7 +95,8 @@ function strcmp ($str1, $str2) {}
 function strncmp ($str1, $str2, $len) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Binary safe case-insensitive string comparison
  * @link http://php.net/manual/en/function.strcasecmp.php
  * @param string $str1 <p>
@@ -106,7 +113,8 @@ function strncmp ($str1, $str2, $len) {}
 function strcasecmp ($str1, $str2) {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Binary safe case-insensitive string comparison of the first n characters
  * @link http://php.net/manual/en/function.strncasecmp.php
  * @param string $str1 <p>
@@ -125,7 +133,8 @@ function strcasecmp ($str1, $str2) {}
 function strncasecmp ($str1, $str2, $len) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Return the current key and value pair from an array and advance the array cursor
  * @link http://php.net/manual/en/function.each.php
  * @param array $array <p>
@@ -147,7 +156,8 @@ function strncasecmp ($str1, $str2, $len) {}
 function each (array &$array) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Sets which PHP errors are reported
  * @link http://php.net/manual/en/function.error-reporting.php
  * @param int $level [optional] <p>
@@ -272,7 +282,8 @@ function each (array &$array) {}
 function error_reporting ($level = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Defines a named constant
  * @link http://php.net/manual/en/function.define.php
  * @param string $name <p>
@@ -299,7 +310,8 @@ function error_reporting ($level = null) {}
 function define ($name, $value, $case_insensitive = false) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Checks whether a given named constant exists
  * @link http://php.net/manual/en/function.defined.php
  * @param string $name <p>
@@ -311,7 +323,8 @@ function define ($name, $value, $case_insensitive = false) {}
 function defined ($name) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Returns the name of the class of an object
  * @link http://php.net/manual/en/function.get-class.php
  * @param object $object [optional] <p>
@@ -328,7 +341,7 @@ function defined ($name) {}
 function get_class ($object = null) {}
 
 /**
- * (PHP 5 &gt;= 5.3.0)<br/>
+ * @since 5.3.0
  * the "Late Static Binding" class name
  * @link http://php.net/manual/en/function.get-called-class.php
  * @return string the class name. Returns false if called from outside a class.
@@ -336,7 +349,8 @@ function get_class ($object = null) {}
 function get_called_class () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Retrieves the parent class name for object or class
  * @link http://php.net/manual/en/function.get-parent-class.php
  * @param mixed $object [optional] <p>
@@ -354,7 +368,8 @@ function get_called_class () {}
 function get_parent_class ($object = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Checks if the class method exists
  * @link http://php.net/manual/en/function.method-exists.php
  * @param mixed $object <p>
@@ -370,7 +385,7 @@ function get_parent_class ($object = null) {}
 function method_exists ($object, $method_name) {}
 
 /**
- * (PHP 5 &gt;= 5.1.0)<br/>
+ * @since 5.1.0
  * Checks if the object or class has a property
  * @link http://php.net/manual/en/function.property-exists.php
  * @param mixed $class <p>
@@ -385,7 +400,7 @@ function method_exists ($object, $method_name) {}
 function property_exists ($class, $property) {}
 
 /**
- * (PHP 5 &gt;= 5.4.0)<br/>
+ * @since 5.4.0
  * Checks if the trait exists
  * @param string $traitname Name of the trait to check
  * @param bool $autoload [optional] Whether to autoload if not already loaded.
@@ -395,7 +410,8 @@ function property_exists ($class, $property) {}
 function trait_exists($traitname, $autoload ) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Checks if the class has been defined
  * @link http://php.net/manual/en/function.class-exists.php
  * @param string $class_name <p>
@@ -410,7 +426,7 @@ function trait_exists($traitname, $autoload ) {}
 function class_exists ($class_name, $autoload = true) {}
 
 /**
- * (PHP 5 &gt;= 5.0.2)<br/>
+ * @since 5.0.2
  * Checks if the interface has been defined
  * @link http://php.net/manual/en/function.interface-exists.php
  * @param string $interface_name <p>
@@ -425,7 +441,8 @@ function class_exists ($class_name, $autoload = true) {}
 function interface_exists ($interface_name, $autoload = true) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Return true if the given function has been defined
  * @link http://php.net/manual/en/function.function-exists.php
  * @param string $function_name <p>
@@ -441,7 +458,7 @@ function interface_exists ($interface_name, $autoload = true) {}
 function function_exists ($function_name) {}
 
 /**
- * (PHP 5 &gt;= 5.3.0)<br/>
+ * @since 5.3.0
  * Creates an alias for a class
  * @link http://php.net/manual/en/function.class-alias.php
  * @param string $original The original class.
@@ -452,7 +469,8 @@ function function_exists ($function_name) {}
 function class_alias ($original, $alias, $autoload = TRUE) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Returns an array with the names of included or required files
  * @link http://php.net/manual/en/function.get-included-files.php
  * @return string[] an array of the names of all files.
@@ -469,7 +487,8 @@ function class_alias ($original, $alias, $autoload = TRUE) {}
 function get_included_files () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Alias of <b>get_included_files</b>
  * @link http://php.net/manual/en/function.get-required-files.php
  * @return string[]
@@ -477,7 +496,8 @@ function get_included_files () {}
 function get_required_files () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Checks if the object has this class as one of its parents
  * @link http://php.net/manual/en/function.is-subclass-of.php
  * @param mixed $object <p>
@@ -493,7 +513,8 @@ function get_required_files () {}
 function is_subclass_of ($object, $class_name) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Checks if the object is of this class or has this class as one of its parents
  * @link http://php.net/manual/en/function.is-a.php
  * @param object|string $object <p>
@@ -512,7 +533,8 @@ function is_subclass_of ($object, $class_name) {}
 function is_a ($object, $class_name, $allow_string = FALSE) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get the default properties of the class
  * @link http://php.net/manual/en/function.get-class-vars.php
  * @param string $class_name <p>
@@ -526,7 +548,8 @@ function is_a ($object, $class_name, $allow_string = FALSE) {}
 function get_class_vars ($class_name) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Gets the properties of the given object
  * @link http://php.net/manual/en/function.get-object-vars.php
  * @param object $object <p>
@@ -539,7 +562,8 @@ function get_class_vars ($class_name) {}
 function get_object_vars ($object) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Gets the class methods' names
  * @link http://php.net/manual/en/function.get-class-methods.php
  * @param mixed $class_name <p>
@@ -551,7 +575,8 @@ function get_object_vars ($object) {}
 function get_class_methods ($class_name) {}
 
 /**
- * (PHP 4 &gt;= 4.0.1, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Generates a user-level error/warning/notice message
  * @link http://php.net/manual/en/function.trigger-error.php
  * @param string $error_msg <p>
@@ -569,7 +594,8 @@ function get_class_methods ($class_name) {}
 function trigger_error ($error_msg, $error_type = E_USER_NOTICE) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Alias of <b>trigger_error</b>
  * @link http://php.net/manual/en/function.user-error.php
  * @param $message
@@ -578,7 +604,8 @@ function trigger_error ($error_msg, $error_type = E_USER_NOTICE) {}
 function user_error ($message, $error_type) {}
 
 /**
- * (PHP 4 &gt;= 4.0.1, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Sets a user-defined error handler function
  * @link http://php.net/manual/en/function.set-error-handler.php
  * @param callback $error_handler <p>
@@ -615,7 +642,8 @@ function user_error ($message, $error_type) {}
 function set_error_handler ($error_handler, $error_types = E_ALL | E_STRICT) {}
 
 /**
- * (PHP 4 &gt;= 4.0.1, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Restores the previous error handler function
  * @link http://php.net/manual/en/function.restore-error-handler.php
  * @return bool This function always returns true.
@@ -623,7 +651,7 @@ function set_error_handler ($error_handler, $error_types = E_ALL | E_STRICT) {}
 function restore_error_handler () {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Sets a user-defined exception handler function
  * @link http://php.net/manual/en/function.set-exception-handler.php
  * @param callback $exception_handler <p>
@@ -639,7 +667,7 @@ function restore_error_handler () {}
 function set_exception_handler ($exception_handler) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Restores the previously defined exception handler function
  * @link http://php.net/manual/en/function.restore-exception-handler.php
  * @return bool This function always returns true.
@@ -647,7 +675,8 @@ function set_exception_handler ($exception_handler) {}
 function restore_exception_handler () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Returns an array with the name of the defined classes
  * @link http://php.net/manual/en/function.get-declared-classes.php
  * @return array an array of the names of the declared classes in the current
@@ -663,7 +692,7 @@ function restore_exception_handler () {}
 function get_declared_classes () {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Returns an array of all declared interfaces
  * @link http://php.net/manual/en/function.get-declared-interfaces.php
  * @return array an array of the names of the declared interfaces in the current
@@ -672,7 +701,7 @@ function get_declared_classes () {}
 function get_declared_interfaces () {}
 
 /**
- * (PHP 5 &gt;= 5.4.0)<br/>
+ * @since 5.4.0
  * Returns an array of all declared traits
  * @return array with names of all declared traits in values. Returns NULL in case of a failure.
  * @link http://www.php.net/manual/en/function.get-declared-traits.php
@@ -681,7 +710,8 @@ function get_declared_interfaces () {}
 function get_declared_traits() {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Returns an array of all defined functions
  * @link http://php.net/manual/en/function.get-defined-functions.php
  * @return array an multidimensional array containing a list of all defined
@@ -693,7 +723,8 @@ function get_declared_traits() {}
 function get_defined_functions () {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Returns an array of all defined variables
  * @link http://php.net/manual/en/function.get-defined-vars.php
  * @return array A multidimensional array with all the variables.
@@ -701,7 +732,8 @@ function get_defined_functions () {}
 function get_defined_vars () {}
 
 /**
- * (PHP 4 &gt;= 4.0.1, PHP 5)<br/>
+ * @since 4.0.1
+ * @since 5.0
  * Create an anonymous (lambda-style) function
  * @link http://php.net/manual/en/function.create-function.php
  * @param string $args <p>
@@ -715,7 +747,8 @@ function get_defined_vars () {}
 function create_function ($args, $code) {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Returns the resource type
  * @link http://php.net/manual/en/function.get-resource-type.php
  * @param resource $handle <p>
@@ -733,7 +766,8 @@ function create_function ($args, $code) {}
 function get_resource_type ($handle) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Returns an array with the names of all modules compiled and loaded
  * @link http://php.net/manual/en/function.get-loaded-extensions.php
  * @param bool $zend_extensions [optional] <p>
@@ -745,7 +779,8 @@ function get_resource_type ($handle) {}
 function get_loaded_extensions ($zend_extensions = false) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Find out whether an extension is loaded
  * @link http://php.net/manual/en/function.extension-loaded.php
  * @param string $name <p>
@@ -780,7 +815,8 @@ function get_loaded_extensions ($zend_extensions = false) {}
 function extension_loaded ($name) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Returns an array with the names of the functions of a module
  * @link http://php.net/manual/en/function.get-extension-funcs.php
  * @param string $module_name <p>
@@ -795,7 +831,8 @@ function extension_loaded ($name) {}
 function get_extension_funcs ($module_name) {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Returns an associative array with the names of all the constants and their values
  * @link http://php.net/manual/en/function.get-defined-constants.php
  * @param bool $categorize [optional] <p>
@@ -848,7 +885,8 @@ function get_extension_funcs ($module_name) {}
 function get_defined_constants ($categorize = false) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Generates a backtrace
  * @link http://php.net/manual/en/function.debug-backtrace.php
  * @param int $options [optional] <p>
@@ -950,7 +988,7 @@ const DEBUG_BACKTRACE_PROVIDE_OBJECT = 0;
 const DEBUG_BACKTRACE_IGNORE_ARGS = 0;
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Prints a backtrace
  * @link http://php.net/manual/en/function.debug-print-backtrace.php
  * @param int $options [optional] <p>
@@ -975,7 +1013,7 @@ const DEBUG_BACKTRACE_IGNORE_ARGS = 0;
 function debug_print_backtrace ($options = 0, $limit = 0) {}
 
 /**
- * (PHP 5 &gt;= 5.3.0)<br/>
+ * @since 5.3.0
  * Forces collection of any existing garbage cycles
  * @link http://php.net/manual/en/function.gc-collect-cycles.php
  * @return int number of collected cycles.
@@ -983,7 +1021,7 @@ function debug_print_backtrace ($options = 0, $limit = 0) {}
 function gc_collect_cycles () {}
 
 /**
- * (PHP 5 &gt;= 5.3.0)<br/>
+ * @since 5.3.0
  * Returns status of the circular reference collector
  * @link http://php.net/manual/en/function.gc-enabled.php
  * @return bool true if the garbage collector is enabled, false otherwise.
@@ -991,7 +1029,7 @@ function gc_collect_cycles () {}
 function gc_enabled () {}
 
 /**
- * (PHP 5 &gt;= 5.3.0)<br/>
+ * @since 5.3.0
  * Activates the circular reference collector
  * @link http://php.net/manual/en/function.gc-enable.php
  * @return void 
@@ -999,7 +1037,7 @@ function gc_enabled () {}
 function gc_enable () {}
 
 /**
- * (PHP 5 &gt;= 5.3.0)<br/>
+ * @since 5.3.0
  * Deactivates the circular reference collector
  * @link http://php.net/manual/en/function.gc-disable.php
  * @return void 

--- a/Core_c.php
+++ b/Core_c.php
@@ -23,7 +23,7 @@ interface Traversable {
 interface IteratorAggregate extends Traversable {
 
     /**
-     * (PHP 5 &gt;= 5.0.0)<br/>
+     * @since 5.0.0
      * Retrieve an external iterator
      * @link http://php.net/manual/en/iteratoraggregate.getiterator.php
      * @return Traversable An instance of an object implementing <b>Iterator</b> or
@@ -40,7 +40,7 @@ interface IteratorAggregate extends Traversable {
 interface Iterator extends Traversable {
 
     /**
-     * (PHP 5 &gt;= 5.0.0)<br/>
+     * @since 5.0.0
      * Return the current element
      * @link http://php.net/manual/en/iterator.current.php
      * @return mixed Can return any type.
@@ -48,7 +48,7 @@ interface Iterator extends Traversable {
     public function current();
 
     /**
-     * (PHP 5 &gt;= 5.0.0)<br/>
+     * @since 5.0.0
      * Move forward to next element
      * @link http://php.net/manual/en/iterator.next.php
      * @return void Any returned value is ignored.
@@ -56,7 +56,7 @@ interface Iterator extends Traversable {
     public function next();
 
     /**
-     * (PHP 5 &gt;= 5.0.0)<br/>
+     * @since 5.0.0
      * Return the key of the current element
      * @link http://php.net/manual/en/iterator.key.php
      * @return mixed scalar on success, or null on failure.
@@ -64,7 +64,7 @@ interface Iterator extends Traversable {
     public function key();
 
     /**
-     * (PHP 5 &gt;= 5.0.0)<br/>
+     * @since 5.0.0
      * Checks if current position is valid
      * @link http://php.net/manual/en/iterator.valid.php
      * @return boolean The return value will be casted to boolean and then evaluated.
@@ -73,7 +73,7 @@ interface Iterator extends Traversable {
     public function valid();
 
     /**
-     * (PHP 5 &gt;= 5.0.0)<br/>
+     * @since 5.0.0
      * Rewind the Iterator to the first element
      * @link http://php.net/manual/en/iterator.rewind.php
      * @return void Any returned value is ignored.
@@ -88,7 +88,7 @@ interface Iterator extends Traversable {
 interface ArrayAccess {
 
     /**
-     * (PHP 5 &gt;= 5.0.0)<br/>
+     * @since 5.0.0
      * Whether a offset exists
      * @link http://php.net/manual/en/arrayaccess.offsetexists.php
      * @param mixed $offset <p>
@@ -102,7 +102,7 @@ interface ArrayAccess {
     public function offsetExists($offset);
 
     /**
-     * (PHP 5 &gt;= 5.0.0)<br/>
+     * @since 5.0.0
      * Offset to retrieve
      * @link http://php.net/manual/en/arrayaccess.offsetget.php
      * @param mixed $offset <p>
@@ -113,7 +113,7 @@ interface ArrayAccess {
     public function offsetGet($offset);
 
     /**
-     * (PHP 5 &gt;= 5.0.0)<br/>
+     * @since 5.0.0
      * Offset to set
      * @link http://php.net/manual/en/arrayaccess.offsetset.php
      * @param mixed $offset <p>
@@ -127,7 +127,7 @@ interface ArrayAccess {
     public function offsetSet($offset, $value);
 
     /**
-     * (PHP 5 &gt;= 5.0.0)<br/>
+     * @since 5.0.0
      * Offset to unset
      * @link http://php.net/manual/en/arrayaccess.offsetunset.php
      * @param mixed $offset <p>
@@ -145,7 +145,7 @@ interface ArrayAccess {
 interface Serializable {
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * String representation of object
      * @link http://php.net/manual/en/serializable.serialize.php
      * @return string the string representation of the object or null
@@ -153,7 +153,7 @@ interface Serializable {
     public function serialize();
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Constructs the object
      * @link http://php.net/manual/en/serializable.unserialize.php
      * @param string $serialized <p>
@@ -177,7 +177,7 @@ class Exception {
 
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Clone the exception
      * @link http://php.net/manual/en/exception.clone.php
      * @return void
@@ -185,7 +185,7 @@ class Exception {
     final private function __clone() { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Construct the exception. Note: The message is NOT binary safe.
      * @link http://php.net/manual/en/exception.construct.php
      * @param string $message [optional] The Exception message to throw.
@@ -195,7 +195,7 @@ class Exception {
     public function __construct($message = "", $code = 0, Exception $previous = null) { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Gets the Exception message
      * @link http://php.net/manual/en/exception.getmessage.php
      * @return string the Exception message as a string.
@@ -203,7 +203,7 @@ class Exception {
     final public function getMessage() { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Gets the Exception code
      * @link http://php.net/manual/en/exception.getcode.php
      * @return mixed|int the exception code as integer in
@@ -214,7 +214,7 @@ class Exception {
     final public function getCode() { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Gets the file in which the exception occurred
      * @link http://php.net/manual/en/exception.getfile.php
      * @return string the filename in which the exception was created.
@@ -222,7 +222,7 @@ class Exception {
     final public function getFile() { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Gets the line in which the exception occurred
      * @link http://php.net/manual/en/exception.getline.php
      * @return int the line number where the exception was created.
@@ -230,7 +230,7 @@ class Exception {
     final public function getLine() { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Gets the stack trace
      * @link http://php.net/manual/en/exception.gettrace.php
      * @return array the Exception stack trace as an array.
@@ -238,7 +238,7 @@ class Exception {
     final public function getTrace() { }
 
     /**
-     * (PHP 5 &gt;= 5.3.0)<br/>
+     * @since 5.3.0
      * Returns previous Exception
      * @link http://php.net/manual/en/exception.getprevious.php
      * @return Exception the previous <b>Exception</b> if available
@@ -247,7 +247,7 @@ class Exception {
     final public function getPrevious() { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Gets the stack trace as a string
      * @link http://php.net/manual/en/exception.gettraceasstring.php
      * @return string the Exception stack trace as a string.
@@ -255,7 +255,7 @@ class Exception {
     final public function getTraceAsString() { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * String representation of the exception
      * @link http://php.net/manual/en/exception.tostring.php
      * @return string the string representation of the exception.
@@ -273,7 +273,7 @@ class ErrorException extends Exception {
 
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Constructs the exception
      * @link http://php.net/manual/en/errorexception.construct.php
      * @param string $message [optional] The Exception message to throw.
@@ -286,7 +286,7 @@ class ErrorException extends Exception {
     public function __construct($message = "", $code = 0, $severity = 1, $filename = __FILE__, $lineno = __LINE__, $previous) { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Gets the exception severity
      * @link http://php.net/manual/en/errorexception.getseverity.php
      * @return int the severity level of the exception.

--- a/PDO.php
+++ b/PDO.php
@@ -367,13 +367,13 @@ class PDO  {
 	const ATTR_MAX_COLUMN_LEN = 18;
 
 	/**
-	 * Available since PHP 5.1.3.
+	 * @since 5.1.3
 	 * @link http://php.net/manual/en/pdo.constants.php
 	 */
 	const ATTR_EMULATE_PREPARES = 20;
 
 	/**
-	 * Available since PHP 5.2.0
+	 * @since 5.2.0
 	 * @link http://php.net/manual/en/pdo.constants.php
 	 */
 	const ATTR_DEFAULT_FETCH_MODE = 19;

--- a/PDO.php
+++ b/PDO.php
@@ -636,7 +636,7 @@ class PDO  {
 	const MYSQL_ATTR_SSL_CAPATH = 1013;
 	const MYSQL_ATTR_SSL_CIPHER = 1014;
 	/**
-	 * @deprecated This constant has been DEPRECATED as of PHP 5.6.0. Use PDO::ATTR_EMULATE_PREPARES instead.
+	 * @deprecated 5.6.0 Use PDO::ATTR_EMULATE_PREPARES instead.
 	 */
 	const PGSQL_ATTR_DISABLE_NATIVE_PREPARED_STATEMENT = 1000;
 	const PGSQL_TRANSACTION_IDLE = 0;

--- a/Phar.php
+++ b/Phar.php
@@ -803,7 +803,7 @@ class Phar extends RecursiveDirectoryIterator implements RecursiveIterator, Seek
 	final public static function webPhar ($alias = null, $index = "index.php", $f404 = null, array $mimetypes = null, callable $rewrites = null) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Returns whether current entry is a directory and not '.' or '..'
 	 * @link http://php.net/manual/en/recursivedirectoryiterator.haschildren.php
 	 * @param bool $allow_links [optional] <p>
@@ -813,7 +813,7 @@ class Phar extends RecursiveDirectoryIterator implements RecursiveIterator, Seek
 	public function hasChildren ($allow_links = false) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.1.0)<br/>
+	 * @since 5.1.0
 	 * Returns an iterator for the current entry if it is a directory
 	 * @link http://php.net/manual/en/recursivedirectoryiterator.getchildren.php
 	 * @return mixed The filename, file information, or $this depending on the set flags.
@@ -823,7 +823,7 @@ class Phar extends RecursiveDirectoryIterator implements RecursiveIterator, Seek
 	public function getChildren () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
 	 * Rewinds back to the beginning
 	 * @link http://php.net/manual/en/filesystemiterator.rewind.php
 	 * @return void No value is returned.
@@ -831,7 +831,7 @@ class Phar extends RecursiveDirectoryIterator implements RecursiveIterator, Seek
 	public function rewind () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
 	 * Move to the next file
 	 * @link http://php.net/manual/en/filesystemiterator.next.php
 	 * @return void No value is returned.
@@ -839,7 +839,7 @@ class Phar extends RecursiveDirectoryIterator implements RecursiveIterator, Seek
 	public function next () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
 	 * Retrieve the key for the current file
 	 * @link http://php.net/manual/en/filesystemiterator.key.php
 	 * @return string the pathname or filename depending on the set flags.
@@ -848,7 +848,7 @@ class Phar extends RecursiveDirectoryIterator implements RecursiveIterator, Seek
 	public function key () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
 	 * The current file
 	 * @link http://php.net/manual/en/filesystemiterator.current.php
 	 * @return mixed The filename, file information, or $this depending on the set flags.
@@ -857,7 +857,7 @@ class Phar extends RecursiveDirectoryIterator implements RecursiveIterator, Seek
 	public function current () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Check whether current DirectoryIterator position is a valid file
 	 * @link http://php.net/manual/en/directoryiterator.valid.php
 	 * @return bool <b>TRUE</b> if the position is valid, otherwise <b>FALSE</b>
@@ -865,7 +865,7 @@ class Phar extends RecursiveDirectoryIterator implements RecursiveIterator, Seek
 	public function valid () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
 	 * Seek to a DirectoryIterator item
 	 * @link http://php.net/manual/en/directoryiterator.seek.php
 	 * @param int $position <p>
@@ -941,7 +941,7 @@ class PharData extends Phar {
 
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Returns whether current entry is a directory and not '.' or '..'
 	 * @link http://php.net/manual/en/recursivedirectoryiterator.haschildren.php
 	 * @param bool $allow_links [optional] <p>
@@ -951,7 +951,7 @@ class PharData extends Phar {
 	public function hasChildren ($allow_links = false) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.1.0)<br/>
+	 * @since 5.1.0
 	 * Returns an iterator for the current entry if it is a directory
 	 * @link http://php.net/manual/en/recursivedirectoryiterator.getchildren.php
 	 * @return mixed The filename, file information, or $this depending on the set flags.
@@ -962,7 +962,7 @@ class PharData extends Phar {
 
 
 	/**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
 	 * Rewinds back to the beginning
 	 * @link http://php.net/manual/en/filesystemiterator.rewind.php
 	 * @return void No value is returned.
@@ -970,7 +970,7 @@ class PharData extends Phar {
 	public function rewind () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
 	 * Move to the next file
 	 * @link http://php.net/manual/en/filesystemiterator.next.php
 	 * @return void No value is returned.
@@ -978,7 +978,7 @@ class PharData extends Phar {
 	public function next () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
 	 * Retrieve the key for the current file
 	 * @link http://php.net/manual/en/filesystemiterator.key.php
 	 * @return string the pathname or filename depending on the set flags.
@@ -987,7 +987,7 @@ class PharData extends Phar {
 	public function key () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
 	 * The current file
 	 * @link http://php.net/manual/en/filesystemiterator.current.php
 	 * @return mixed The filename, file information, or $this depending on the set flags.
@@ -998,7 +998,7 @@ class PharData extends Phar {
 
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Check whether current DirectoryIterator position is a valid file
 	 * @link http://php.net/manual/en/directoryiterator.valid.php
 	 * @return bool <b>TRUE</b> if the position is valid, otherwise <b>FALSE</b>
@@ -1006,7 +1006,7 @@ class PharData extends Phar {
 	public function valid () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
 	 * Seek to a DirectoryIterator item
 	 * @link http://php.net/manual/en/directoryiterator.seek.php
 	 * @param int $position <p>

--- a/Reflection.php
+++ b/Reflection.php
@@ -17,7 +17,7 @@ class ReflectionException extends Exception  {
 class Reflection  {
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Gets modifier names
 	 * @link http://php.net/manual/en/reflection.getmodifiernames.php
 	 * @param int $modifiers <p>
@@ -28,7 +28,7 @@ class Reflection  {
 	public static function getModifierNames ($modifiers) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Exports
 	 * @link http://php.net/manual/en/reflection.export.php
 	 * @param Reflector $reflector <p>
@@ -54,7 +54,7 @@ class Reflection  {
 interface Reflector  {
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Exports
 	 * @link http://php.net/manual/en/reflector.export.php
 	 * @return string
@@ -62,7 +62,7 @@ interface Reflector  {
 	static function export ();
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * To string
 	 * @link http://php.net/manual/en/reflector.tostring.php
 	 * @return string 
@@ -81,7 +81,7 @@ abstract class ReflectionFunctionAbstract implements Reflector {
 
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Clones function
 	 * @link http://php.net/manual/en/reflectionfunctionabstract.clone.php
 	 * @return void
@@ -89,7 +89,7 @@ abstract class ReflectionFunctionAbstract implements Reflector {
 	final private function __clone () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * To string
 	 * @link http://php.net/manual/en/reflectionfunctionabstract.tostring.php
 	 * @return string.
@@ -97,7 +97,7 @@ abstract class ReflectionFunctionAbstract implements Reflector {
 	abstract public function __toString ();
 
 	/**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
 	 * Checks if function in namespace
 	 * @link http://php.net/manual/en/reflectionfunctionabstract.innamespace.php
 	 * @return bool <b>TRUE</b> if it's in a namespace, otherwise <b>FALSE</b>
@@ -105,7 +105,7 @@ abstract class ReflectionFunctionAbstract implements Reflector {
 	public function inNamespace () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
 	 * Checks if closure
 	 * @link http://php.net/manual/en/reflectionfunctionabstract.isclosure.php
 	 * @return bool <b>TRUE</b> if it's a closure, otherwise <b>FALSE</b>
@@ -113,7 +113,7 @@ abstract class ReflectionFunctionAbstract implements Reflector {
 	public function isClosure () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Checks if deprecated
 	 * @link http://php.net/manual/en/reflectionfunctionabstract.isdeprecated.php
 	 * @return bool <b>TRUE</b> if it's deprecated, otherwise <b>FALSE</b>
@@ -121,7 +121,7 @@ abstract class ReflectionFunctionAbstract implements Reflector {
 	public function isDeprecated () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Checks if is internal
 	 * @link http://php.net/manual/en/reflectionfunctionabstract.isinternal.php
 	 * @return bool <b>TRUE</b> if it's internal, otherwise <b>FALSE</b>
@@ -129,7 +129,7 @@ abstract class ReflectionFunctionAbstract implements Reflector {
 	public function isInternal () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Checks if user defined
 	 * @link http://php.net/manual/en/reflectionfunctionabstract.isuserdefined.php
 	 * @return bool <b>TRUE</b> if it's user-defined, otherwise false;
@@ -137,7 +137,7 @@ abstract class ReflectionFunctionAbstract implements Reflector {
 	public function isUserDefined () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Returns this pointer bound to closure
 	 * @link http://php.net/manual/en/reflectionfunctionabstract.getclosurethis.php
 	 * @return object $this pointer.
@@ -148,7 +148,7 @@ abstract class ReflectionFunctionAbstract implements Reflector {
 	public function getClosureScopeClass () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.1.0)<br/>
+	 * @since 5.1.0
 	 * Gets doc comment
 	 * @link http://php.net/manual/en/reflectionfunctionabstract.getdoccomment.php
 	 * @return string The doc comment if it exists, otherwise <b>FALSE</b>
@@ -156,7 +156,7 @@ abstract class ReflectionFunctionAbstract implements Reflector {
 	public function getDocComment () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Gets end line number
 	 * @link http://php.net/manual/en/reflectionfunctionabstract.getendline.php
 	 * @return int The ending line number of the user defined function, or <b>FALSE</b> if unknown.
@@ -164,7 +164,7 @@ abstract class ReflectionFunctionAbstract implements Reflector {
 	public function getEndLine () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Gets extension info
 	 * @link http://php.net/manual/en/reflectionfunctionabstract.getextension.php
 	 * @return ReflectionExtension The extension information, as a <b>ReflectionExtension</b> object.
@@ -172,7 +172,7 @@ abstract class ReflectionFunctionAbstract implements Reflector {
 	public function getExtension () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Gets extension name
 	 * @link http://php.net/manual/en/reflectionfunctionabstract.getextensionname.php
 	 * @return string The extensions name.
@@ -180,7 +180,7 @@ abstract class ReflectionFunctionAbstract implements Reflector {
 	public function getExtensionName () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Gets file name
 	 * @link http://php.net/manual/en/reflectionfunctionabstract.getfilename.php
 	 * @return string The file name.
@@ -188,7 +188,7 @@ abstract class ReflectionFunctionAbstract implements Reflector {
 	public function getFileName () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Gets function name
 	 * @link http://php.net/manual/en/reflectionfunctionabstract.getname.php
 	 * @return string The name of the function.
@@ -196,7 +196,7 @@ abstract class ReflectionFunctionAbstract implements Reflector {
 	public function getName () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
 	 * Gets namespace name
 	 * @link http://php.net/manual/en/reflectionfunctionabstract.getnamespacename.php
 	 * @return string The namespace name.
@@ -204,7 +204,7 @@ abstract class ReflectionFunctionAbstract implements Reflector {
 	public function getNamespaceName () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.0.3)<br/>
+	 * @since 5.0.3
 	 * Gets number of parameters
 	 * @link http://php.net/manual/en/reflectionfunctionabstract.getnumberofparameters.php
 	 * @return int The number of parameters.
@@ -212,7 +212,7 @@ abstract class ReflectionFunctionAbstract implements Reflector {
 	public function getNumberOfParameters () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.0.3)<br/>
+	 * @since 5.0.3
 	 * Gets number of required parameters
 	 * @link http://php.net/manual/en/reflectionfunctionabstract.getnumberofrequiredparameters.php
 	 * @return int The number of required parameters.
@@ -220,7 +220,7 @@ abstract class ReflectionFunctionAbstract implements Reflector {
 	public function getNumberOfRequiredParameters () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Gets parameters
 	 * @link http://php.net/manual/en/reflectionfunctionabstract.getparameters.php
 	 * @return ReflectionParameter[] The parameters, as a ReflectionParameter objects.
@@ -228,7 +228,7 @@ abstract class ReflectionFunctionAbstract implements Reflector {
 	public function getParameters () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
 	 * Gets function short name
 	 * @link http://php.net/manual/en/reflectionfunctionabstract.getshortname.php
 	 * @return string The short name of the function.
@@ -236,7 +236,7 @@ abstract class ReflectionFunctionAbstract implements Reflector {
 	public function getShortName () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Gets starting line number
 	 * @link http://php.net/manual/en/reflectionfunctionabstract.getstartline.php
 	 * @return int The starting line number.
@@ -244,7 +244,7 @@ abstract class ReflectionFunctionAbstract implements Reflector {
 	public function getStartLine () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Gets static variables
 	 * @link http://php.net/manual/en/reflectionfunctionabstract.getstaticvariables.php
 	 * @return array An array of static variables.
@@ -252,7 +252,7 @@ abstract class ReflectionFunctionAbstract implements Reflector {
 	public function getStaticVariables () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Checks if returns reference
 	 * @link http://php.net/manual/en/reflectionfunctionabstract.returnsreference.php
 	 * @return bool <b>TRUE</b> if it returns a reference, otherwise <b>FALSE</b>
@@ -288,7 +288,7 @@ class ReflectionFunction extends ReflectionFunctionAbstract implements Reflector
 
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Constructs a ReflectionFunction object
 	 * @link http://php.net/manual/en/reflectionfunction.construct.php
 	 * @param mixed $name <p>
@@ -298,7 +298,7 @@ class ReflectionFunction extends ReflectionFunctionAbstract implements Reflector
 	public function __construct ($name) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * To string
 	 * @link http://php.net/manual/en/reflectionfunction.tostring.php
 	 * @return string <b>ReflectionFunction::export</b>-like output for
@@ -307,7 +307,7 @@ class ReflectionFunction extends ReflectionFunctionAbstract implements Reflector
 	public function __toString () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Exports function
 	 * @link http://php.net/manual/en/reflectionfunction.export.php
 	 * @param string $name <p>
@@ -324,7 +324,7 @@ class ReflectionFunction extends ReflectionFunctionAbstract implements Reflector
 	public static function export ($name, $return = null) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Checks if function is disabled
 	 * @link http://php.net/manual/en/reflectionfunction.isdisabled.php
 	 * @return bool <b>TRUE</b> if it's disable, otherwise <b>FALSE</b>
@@ -332,7 +332,7 @@ class ReflectionFunction extends ReflectionFunctionAbstract implements Reflector
 	public function isDisabled () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Invokes function
 	 * @link http://php.net/manual/en/reflectionfunction.invoke.php
 	 * @param string $args [optional] <p>
@@ -345,7 +345,7 @@ class ReflectionFunction extends ReflectionFunctionAbstract implements Reflector
 	public function invoke ($args = null) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.1.0)<br/>
+	 * @since 5.1.0
 	 * Invokes function args
 	 * @link http://php.net/manual/en/reflectionfunction.invokeargs.php
 	 * @param array $args <p>
@@ -357,7 +357,7 @@ class ReflectionFunction extends ReflectionFunctionAbstract implements Reflector
 	public function invokeArgs (array $args) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Returns a dynamically created closure for the function
 	 * @link http://php.net/manual/en/reflectionfunction.getclosure.php
 	 * @return Closure <b>Closure</b>.
@@ -377,7 +377,7 @@ class ReflectionParameter implements Reflector {
 
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Clone
 	 * @link http://php.net/manual/en/reflectionparameter.clone.php
 	 * @return void
@@ -385,7 +385,7 @@ class ReflectionParameter implements Reflector {
 	final private function __clone () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Exports
 	 * @link http://php.net/manual/en/reflectionparameter.export.php
 	 * @param string $function <p>
@@ -403,7 +403,7 @@ class ReflectionParameter implements Reflector {
 	public static function export ($function, $parameter, $return = null) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Construct
 	 * @link http://php.net/manual/en/reflectionparameter.construct.php
 	 * @param string $function <p>
@@ -416,7 +416,7 @@ class ReflectionParameter implements Reflector {
 	public function __construct ($function, $parameter) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * To string
 	 * @link http://php.net/manual/en/reflectionparameter.tostring.php
 	 * @return string
@@ -424,7 +424,7 @@ class ReflectionParameter implements Reflector {
 	public function __toString () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Gets parameter name
 	 * @link http://php.net/manual/en/reflectionparameter.getname.php
 	 * @return string The name of the reflected parameter.
@@ -432,7 +432,7 @@ class ReflectionParameter implements Reflector {
 	public function getName () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Checks if passed by reference
 	 * @link http://php.net/manual/en/reflectionparameter.ispassedbyreference.php
 	 * @return bool <b>TRUE</b> if the parameter is passed in by reference, otherwise <b>FALSE</b>
@@ -449,7 +449,7 @@ class ReflectionParameter implements Reflector {
 	public function canBePassedByValue () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.2.3)<br/>
+	 * @since 5.2.3
 	 * Gets declaring function
 	 * @link http://php.net/manual/en/reflectionparameter.getdeclaringfunction.php
 	 * @return ReflectionFunctionAbstract A <b>ReflectionFunctionAbstract</b> object.
@@ -457,7 +457,7 @@ class ReflectionParameter implements Reflector {
 	public function getDeclaringFunction () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Gets declaring class
 	 * @link http://php.net/manual/en/reflectionparameter.getdeclaringclass.php
 	 * @return ReflectionClass A <b>ReflectionClass</b> object.
@@ -465,7 +465,7 @@ class ReflectionParameter implements Reflector {
 	public function getDeclaringClass () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Get class
 	 * @link http://php.net/manual/en/reflectionparameter.getclass.php
 	 * @return ReflectionClass A <b>ReflectionClass</b> object.
@@ -473,7 +473,7 @@ class ReflectionParameter implements Reflector {
 	public function getClass () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.1.0)<br/>
+	 * @since 5.1.0
 	 * Checks if parameter expects an array
 	 * @link http://php.net/manual/en/reflectionparameter.isarray.php
 	 * @return bool <b>TRUE</b> if an array is expected, <b>FALSE</b> otherwise.
@@ -489,7 +489,7 @@ class ReflectionParameter implements Reflector {
     public function isCallable () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Checks if null is allowed
 	 * @link http://php.net/manual/en/reflectionparameter.allowsnull.php
 	 * @return bool <b>TRUE</b> if <b>NULL</b> is allowed, otherwise <b>FALSE</b>
@@ -497,7 +497,7 @@ class ReflectionParameter implements Reflector {
 	public function allowsNull () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.2.3)<br/>
+	 * @since 5.2.3
 	 * Gets parameter position
 	 * @link http://php.net/manual/en/reflectionparameter.getposition.php
 	 * @return int The position of the parameter, left to right, starting at position #0.
@@ -505,7 +505,7 @@ class ReflectionParameter implements Reflector {
 	public function getPosition () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.0.3)<br/>
+	 * @since 5.0.3
 	 * Checks if optional
 	 * @link http://php.net/manual/en/reflectionparameter.isoptional.php
 	 * @return bool <b>TRUE</b> if the parameter is optional, otherwise <b>FALSE</b>
@@ -513,7 +513,7 @@ class ReflectionParameter implements Reflector {
 	public function isOptional () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.0.3)<br/>
+	 * @since 5.0.3
 	 * Checks if a default value is available
 	 * @link http://php.net/manual/en/reflectionparameter.isdefaultvalueavailable.php
 	 * @return bool <b>TRUE</b> if a default value is available, otherwise <b>FALSE</b>
@@ -521,7 +521,7 @@ class ReflectionParameter implements Reflector {
 	public function isDefaultValueAvailable () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.0.3)<br/>
+	 * @since 5.0.3
 	 * Gets default parameter value
 	 * @link http://php.net/manual/en/reflectionparameter.getdefaultvalue.php
 	 * @return mixed The parameters default value.
@@ -558,7 +558,7 @@ class ReflectionMethod extends ReflectionFunctionAbstract implements Reflector {
 
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Export a reflection method.
 	 * @link http://php.net/manual/en/reflectionmethod.export.php
 	 * @param string $class <p>
@@ -578,7 +578,7 @@ class ReflectionMethod extends ReflectionFunctionAbstract implements Reflector {
 	public static function export ($class, $name, $return = false) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Constructs a ReflectionMethod
 	 * @link http://php.net/manual/en/reflectionmethod.construct.php
 	 * @param mixed $class <p>
@@ -591,7 +591,7 @@ class ReflectionMethod extends ReflectionFunctionAbstract implements Reflector {
 	public function __construct ($class, $name) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Returns the string representation of the Reflection method object.
 	 * @link http://php.net/manual/en/reflectionmethod.tostring.php
 	 * @return string A string representation of this <b>ReflectionMethod</b> instance.
@@ -599,7 +599,7 @@ class ReflectionMethod extends ReflectionFunctionAbstract implements Reflector {
 	public function __toString () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Checks if method is public
 	 * @link http://php.net/manual/en/reflectionmethod.ispublic.php
 	 * @return bool <b>TRUE</b> if the method is public, otherwise <b>FALSE</b>
@@ -607,7 +607,7 @@ class ReflectionMethod extends ReflectionFunctionAbstract implements Reflector {
 	public function isPublic () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Checks if method is private
 	 * @link http://php.net/manual/en/reflectionmethod.isprivate.php
 	 * @return bool <b>TRUE</b> if the method is private, otherwise <b>FALSE</b>
@@ -615,7 +615,7 @@ class ReflectionMethod extends ReflectionFunctionAbstract implements Reflector {
 	public function isPrivate () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Checks if method is protected
 	 * @link http://php.net/manual/en/reflectionmethod.isprotected.php
 	 * @return bool <b>TRUE</b> if the method is protected, otherwise <b>FALSE</b>
@@ -623,7 +623,7 @@ class ReflectionMethod extends ReflectionFunctionAbstract implements Reflector {
 	public function isProtected () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Checks if method is abstract
 	 * @link http://php.net/manual/en/reflectionmethod.isabstract.php
 	 * @return bool <b>TRUE</b> if the method is abstract, otherwise <b>FALSE</b>
@@ -631,7 +631,7 @@ class ReflectionMethod extends ReflectionFunctionAbstract implements Reflector {
 	public function isAbstract () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Checks if method is final
 	 * @link http://php.net/manual/en/reflectionmethod.isfinal.php
 	 * @return bool <b>TRUE</b> if the method is final, otherwise <b>FALSE</b>
@@ -639,7 +639,7 @@ class ReflectionMethod extends ReflectionFunctionAbstract implements Reflector {
 	public function isFinal () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Checks if method is static
 	 * @link http://php.net/manual/en/reflectionmethod.isstatic.php
 	 * @return bool <b>TRUE</b> if the method is static, otherwise <b>FALSE</b>
@@ -647,7 +647,7 @@ class ReflectionMethod extends ReflectionFunctionAbstract implements Reflector {
 	public function isStatic () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Checks if method is a constructor
 	 * @link http://php.net/manual/en/reflectionmethod.isconstructor.php
 	 * @return bool <b>TRUE</b> if the method is a constructor, otherwise <b>FALSE</b>
@@ -655,7 +655,7 @@ class ReflectionMethod extends ReflectionFunctionAbstract implements Reflector {
 	public function isConstructor () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Checks if method is a destructor
 	 * @link http://php.net/manual/en/reflectionmethod.isdestructor.php
 	 * @return bool <b>TRUE</b> if the method is a destructor, otherwise <b>FALSE</b>
@@ -673,7 +673,7 @@ class ReflectionMethod extends ReflectionFunctionAbstract implements Reflector {
 	public function getClosure ($object) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Gets the method modifiers
 	 * @link http://php.net/manual/en/reflectionmethod.getmodifiers.php
 	 * @return int A numeric representation of the modifiers. The modifiers are listed below.
@@ -726,7 +726,7 @@ class ReflectionMethod extends ReflectionFunctionAbstract implements Reflector {
 	public function getModifiers () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Invoke
 	 * @link http://php.net/manual/en/reflectionmethod.invoke.php
 	 * @param object $object <p>
@@ -743,7 +743,7 @@ class ReflectionMethod extends ReflectionFunctionAbstract implements Reflector {
 	public function invoke ($object, $parameter = null, $_ = null) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.1.0)<br/>
+	 * @since 5.1.0
 	 * Invoke args
 	 * @link http://php.net/manual/en/reflectionmethod.invokeargs.php
 	 * @param object $object <p>
@@ -758,7 +758,7 @@ class ReflectionMethod extends ReflectionFunctionAbstract implements Reflector {
 	public function invokeArgs ($object, array $args) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Gets declaring class for the reflected method.
 	 * @link http://php.net/manual/en/reflectionmethod.getdeclaringclass.php
 	 * @return ReflectionClass A <b>ReflectionClass</b> object of the class that the
@@ -767,7 +767,7 @@ class ReflectionMethod extends ReflectionFunctionAbstract implements Reflector {
 	public function getDeclaringClass () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Gets the method prototype (if there is one).
 	 * @link http://php.net/manual/en/reflectionmethod.getprototype.php
 	 * @return ReflectionMethod A <b>ReflectionMethod</b> instance of the method prototype.
@@ -775,7 +775,7 @@ class ReflectionMethod extends ReflectionFunctionAbstract implements Reflector {
 	public function getPrototype () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.3.2)<br/>
+	 * @since 5.3.2
 	 * Set method accessibility
 	 * @link http://php.net/manual/en/reflectionmethod.setaccessible.php
 	 * @param bool $accessible <p>
@@ -801,7 +801,7 @@ class ReflectionClass implements Reflector {
 
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Clones object
 	 * @link http://php.net/manual/en/reflectionclass.clone.php
 	 * @return void 
@@ -809,7 +809,7 @@ class ReflectionClass implements Reflector {
 	final private function __clone () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Exports a class
 	 * @link http://php.net/manual/en/reflectionclass.export.php
 	 * @param mixed $argument <p>
@@ -826,7 +826,7 @@ class ReflectionClass implements Reflector {
 	public static function export ($argument, $return = false) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Constructs a ReflectionClass
 	 * @link http://php.net/manual/en/reflectionclass.construct.php
 	 * @param mixed $argument <p>
@@ -837,7 +837,7 @@ class ReflectionClass implements Reflector {
 	public function __construct ($argument) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Returns the string representation of the ReflectionClass object.
 	 * @link http://php.net/manual/en/reflectionclass.tostring.php
 	 * @return string A string representation of this <b>ReflectionClass</b> instance.
@@ -845,7 +845,7 @@ class ReflectionClass implements Reflector {
 	public function __toString () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Gets class name
 	 * @link http://php.net/manual/en/reflectionclass.getname.php
 	 * @return string The class name.
@@ -853,7 +853,7 @@ class ReflectionClass implements Reflector {
 	public function getName () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Checks if class is defined internally by an extension, or the core
 	 * @link http://php.net/manual/en/reflectionclass.isinternal.php
 	 * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
@@ -861,7 +861,7 @@ class ReflectionClass implements Reflector {
 	public function isInternal () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Checks if user defined
 	 * @link http://php.net/manual/en/reflectionclass.isuserdefined.php
 	 * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
@@ -869,7 +869,7 @@ class ReflectionClass implements Reflector {
 	public function isUserDefined () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Checks if the class is instantiable
 	 * @link http://php.net/manual/en/reflectionclass.isinstantiable.php
 	 * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
@@ -885,7 +885,7 @@ class ReflectionClass implements Reflector {
 	public function isCloneable () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Gets the filename of the file in which the class has been defined
 	 * @link http://php.net/manual/en/reflectionclass.getfilename.php
 	 * @return string the filename of the file in which the class has been defined.
@@ -895,7 +895,7 @@ class ReflectionClass implements Reflector {
 	public function getFileName () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Gets starting line number
 	 * @link http://php.net/manual/en/reflectionclass.getstartline.php
 	 * @return int The starting line number, as an integer.
@@ -903,7 +903,7 @@ class ReflectionClass implements Reflector {
 	public function getStartLine () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Gets end line
 	 * @link http://php.net/manual/en/reflectionclass.getendline.php
 	 * @return int The ending line number of the user defined class, or <b>FALSE</b> if unknown.
@@ -911,7 +911,7 @@ class ReflectionClass implements Reflector {
 	public function getEndLine () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.1.0)<br/>
+	 * @since 5.1.0
 	 * Gets doc comments
 	 * @link http://php.net/manual/en/reflectionclass.getdoccomment.php
 	 * @return string The doc comment if it exists, otherwise <b>FALSE</b>
@@ -919,7 +919,7 @@ class ReflectionClass implements Reflector {
 	public function getDocComment () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Gets the constructor of the class
 	 * @link http://php.net/manual/en/reflectionclass.getconstructor.php
 	 * @return ReflectionMethod A <b>ReflectionMethod</b> object reflecting the class' constructor, or <b>NULL</b> if the class
@@ -928,7 +928,7 @@ class ReflectionClass implements Reflector {
 	public function getConstructor () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.1.0)<br/>
+	 * @since 5.1.0
 	 * Checks if method is defined
 	 * @link http://php.net/manual/en/reflectionclass.hasmethod.php
 	 * @param string $name <p>
@@ -939,7 +939,7 @@ class ReflectionClass implements Reflector {
 	public function hasMethod ($name) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Gets a <b>ReflectionMethod</b> for a class method.
 	 * @link http://php.net/manual/en/reflectionclass.getmethod.php
 	 * @param string $name <p>
@@ -950,7 +950,7 @@ class ReflectionClass implements Reflector {
 	public function getMethod ($name) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Gets an array of methods
 	 * @link http://php.net/manual/en/reflectionclass.getmethods.php
 	 * @param string $filter [optional] <p>
@@ -970,7 +970,7 @@ class ReflectionClass implements Reflector {
 	public function getMethods ($filter = null) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.1.0)<br/>
+	 * @since 5.1.0
 	 * Checks if property is defined
 	 * @link http://php.net/manual/en/reflectionclass.hasproperty.php
 	 * @param string $name <p>
@@ -981,7 +981,7 @@ class ReflectionClass implements Reflector {
 	public function hasProperty ($name) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Gets a <b>ReflectionProperty</b> for a class's property
 	 * @link http://php.net/manual/en/reflectionclass.getproperty.php
 	 * @param string $name <p>
@@ -992,7 +992,7 @@ class ReflectionClass implements Reflector {
 	public function getProperty ($name) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Gets properties
 	 * @link http://php.net/manual/en/reflectionclass.getproperties.php
 	 * @param int $filter [optional] <p>
@@ -1005,7 +1005,7 @@ class ReflectionClass implements Reflector {
 	public function getProperties ($filter = null) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.1.0)<br/>
+	 * @since 5.1.0
 	 * Checks if constant is defined
 	 * @link http://php.net/manual/en/reflectionclass.hasconstant.php
 	 * @param string $name <p>
@@ -1016,7 +1016,7 @@ class ReflectionClass implements Reflector {
 	public function hasConstant ($name) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Gets constants
 	 * @link http://php.net/manual/en/reflectionclass.getconstants.php
 	 * @return array An array of constants.
@@ -1025,7 +1025,7 @@ class ReflectionClass implements Reflector {
 	public function getConstants () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Gets defined constant
 	 * @link http://php.net/manual/en/reflectionclass.getconstant.php
 	 * @param string $name <p>
@@ -1036,7 +1036,7 @@ class ReflectionClass implements Reflector {
 	public function getConstant ($name) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Gets the interfaces
 	 * @link http://php.net/manual/en/reflectionclass.getinterfaces.php
          * @return ReflectionClass[] An associative array of interfaces, with keys as interface
@@ -1045,7 +1045,7 @@ class ReflectionClass implements Reflector {
 	public function getInterfaces () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.2.0)<br/>
+	 * @since 5.2.0
 	 * Gets the interface names
 	 * @link http://php.net/manual/en/reflectionclass.getinterfacenames.php
 	 * @return array A numerical array with interface names as the values.
@@ -1053,7 +1053,7 @@ class ReflectionClass implements Reflector {
 	public function getInterfaceNames () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Checks if the class is an interface
 	 * @link http://php.net/manual/en/reflectionclass.isinterface.php
 	 * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
@@ -1099,7 +1099,7 @@ class ReflectionClass implements Reflector {
 	public function isTrait () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Checks if class is abstract
 	 * @link http://php.net/manual/en/reflectionclass.isabstract.php
 	 * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
@@ -1107,7 +1107,7 @@ class ReflectionClass implements Reflector {
 	public function isAbstract () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Checks if class is final
 	 * @link http://php.net/manual/en/reflectionclass.isfinal.php
 	 * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
@@ -1115,7 +1115,7 @@ class ReflectionClass implements Reflector {
 	public function isFinal () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Gets modifiers
 	 * @link http://php.net/manual/en/reflectionclass.getmodifiers.php
 	 * @return int bitmask of
@@ -1124,7 +1124,7 @@ class ReflectionClass implements Reflector {
 	public function getModifiers () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Checks class for instance
 	 * @link http://php.net/manual/en/reflectionclass.isinstance.php
 	 * @param object $object <p>
@@ -1135,7 +1135,7 @@ class ReflectionClass implements Reflector {
 	public function isInstance ($object) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Creates a new class instance from given arguments.
 	 * @link http://php.net/manual/en/reflectionclass.newinstance.php
 	 * @param mixed $args [optional]<p>
@@ -1155,7 +1155,7 @@ class ReflectionClass implements Reflector {
 	public function newInstanceWithoutConstructor() {}
 
 	/**
-	 * (PHP 5 &gt;= 5.1.3)<br/>
+	 * @since 5.1.3
 	 * Creates a new class instance from given arguments.
 	 * @link http://php.net/manual/en/reflectionclass.newinstanceargs.php
 	 * @param array $args [optional] <p>
@@ -1166,7 +1166,7 @@ class ReflectionClass implements Reflector {
 	public function newInstanceArgs (array $args = null) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Gets parent class
 	 * @link http://php.net/manual/en/reflectionclass.getparentclass.php
 	 * @return ReflectionClass
@@ -1174,7 +1174,7 @@ class ReflectionClass implements Reflector {
 	public function getParentClass () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Checks if a subclass
 	 * @link http://php.net/manual/en/reflectionclass.issubclassof.php
 	 * @param string $class <p>
@@ -1185,7 +1185,7 @@ class ReflectionClass implements Reflector {
 	public function isSubclassOf ($class) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Gets static properties
 	 * @link http://php.net/manual/en/reflectionclass.getstaticproperties.php
 	 * @return array The static properties, as an array.
@@ -1193,7 +1193,7 @@ class ReflectionClass implements Reflector {
 	public function getStaticProperties () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.1.0)<br/>
+	 * @since 5.1.0
 	 * Gets static property value
 	 * @link http://php.net/manual/en/reflectionclass.getstaticpropertyvalue.php
 	 * @param string $name <p>
@@ -1206,7 +1206,7 @@ class ReflectionClass implements Reflector {
 	public function getStaticPropertyValue ($name, $default = null) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.1.0)<br/>
+	 * @since 5.1.0
 	 * Sets static property value
 	 * @link http://php.net/manual/en/reflectionclass.setstaticpropertyvalue.php
 	 * @param string $name <p>
@@ -1220,7 +1220,7 @@ class ReflectionClass implements Reflector {
 	public function setStaticPropertyValue ($name, $value) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Gets default properties
 	 * @link http://php.net/manual/en/reflectionclass.getdefaultproperties.php
 	 * @return array An array of default properties, with the key being the name of
@@ -1232,7 +1232,7 @@ class ReflectionClass implements Reflector {
 	public function getDefaultProperties () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Checks if iterateable
 	 * @link http://php.net/manual/en/reflectionclass.isiterateable.php
 	 * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
@@ -1240,7 +1240,7 @@ class ReflectionClass implements Reflector {
 	public function isIterateable () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Implements interface
 	 * @link http://php.net/manual/en/reflectionclass.implementsinterface.php
 	 * @param string $interface <p>
@@ -1251,7 +1251,7 @@ class ReflectionClass implements Reflector {
 	public function implementsInterface ($interface) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Gets a <b>ReflectionExtension</b> object for the extension which defined the class
 	 * @link http://php.net/manual/en/reflectionclass.getextension.php
 	 * @return ReflectionExtension A <b>ReflectionExtension</b> object representing the extension which defined the class,
@@ -1260,7 +1260,7 @@ class ReflectionClass implements Reflector {
 	public function getExtension () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Gets the name of the extension which defined the class
 	 * @link http://php.net/manual/en/reflectionclass.getextensionname.php
 	 * @return string The name of the extension which defined the class, or <b>FALSE</b> for user-defined classes.
@@ -1268,7 +1268,7 @@ class ReflectionClass implements Reflector {
 	public function getExtensionName () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
 	 * Checks if in namespace
 	 * @link http://php.net/manual/en/reflectionclass.innamespace.php
 	 * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
@@ -1276,7 +1276,7 @@ class ReflectionClass implements Reflector {
 	public function inNamespace () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
 	 * Gets namespace name
 	 * @link http://php.net/manual/en/reflectionclass.getnamespacename.php
 	 * @return string The namespace name.
@@ -1284,7 +1284,7 @@ class ReflectionClass implements Reflector {
 	public function getNamespaceName () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
 	 * Gets short name
 	 * @link http://php.net/manual/en/reflectionclass.getshortname.php
 	 * @return string The class short name.
@@ -1301,7 +1301,7 @@ class ReflectionClass implements Reflector {
 class ReflectionObject extends ReflectionClass implements Reflector {
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Export
 	 * @link http://php.net/manual/en/reflectionobject.export.php
 	 * @param string $argument <p>
@@ -1318,7 +1318,7 @@ class ReflectionObject extends ReflectionClass implements Reflector {
 	public static function export ($argument, $return = null) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Constructs a ReflectionObject
 	 * @link http://php.net/manual/en/reflectionobject.construct.php
 	 * @param object $argument <p>
@@ -1345,7 +1345,7 @@ class ReflectionProperty implements Reflector {
 
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Clone
 	 * @link http://php.net/manual/en/reflectionproperty.clone.php
 	 * @return void 
@@ -1353,7 +1353,7 @@ class ReflectionProperty implements Reflector {
 	final private function __clone () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Export
 	 * @link http://php.net/manual/en/reflectionproperty.export.php
 	 * @param mixed $class 
@@ -1369,7 +1369,7 @@ class ReflectionProperty implements Reflector {
 	public static function export ($class, $name, $return = null) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Construct a ReflectionProperty object
 	 * @link http://php.net/manual/en/reflectionproperty.construct.php
 	 * @param mixed $class <p>
@@ -1382,7 +1382,7 @@ class ReflectionProperty implements Reflector {
 	public function __construct ($class, $name) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * To string
 	 * @link http://php.net/manual/en/reflectionproperty.tostring.php
 	 * @return string
@@ -1390,7 +1390,7 @@ class ReflectionProperty implements Reflector {
 	public function __toString () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Gets property name
 	 * @link http://php.net/manual/en/reflectionproperty.getname.php
 	 * @return string The name of the reflected property.
@@ -1398,7 +1398,7 @@ class ReflectionProperty implements Reflector {
 	public function getName () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Gets value
 	 * @link http://php.net/manual/en/reflectionproperty.getvalue.php
 	 * @param object $object [optional]<p>
@@ -1412,7 +1412,7 @@ class ReflectionProperty implements Reflector {
 	public function getValue ($object) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Set property value
 	 * @link http://php.net/manual/en/reflectionproperty.setvalue.php
 	 * @param object $object [optional]<p>
@@ -1428,7 +1428,7 @@ class ReflectionProperty implements Reflector {
 	public function setValue ($object, $value) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Set static property value
 	 * @link http://php.net/manual/en/reflectionproperty.setvalue.php
 	 * @param mixed $value The new value.
@@ -1437,7 +1437,7 @@ class ReflectionProperty implements Reflector {
 	public function setValue ($value) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Checks if property is public
 	 * @link http://php.net/manual/en/reflectionproperty.ispublic.php
 	 * @return bool <b>TRUE</b> if the property is public, <b>FALSE</b> otherwise.
@@ -1445,7 +1445,7 @@ class ReflectionProperty implements Reflector {
 	public function isPublic () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Checks if property is private
 	 * @link http://php.net/manual/en/reflectionproperty.isprivate.php
 	 * @return bool <b>TRUE</b> if the property is private, <b>FALSE</b> otherwise.
@@ -1453,7 +1453,7 @@ class ReflectionProperty implements Reflector {
 	public function isPrivate () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Checks if property is protected
 	 * @link http://php.net/manual/en/reflectionproperty.isprotected.php
 	 * @return bool <b>TRUE</b> if the property is protected, <b>FALSE</b> otherwise.
@@ -1461,7 +1461,7 @@ class ReflectionProperty implements Reflector {
 	public function isProtected () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Checks if property is static
 	 * @link http://php.net/manual/en/reflectionproperty.isstatic.php
 	 * @return bool <b>TRUE</b> if the property is static, <b>FALSE</b> otherwise.
@@ -1469,7 +1469,7 @@ class ReflectionProperty implements Reflector {
 	public function isStatic () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Checks if default value
 	 * @link http://php.net/manual/en/reflectionproperty.isdefault.php
 	 * @return bool <b>TRUE</b> if the property was declared at compile-time, or <b>FALSE</b> if
@@ -1478,7 +1478,7 @@ class ReflectionProperty implements Reflector {
 	public function isDefault () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Gets modifiers
 	 * @link http://php.net/manual/en/reflectionproperty.getmodifiers.php
 	 * @return int A numeric representation of the modifiers.
@@ -1486,7 +1486,7 @@ class ReflectionProperty implements Reflector {
 	public function getModifiers () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Gets declaring class
 	 * @link http://php.net/manual/en/reflectionproperty.getdeclaringclass.php
 	 * @return ReflectionClass A <b>ReflectionClass</b> object.
@@ -1494,7 +1494,7 @@ class ReflectionProperty implements Reflector {
 	public function getDeclaringClass () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.1.0)<br/>
+	 * @since 5.1.0
 	 * Gets doc comment
 	 * @link http://php.net/manual/en/reflectionproperty.getdoccomment.php
 	 * @return string The doc comment.
@@ -1502,7 +1502,7 @@ class ReflectionProperty implements Reflector {
 	public function getDocComment () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
 	 * Set property accessibility
 	 * @link http://php.net/manual/en/reflectionproperty.setaccessible.php
 	 * @param bool $accessible <p>
@@ -1524,7 +1524,7 @@ class ReflectionExtension implements Reflector {
 
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Clones
 	 * @link http://php.net/manual/en/reflectionextension.clone.php
 	 * @return void No value is returned, if called a fatal error will occur.
@@ -1532,7 +1532,7 @@ class ReflectionExtension implements Reflector {
 	final private function __clone () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Export
 	 * @link http://php.net/manual/en/reflectionextension.export.php
 	 * @param string $name <p>
@@ -1549,7 +1549,7 @@ class ReflectionExtension implements Reflector {
 	public static function export ($name, $return = false) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Constructs a ReflectionExtension
 	 * @link http://php.net/manual/en/reflectionextension.construct.php
 	 * @param string $name <p>
@@ -1559,7 +1559,7 @@ class ReflectionExtension implements Reflector {
 	public function __construct ($name) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * To string
 	 * @link http://php.net/manual/en/reflectionextension.tostring.php
 	 * @return string the exported extension as a string, in the same way as the
@@ -1568,7 +1568,7 @@ class ReflectionExtension implements Reflector {
 	public function __toString () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Gets extension name
 	 * @link http://php.net/manual/en/reflectionextension.getname.php
 	 * @return string The extensions name.
@@ -1576,7 +1576,7 @@ class ReflectionExtension implements Reflector {
 	public function getName () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Gets extension version
 	 * @link http://php.net/manual/en/reflectionextension.getversion.php
 	 * @return string The version of the extension.
@@ -1584,7 +1584,7 @@ class ReflectionExtension implements Reflector {
 	public function getVersion () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Gets extension functions
 	 * @link http://php.net/manual/en/reflectionextension.getfunctions.php
          * @return ReflectionFunction[] An associative array of <b>ReflectionFunction</b> objects,
@@ -1594,7 +1594,7 @@ class ReflectionExtension implements Reflector {
 	public function getFunctions () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Gets constants
 	 * @link http://php.net/manual/en/reflectionextension.getconstants.php
 	 * @return array An associative array with constant names as keys.
@@ -1602,7 +1602,7 @@ class ReflectionExtension implements Reflector {
 	public function getConstants () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Gets extension ini entries
 	 * @link http://php.net/manual/en/reflectionextension.getinientries.php
 	 * @return array An associative array with the ini entries as keys,
@@ -1611,7 +1611,7 @@ class ReflectionExtension implements Reflector {
 	public function getINIEntries () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Gets classes
 	 * @link http://php.net/manual/en/reflectionextension.getclasses.php
          * @return ReflectionClass[] An array of <b>ReflectionClass</b> objects, one
@@ -1621,7 +1621,7 @@ class ReflectionExtension implements Reflector {
 	public function getClasses () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Gets class names
 	 * @link http://php.net/manual/en/reflectionextension.getclassnames.php
 	 * @return array An array of class names, as defined in the extension.
@@ -1630,7 +1630,7 @@ class ReflectionExtension implements Reflector {
 	public function getClassNames () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Gets dependencies
 	 * @link http://php.net/manual/en/reflectionextension.getdependencies.php
 	 * @return array An associative array with dependencies as keys and
@@ -1640,7 +1640,7 @@ class ReflectionExtension implements Reflector {
 	public function getDependencies () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Gets extension info
 	 * @link http://php.net/manual/en/reflectionextension.info.php
 	 * @return string Information about the extension.

--- a/SPL.php
+++ b/SPL.php
@@ -111,7 +111,7 @@ class UnexpectedValueException extends RuntimeException {
 class EmptyIterator implements Iterator, Traversable {
 
     /**
-     * (PHP 5 &gt;= 5.0.0)<br/>
+     * @since 5.0.0
      * Return the current element
      * @link http://php.net/manual/en/iterator.current.php
      * @return mixed Can return any type.
@@ -119,7 +119,7 @@ class EmptyIterator implements Iterator, Traversable {
     public function current() { }
 
     /**
-     * (PHP 5 &gt;= 5.0.0)<br/>
+     * @since 5.0.0
      * Move forward to next element
      * @link http://php.net/manual/en/iterator.next.php
      * @return void Any returned value is ignored.
@@ -127,7 +127,7 @@ class EmptyIterator implements Iterator, Traversable {
     public function next() { }
 
     /**
-     * (PHP 5 &gt;= 5.0.0)<br/>
+     * @since 5.0.0
      * Return the key of the current element
      * @link http://php.net/manual/en/iterator.key.php
      * @return mixed scalar on success, or null on failure.
@@ -135,7 +135,7 @@ class EmptyIterator implements Iterator, Traversable {
     public function key() { }
 
     /**
-     * (PHP 5 &gt;= 5.0.0)<br/>
+     * @since 5.0.0
      * Checks if current position is valid
      * @link http://php.net/manual/en/iterator.valid.php
      * @return boolean The return value will be casted to boolean and then evaluated.
@@ -144,7 +144,7 @@ class EmptyIterator implements Iterator, Traversable {
     public function valid() { }
 
     /**
-     * (PHP 5 &gt;= 5.0.0)<br/>
+     * @since 5.0.0
      * Rewind the Iterator to the first element
      * @link http://php.net/manual/en/iterator.rewind.php
      * @return void Any returned value is ignored.
@@ -153,7 +153,7 @@ class EmptyIterator implements Iterator, Traversable {
 }
 
 /**
- * (PHP 5 &gt;= 5.4.0)<br/>
+ * @since 5.4.0
  * Filtered iterator using the callback to determine which items are accepted or rejected.
  * @link http://www.php.net/manual/en/class.callbackfilteriterator.php
  */
@@ -219,7 +219,7 @@ class RecursiveCallbackFilterIterator extends CallbackFilterIterator implements 
 interface RecursiveIterator extends Iterator, Traversable {
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Returns if an iterator can be created for the current entry.
      * @link http://php.net/manual/en/recursiveiterator.haschildren.php
      * @return bool true if the current entry can be iterated over, otherwise returns false.
@@ -227,7 +227,7 @@ interface RecursiveIterator extends Iterator, Traversable {
     public function hasChildren();
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Returns an iterator for the current entry.
      * @link http://php.net/manual/en/recursiveiterator.getchildren.php
      * @return RecursiveIterator An iterator for the current entry.
@@ -246,7 +246,7 @@ class RecursiveIteratorIterator implements Iterator, Traversable, OuterIterator 
     const CATCH_GET_CHILD = 16;
 
     /**
-     * (PHP 5 &gt;= 5.1.3)<br/>
+     * @since 5.1.3
      * Construct a RecursiveIteratorIterator
      * @link http://php.net/manual/en/recursiveiteratoriterator.construct.php
      * @param Traversable $iterator
@@ -256,7 +256,7 @@ class RecursiveIteratorIterator implements Iterator, Traversable, OuterIterator 
     public function __construct(Traversable $iterator, $mode, $flags) { }
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Rewind the iterator to the first element of the top level inner iterator
      * @link http://php.net/manual/en/recursiveiteratoriterator.rewind.php
      * @return void
@@ -264,7 +264,7 @@ class RecursiveIteratorIterator implements Iterator, Traversable, OuterIterator 
     public function rewind() { }
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Check whether the current position is valid
      * @link http://php.net/manual/en/recursiveiteratoriterator.valid.php
      * @return bool true if the current position is valid, otherwise false
@@ -272,7 +272,7 @@ class RecursiveIteratorIterator implements Iterator, Traversable, OuterIterator 
     public function valid() { }
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Access the current key
      * @link http://php.net/manual/en/recursiveiteratoriterator.key.php
      * @return mixed The current key.
@@ -280,7 +280,7 @@ class RecursiveIteratorIterator implements Iterator, Traversable, OuterIterator 
     public function key() { }
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Access the current element value
      * @link http://php.net/manual/en/recursiveiteratoriterator.current.php
      * @return mixed The current elements value.
@@ -288,7 +288,7 @@ class RecursiveIteratorIterator implements Iterator, Traversable, OuterIterator 
     public function current() { }
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Move forward to the next element
      * @link http://php.net/manual/en/recursiveiteratoriterator.next.php
      * @return void
@@ -296,7 +296,7 @@ class RecursiveIteratorIterator implements Iterator, Traversable, OuterIterator 
     public function next() { }
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Get the current depth of the recursive iteration
      * @link http://php.net/manual/en/recursiveiteratoriterator.getdepth.php
      * @return int The current depth of the recursive iteration.
@@ -304,7 +304,7 @@ class RecursiveIteratorIterator implements Iterator, Traversable, OuterIterator 
     public function getDepth() { }
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * The current active sub iterator
      * @link http://php.net/manual/en/recursiveiteratoriterator.getsubiterator.php
      * @param $level [optional]
@@ -313,7 +313,7 @@ class RecursiveIteratorIterator implements Iterator, Traversable, OuterIterator 
     public function getSubIterator($level) { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Get inner iterator
      * @link http://php.net/manual/en/recursiveiteratoriterator.getinneriterator.php
      * @return Iterator The current active sub iterator.
@@ -321,7 +321,7 @@ class RecursiveIteratorIterator implements Iterator, Traversable, OuterIterator 
     public function getInnerIterator() { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Begin Iteration
      * @link http://php.net/manual/en/recursiveiteratoriterator.beginiteration.php
      * @return void
@@ -329,7 +329,7 @@ class RecursiveIteratorIterator implements Iterator, Traversable, OuterIterator 
     public function beginIteration() { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * End Iteration
      * @link http://php.net/manual/en/recursiveiteratoriterator.enditeration.php
      * @return void
@@ -337,7 +337,7 @@ class RecursiveIteratorIterator implements Iterator, Traversable, OuterIterator 
     public function endIteration() { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Has children
      * @link http://php.net/manual/en/recursiveiteratoriterator.callhaschildren.php
      * @return bool true if the element has children, otherwise false
@@ -345,7 +345,7 @@ class RecursiveIteratorIterator implements Iterator, Traversable, OuterIterator 
     public function callHasChildren() { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Get children
      * @link http://php.net/manual/en/recursiveiteratoriterator.callgetchildren.php
      * @return RecursiveIterator A <b>RecursiveIterator</b>.
@@ -353,7 +353,7 @@ class RecursiveIteratorIterator implements Iterator, Traversable, OuterIterator 
     public function callGetChildren() { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Begin children
      * @link http://php.net/manual/en/recursiveiteratoriterator.beginchildren.php
      * @return void
@@ -361,7 +361,7 @@ class RecursiveIteratorIterator implements Iterator, Traversable, OuterIterator 
     public function beginChildren() { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * End children
      * @link http://php.net/manual/en/recursiveiteratoriterator.endchildren.php
      * @return void
@@ -369,7 +369,7 @@ class RecursiveIteratorIterator implements Iterator, Traversable, OuterIterator 
     public function endChildren() { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Next element
      * @link http://php.net/manual/en/recursiveiteratoriterator.nextelement.php
      * @return void
@@ -377,7 +377,7 @@ class RecursiveIteratorIterator implements Iterator, Traversable, OuterIterator 
     public function nextElement() { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Set max depth
      * @link http://php.net/manual/en/recursiveiteratoriterator.setmaxdepth.php
      * @param string $max_depth [optional] <p>
@@ -389,7 +389,7 @@ class RecursiveIteratorIterator implements Iterator, Traversable, OuterIterator 
     public function setMaxDepth($max_depth = -1) { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Get max depth
      * @link http://php.net/manual/en/recursiveiteratoriterator.getmaxdepth.php
      * @return mixed The maximum accepted depth, or false if any depth is allowed.
@@ -405,7 +405,7 @@ class RecursiveIteratorIterator implements Iterator, Traversable, OuterIterator 
 interface OuterIterator extends Iterator, Traversable {
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Returns the inner iterator for the current entry.
      * @link http://php.net/manual/en/outeriterator.getinneriterator.php
      * @return Iterator The inner iterator for the current entry.
@@ -426,7 +426,7 @@ interface OuterIterator extends Iterator, Traversable {
 class IteratorIterator implements Iterator, Traversable, OuterIterator {
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Create an iterator from anything that is traversable
      * @link http://php.net/manual/en/iteratoriterator.construct.php
      * @param Traversable $iterator
@@ -434,7 +434,7 @@ class IteratorIterator implements Iterator, Traversable, OuterIterator {
     public function __construct(Traversable $iterator) { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Get the inner iterator
      * @link http://php.net/manual/en/iteratoriterator.getinneriterator.php
      * @return Iterator The inner iterator as passed to IteratorIterator::__construct.
@@ -442,7 +442,7 @@ class IteratorIterator implements Iterator, Traversable, OuterIterator {
     public function getInnerIterator() { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Rewind to the first element
      * @link http://php.net/manual/en/iteratoriterator.rewind.php
      * @return void
@@ -450,7 +450,7 @@ class IteratorIterator implements Iterator, Traversable, OuterIterator {
     public function rewind() { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Checks if the iterator is valid
      * @link http://php.net/manual/en/iteratoriterator.valid.php
      * @return bool true if the iterator is valid, otherwise false
@@ -458,7 +458,7 @@ class IteratorIterator implements Iterator, Traversable, OuterIterator {
     public function valid() { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Get the key of the current element
      * @link http://php.net/manual/en/iteratoriterator.key.php
      * @return mixed The key of the current element.
@@ -466,7 +466,7 @@ class IteratorIterator implements Iterator, Traversable, OuterIterator {
     public function key() { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Get the current value
      * @link http://php.net/manual/en/iteratoriterator.current.php
      * @return mixed The value of the current element.
@@ -474,7 +474,7 @@ class IteratorIterator implements Iterator, Traversable, OuterIterator {
     public function current() { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Forward to the next element
      * @link http://php.net/manual/en/iteratoriterator.next.php
      * @return void
@@ -491,7 +491,7 @@ class IteratorIterator implements Iterator, Traversable, OuterIterator {
 abstract class FilterIterator extends IteratorIterator implements OuterIterator, Traversable, Iterator {
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Check whether the current element of the iterator is acceptable
      * @link http://php.net/manual/en/filteriterator.accept.php
      * @return bool true if the current element is acceptable, otherwise false.
@@ -499,7 +499,7 @@ abstract class FilterIterator extends IteratorIterator implements OuterIterator,
     abstract public function accept();
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Construct a filterIterator
      * @link http://php.net/manual/en/filteriterator.construct.php
      * @param Iterator $iterator
@@ -507,7 +507,7 @@ abstract class FilterIterator extends IteratorIterator implements OuterIterator,
     public function __construct(Iterator $iterator) { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Rewind the iterator
      * @link http://php.net/manual/en/filteriterator.rewind.php
      * @return void
@@ -515,7 +515,7 @@ abstract class FilterIterator extends IteratorIterator implements OuterIterator,
     public function rewind() { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Check whether the current element is valid
      * @link http://php.net/manual/en/filteriterator.valid.php
      * @return bool true if the current element is valid, otherwise false
@@ -523,7 +523,7 @@ abstract class FilterIterator extends IteratorIterator implements OuterIterator,
     public function valid() { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Get the current key
      * @link http://php.net/manual/en/filteriterator.key.php
      * @return mixed The current key.
@@ -531,7 +531,7 @@ abstract class FilterIterator extends IteratorIterator implements OuterIterator,
     public function key() { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Get the current element value
      * @link http://php.net/manual/en/filteriterator.current.php
      * @return mixed The current element value.
@@ -539,7 +539,7 @@ abstract class FilterIterator extends IteratorIterator implements OuterIterator,
     public function current() { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Move the iterator forward
      * @link http://php.net/manual/en/filteriterator.next.php
      * @return void
@@ -547,7 +547,7 @@ abstract class FilterIterator extends IteratorIterator implements OuterIterator,
     public function next() { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Get the inner iterator
      * @link http://php.net/manual/en/filteriterator.getinneriterator.php
      * @return Iterator The inner iterator.
@@ -564,7 +564,7 @@ abstract class FilterIterator extends IteratorIterator implements OuterIterator,
 abstract class RecursiveFilterIterator extends FilterIterator implements Iterator, Traversable, OuterIterator, RecursiveIterator {
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Create a RecursiveFilterIterator from a RecursiveIterator
      * @link http://php.net/manual/en/recursivefilteriterator.construct.php
      * @param RecursiveIterator $iterator
@@ -572,7 +572,7 @@ abstract class RecursiveFilterIterator extends FilterIterator implements Iterato
     public function __construct(RecursiveIterator $iterator) { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Check whether the inner iterator's current element has children
      * @link http://php.net/manual/en/recursivefilteriterator.haschildren.php
      * @return bool true if the inner iterator has children, otherwise false
@@ -580,7 +580,7 @@ abstract class RecursiveFilterIterator extends FilterIterator implements Iterato
     public function hasChildren() { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Return the inner iterator's children contained in a RecursiveFilterIterator
      * @link http://php.net/manual/en/recursivefilteriterator.getchildren.php
      * @return RecursiveFilterIterator containing the inner iterator's children.
@@ -595,7 +595,7 @@ abstract class RecursiveFilterIterator extends FilterIterator implements Iterato
 class ParentIterator extends RecursiveFilterIterator implements RecursiveIterator, OuterIterator, Traversable, Iterator {
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Determines acceptability
      * @link http://php.net/manual/en/parentiterator.accept.php
      * @return bool true if the current element is acceptable, otherwise false.
@@ -603,7 +603,7 @@ class ParentIterator extends RecursiveFilterIterator implements RecursiveIterato
     public function accept() { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Constructs a ParentIterator
      * @link http://php.net/manual/en/parentiterator.construct.php
      * @param RecursiveIterator $iterator
@@ -611,7 +611,7 @@ class ParentIterator extends RecursiveFilterIterator implements RecursiveIterato
     public function __construct(RecursiveIterator $iterator) { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Check whether the inner iterator's current element has children
      * @link http://php.net/manual/en/recursivefilteriterator.haschildren.php
      * @return bool true if the inner iterator has children, otherwise false
@@ -619,7 +619,7 @@ class ParentIterator extends RecursiveFilterIterator implements RecursiveIterato
     public function hasChildren() { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Return the inner iterator's children contained in a RecursiveFilterIterator
      * @link http://php.net/manual/en/recursivefilteriterator.getchildren.php
      * @return ParentIterator containing the inner iterator's children.
@@ -635,7 +635,7 @@ class ParentIterator extends RecursiveFilterIterator implements RecursiveIterato
 interface Countable {
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Count elements of an object
      * @link http://php.net/manual/en/countable.count.php
      * @return int The custom count as an integer.
@@ -653,7 +653,7 @@ interface Countable {
 interface SeekableIterator extends Iterator, Traversable {
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Seeks to a position
      * @link http://php.net/manual/en/seekableiterator.seek.php
      * @param int $position <p>
@@ -672,7 +672,7 @@ interface SeekableIterator extends Iterator, Traversable {
 class LimitIterator extends IteratorIterator implements OuterIterator, Traversable, Iterator {
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Construct a LimitIterator
      * @link http://php.net/manual/en/limititerator.construct.php
      * @param Iterator $iterator
@@ -682,7 +682,7 @@ class LimitIterator extends IteratorIterator implements OuterIterator, Traversab
     public function __construct(Iterator $iterator, $offset, $count) { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Rewind the iterator to the specified starting offset
      * @link http://php.net/manual/en/limititerator.rewind.php
      * @return void
@@ -690,7 +690,7 @@ class LimitIterator extends IteratorIterator implements OuterIterator, Traversab
     public function rewind() { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Check whether the current element is valid
      * @link http://php.net/manual/en/limititerator.valid.php
      * @return bool true on success or false on failure.
@@ -698,7 +698,7 @@ class LimitIterator extends IteratorIterator implements OuterIterator, Traversab
     public function valid() { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Get current key
      * @link http://php.net/manual/en/limititerator.key.php
      * @return mixed the key for the current item.
@@ -706,7 +706,7 @@ class LimitIterator extends IteratorIterator implements OuterIterator, Traversab
     public function key() { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Get current element
      * @link http://php.net/manual/en/limititerator.current.php
      * @return mixed the current element or null if there is none.
@@ -714,7 +714,7 @@ class LimitIterator extends IteratorIterator implements OuterIterator, Traversab
     public function current() { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Move the iterator forward
      * @link http://php.net/manual/en/limititerator.next.php
      * @return void
@@ -722,7 +722,7 @@ class LimitIterator extends IteratorIterator implements OuterIterator, Traversab
     public function next() { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Seek to the given position
      * @link http://php.net/manual/en/limititerator.seek.php
      * @param int $position <p>
@@ -733,7 +733,7 @@ class LimitIterator extends IteratorIterator implements OuterIterator, Traversab
     public function seek($position) { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Return the current position
      * @link http://php.net/manual/en/limititerator.getposition.php
      * @return int The current position.
@@ -741,7 +741,7 @@ class LimitIterator extends IteratorIterator implements OuterIterator, Traversab
     public function getPosition() { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Get inner iterator
      * @link http://php.net/manual/en/limititerator.getinneriterator.php
      * @return Iterator The inner iterator passed to <b>LimitIterator::__construct</b>.
@@ -763,7 +763,7 @@ class CachingIterator extends IteratorIterator implements OuterIterator, Travers
 
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Construct a new CachingIterator object for the iterator.
      * @link http://php.net/manual/en/cachingiterator.construct.php
      * @param Iterator $iterator
@@ -772,7 +772,7 @@ class CachingIterator extends IteratorIterator implements OuterIterator, Travers
     public function __construct(Iterator $iterator, $flags = self::CALL_TOSTRING) { }
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Rewind the iterator
      * @link http://php.net/manual/en/cachingiterator.rewind.php
      * @return void
@@ -780,7 +780,7 @@ class CachingIterator extends IteratorIterator implements OuterIterator, Travers
     public function rewind() { }
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Check whether the current element is valid
      * @link http://php.net/manual/en/cachingiterator.valid.php
      * @return bool true on success or false on failure.
@@ -788,7 +788,7 @@ class CachingIterator extends IteratorIterator implements OuterIterator, Travers
     public function valid() { }
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Return the key for the current element
      * @link http://php.net/manual/en/cachingiterator.key.php
      * @return mixed
@@ -796,7 +796,7 @@ class CachingIterator extends IteratorIterator implements OuterIterator, Travers
     public function key() { }
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Return the current element
      * @link http://php.net/manual/en/cachingiterator.current.php
      * @return mixed
@@ -804,7 +804,7 @@ class CachingIterator extends IteratorIterator implements OuterIterator, Travers
     public function current() { }
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Move the iterator forward
      * @link http://php.net/manual/en/cachingiterator.next.php
      * @return void
@@ -812,7 +812,7 @@ class CachingIterator extends IteratorIterator implements OuterIterator, Travers
     public function next() { }
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Check whether the inner iterator has a valid next element
      * @link http://php.net/manual/en/cachingiterator.hasnext.php
      * @return bool true on success or false on failure.
@@ -820,7 +820,7 @@ class CachingIterator extends IteratorIterator implements OuterIterator, Travers
     public function hasNext() { }
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Return the string representation of the current element
      * @link http://php.net/manual/en/cachingiterator.tostring.php
      * @return string The string representation of the current element.
@@ -828,7 +828,7 @@ class CachingIterator extends IteratorIterator implements OuterIterator, Travers
     public function __toString() { }
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Returns the inner iterator
      * @link http://php.net/manual/en/cachingiterator.getinneriterator.php
      * @return Iterator an object implementing the Iterator interface.
@@ -836,7 +836,7 @@ class CachingIterator extends IteratorIterator implements OuterIterator, Travers
     public function getInnerIterator() { }
 
     /**
-     * (PHP 5 &gt;= 5.2.0)<br/>
+     * @since 5.2.0
      * Get flags used
      * @link http://php.net/manual/en/cachingiterator.getflags.php
      * @return int Bitmask of the flags
@@ -844,7 +844,7 @@ class CachingIterator extends IteratorIterator implements OuterIterator, Travers
     public function getFlags() { }
 
     /**
-     * (PHP 5 &gt;= 5.2.0)<br/>
+     * @since 5.2.0
      * The setFlags purpose
      * @link http://php.net/manual/en/cachingiterator.setflags.php
      * @param int $flags Bitmask of the flags to set.
@@ -853,7 +853,7 @@ class CachingIterator extends IteratorIterator implements OuterIterator, Travers
     public function setFlags($flags) { }
 
     /**
-     * (PHP 5 &gt;= 5.2.0)<br/>
+     * @since 5.2.0
      * The offsetGet purpose
      * @link http://php.net/manual/en/cachingiterator.offsetget.php
      * @param string $index <p>
@@ -864,7 +864,7 @@ class CachingIterator extends IteratorIterator implements OuterIterator, Travers
     public function offsetGet($index) { }
 
     /**
-     * (PHP 5 &gt;= 5.2.0)<br/>
+     * @since 5.2.0
      * The offsetSet purpose
      * @link http://php.net/manual/en/cachingiterator.offsetset.php
      * @param string $index <p>
@@ -878,7 +878,7 @@ class CachingIterator extends IteratorIterator implements OuterIterator, Travers
     public function offsetSet($index, $newval) { }
 
     /**
-     * (PHP 5 &gt;= 5.2.0)<br/>
+     * @since 5.2.0
      * The offsetUnset purpose
      * @link http://php.net/manual/en/cachingiterator.offsetunset.php
      * @param string $index <p>
@@ -889,7 +889,7 @@ class CachingIterator extends IteratorIterator implements OuterIterator, Travers
     public function offsetUnset($index) { }
 
     /**
-     * (PHP 5 &gt;= 5.2.0)<br/>
+     * @since 5.2.0
      * The offsetExists purpose
      * @link http://php.net/manual/en/cachingiterator.offsetexists.php
      * @param string $index <p>
@@ -900,7 +900,7 @@ class CachingIterator extends IteratorIterator implements OuterIterator, Travers
     public function offsetExists($index) { }
 
     /**
-     * (PHP 5 &gt;= 5.2.0)<br/>
+     * @since 5.2.0
      * The getCache purpose
      * @link http://php.net/manual/en/cachingiterator.getcache.php
      * @return array Description...
@@ -908,7 +908,7 @@ class CachingIterator extends IteratorIterator implements OuterIterator, Travers
     public function getCache() { }
 
     /**
-     * (PHP 5 &gt;= 5.2.2)<br/>
+     * @since 5.2.2
      * The number of elements in the iterator
      * @link http://php.net/manual/en/cachingiterator.count.php
      * @return void The count of the elements iterated over.
@@ -924,7 +924,7 @@ class RecursiveCachingIterator extends CachingIterator
     implements Countable, ArrayAccess, Iterator, Traversable, OuterIterator, RecursiveIterator {
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Construct
      * @link http://php.net/manual/en/recursivecachingiterator.construct.php
      * @param Iterator $iterator The iterator being used.
@@ -934,7 +934,7 @@ class RecursiveCachingIterator extends CachingIterator
     public function __construct(Iterator $iterator, $flags = self::CALL_TOSTRING) { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Check whether the current element of the inner iterator has children
      * @link http://php.net/manual/en/recursivecachingiterator.haschildren.php
      * @return bool true if the inner iterator has children, otherwise false
@@ -942,7 +942,7 @@ class RecursiveCachingIterator extends CachingIterator
     public function hasChildren() { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Return the inner iterator's children as a RecursiveCachingIterator
      * @link http://php.net/manual/en/recursivecachingiterator.getchildren.php
      * @return RecursiveCachingIterator The inner iterator's children, as a RecursiveCachingIterator.
@@ -958,7 +958,7 @@ class RecursiveCachingIterator extends CachingIterator
 class NoRewindIterator extends IteratorIterator implements OuterIterator, Traversable, Iterator {
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Construct a NoRewindIterator
      * @link http://php.net/manual/en/norewinditerator.construct.php
      * @param Iterator $iterator
@@ -966,7 +966,7 @@ class NoRewindIterator extends IteratorIterator implements OuterIterator, Traver
     public function __construct(Iterator $iterator) { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Prevents the rewind operation on the inner iterator.
      * @link http://php.net/manual/en/norewinditerator.rewind.php
      * @return void
@@ -974,7 +974,7 @@ class NoRewindIterator extends IteratorIterator implements OuterIterator, Traver
     public function rewind() { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Validates the iterator
      * @link http://php.net/manual/en/norewinditerator.valid.php
      * @return bool true on success or false on failure.
@@ -982,7 +982,7 @@ class NoRewindIterator extends IteratorIterator implements OuterIterator, Traver
     public function valid() { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Get the current key
      * @link http://php.net/manual/en/norewinditerator.key.php
      * @return mixed The current key.
@@ -990,7 +990,7 @@ class NoRewindIterator extends IteratorIterator implements OuterIterator, Traver
     public function key() { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Get the current value
      * @link http://php.net/manual/en/norewinditerator.current.php
      * @return mixed The current value.
@@ -998,7 +998,7 @@ class NoRewindIterator extends IteratorIterator implements OuterIterator, Traver
     public function current() { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Forward to the next element
      * @link http://php.net/manual/en/norewinditerator.next.php
      * @return void
@@ -1006,7 +1006,7 @@ class NoRewindIterator extends IteratorIterator implements OuterIterator, Traver
     public function next() { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Get the inner iterator
      * @link http://php.net/manual/en/norewinditerator.getinneriterator.php
      * @return Iterator The inner iterator, as passed to <b>NoRewindIterator::__construct</b>.
@@ -1021,14 +1021,14 @@ class NoRewindIterator extends IteratorIterator implements OuterIterator, Traver
 class AppendIterator extends IteratorIterator implements OuterIterator, Traversable, Iterator {
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Constructs an AppendIterator
      * @link http://php.net/manual/en/appenditerator.construct.php
      */
     public function __construct() { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Appends an iterator
      * @link http://php.net/manual/en/appenditerator.append.php
      * @param Iterator $iterator <p>
@@ -1039,7 +1039,7 @@ class AppendIterator extends IteratorIterator implements OuterIterator, Traversa
     public function append(Iterator $iterator) { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Rewinds the Iterator
      * @link http://php.net/manual/en/appenditerator.rewind.php
      * @return void
@@ -1047,7 +1047,7 @@ class AppendIterator extends IteratorIterator implements OuterIterator, Traversa
     public function rewind() { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Checks validity of the current element
      * @link http://php.net/manual/en/appenditerator.valid.php
      * @return bool true on success or false on failure.
@@ -1055,7 +1055,7 @@ class AppendIterator extends IteratorIterator implements OuterIterator, Traversa
     public function valid() { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Gets the current key
      * @link http://php.net/manual/en/appenditerator.key.php
      * @return mixed The current key if it is valid or null otherwise.
@@ -1063,7 +1063,7 @@ class AppendIterator extends IteratorIterator implements OuterIterator, Traversa
     public function key() { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Gets the current value
      * @link http://php.net/manual/en/appenditerator.current.php
      * @return mixed The current value if it is valid or &null; otherwise.
@@ -1071,7 +1071,7 @@ class AppendIterator extends IteratorIterator implements OuterIterator, Traversa
     public function current() { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Moves to the next element
      * @link http://php.net/manual/en/appenditerator.next.php
      * @return void
@@ -1079,7 +1079,7 @@ class AppendIterator extends IteratorIterator implements OuterIterator, Traversa
     public function next() { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Gets an inner iterator
      * @link http://php.net/manual/en/appenditerator.getinneriterator.php
      * @return Iterator the current inner Iterator.
@@ -1087,7 +1087,7 @@ class AppendIterator extends IteratorIterator implements OuterIterator, Traversa
     public function getInnerIterator() { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Gets an index of iterators
      * @link http://php.net/manual/en/appenditerator.getiteratorindex.php
      * @return int The index of iterators.
@@ -1095,7 +1095,7 @@ class AppendIterator extends IteratorIterator implements OuterIterator, Traversa
     public function getIteratorIndex() { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * The getArrayIterator method
      * @link http://php.net/manual/en/appenditerator.getarrayiterator.php
      * @return ArrayIterator containing the appended iterators.
@@ -1112,7 +1112,7 @@ class AppendIterator extends IteratorIterator implements OuterIterator, Traversa
 class InfiniteIterator extends IteratorIterator implements OuterIterator, Traversable, Iterator {
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Constructs an InfiniteIterator
      * @link http://php.net/manual/en/infiniteiterator.construct.php
      * @param Iterator $iterator
@@ -1120,7 +1120,7 @@ class InfiniteIterator extends IteratorIterator implements OuterIterator, Traver
     public function __construct(Iterator $iterator) { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Moves the inner Iterator forward or rewinds it
      * @link http://php.net/manual/en/infiniteiterator.next.php
      * @return void
@@ -1168,7 +1168,7 @@ class RegexIterator extends FilterIterator implements Iterator, Traversable, Out
 
 
     /**
-     * (PHP 5 &gt;= 5.2.0)<br/>
+     * @since 5.2.0
      * Create a new RegexIterator
      * @link http://php.net/manual/en/regexiterator.construct.php
      * @param Iterator $iterator The iterator to apply this regex filter to.
@@ -1180,7 +1180,7 @@ class RegexIterator extends FilterIterator implements Iterator, Traversable, Out
     public function __construct(Iterator $iterator, $regex, $mode = self::MATCH, $flags = 0, $preg_flags = 0) { }
 
     /**
-     * (PHP 5 &gt;= 5.2.0)<br/>
+     * @since 5.2.0
      * Get accept status
      * @link http://php.net/manual/en/regexiterator.accept.php
      * @return bool true if a match, false otherwise.
@@ -1188,7 +1188,7 @@ class RegexIterator extends FilterIterator implements Iterator, Traversable, Out
     public function accept() { }
 
     /**
-     * (PHP 5 &gt;= 5.2.0)<br/>
+     * @since 5.2.0
      * Returns operation mode.
      * @link http://php.net/manual/en/regexiterator.getmode.php
      * @return int the operation mode.
@@ -1196,7 +1196,7 @@ class RegexIterator extends FilterIterator implements Iterator, Traversable, Out
     public function getMode() { }
 
     /**
-     * (PHP 5 &gt;= 5.2.0)<br/>
+     * @since 5.2.0
      * Sets the operation mode.
      * @link http://php.net/manual/en/regexiterator.setmode.php
      * @param int $mode <p>
@@ -1249,7 +1249,7 @@ class RegexIterator extends FilterIterator implements Iterator, Traversable, Out
     public function setMode($mode) { }
 
     /**
-     * (PHP 5 &gt;= 5.2.0)<br/>
+     * @since 5.2.0
      * Get flags
      * @link http://php.net/manual/en/regexiterator.getflags.php
      * @return int the set flags.
@@ -1257,7 +1257,7 @@ class RegexIterator extends FilterIterator implements Iterator, Traversable, Out
     public function getFlags() { }
 
     /**
-     * (PHP 5 &gt;= 5.2.0)<br/>
+     * @since 5.2.0
      * Sets the flags.
      * @link http://php.net/manual/en/regexiterator.setflags.php
      * @param int $flags <p>
@@ -1286,7 +1286,7 @@ class RegexIterator extends FilterIterator implements Iterator, Traversable, Out
     public function setFlags($flags) { }
 
     /**
-    * PHP >= 5.4.0<br/>
+    * @since 5.4.0
     * Returns current regular expression
     * @link http://www.php.net/manual/en/regexiterator.getregex.php
     * @return string
@@ -1294,7 +1294,7 @@ class RegexIterator extends FilterIterator implements Iterator, Traversable, Out
     public function getRegex() {}
 
     /**
-     * (PHP 5 &gt;= 5.2.0)<br/>
+     * @since 5.2.0
      * Returns the regular expression flags.
      * @link http://php.net/manual/en/regexiterator.getpregflags.php
      * @return int a bitmask of the regular expression flags.
@@ -1302,7 +1302,7 @@ class RegexIterator extends FilterIterator implements Iterator, Traversable, Out
     public function getPregFlags() { }
 
     /**
-     * (PHP 5 &gt;= 5.2.0)<br/>
+     * @since 5.2.0
      * Sets the regular expression flags.
      * @link http://php.net/manual/en/regexiterator.setpregflags.php
      * @param int $preg_flags <p>
@@ -1320,7 +1320,7 @@ class RegexIterator extends FilterIterator implements Iterator, Traversable, Out
  */
 class RecursiveRegexIterator extends RegexIterator implements OuterIterator, Traversable, Iterator, RecursiveIterator {
     /**
-     * (PHP 5 &gt;= 5.2.0)<br/>
+     * @since 5.2.0
      * Creates a new RecursiveRegexIterator.
      * @link http://php.net/manual/en/recursiveregexiterator.construct.php
      * @param RecursiveIterator $iterator The iterator to apply this regex filter to.
@@ -1332,7 +1332,7 @@ class RecursiveRegexIterator extends RegexIterator implements OuterIterator, Tra
     public function __construct(RecursiveIterator $iterator, $regex, $mode, $flags, $preg_flags) { }
 
     /**
-     * (PHP 5 &gt;= 5.2.0)<br/>
+     * @since 5.2.0
      * Returns whether an iterator can be obtained for the current entry.
      * @link http://php.net/manual/en/recursiveregexiterator.haschildren.php
      * @return bool true if an iterator can be obtained for the current entry, otherwise returns false.
@@ -1340,7 +1340,7 @@ class RecursiveRegexIterator extends RegexIterator implements OuterIterator, Tra
     public function hasChildren() { }
 
     /**
-     * (PHP 5 &gt;= 5.2.0)<br/>
+     * @since 5.2.0
      * Returns an iterator for the current entry.
      * @link http://php.net/manual/en/recursiveregexiterator.getchildren.php
      * @return RecursiveRegexIterator An iterator for the current entry, if it can be iterated over by the inner iterator.
@@ -1366,7 +1366,7 @@ class RecursiveTreeIterator extends RecursiveIteratorIterator implements OuterIt
 
 
     /**
-     * (PHP 5 &gt;= 5.3.0)<br/>
+     * @since 5.3.0
      * Construct a RecursiveTreeIterator
      * @link http://php.net/manual/en/recursivetreeiterator.construct.php
      * @param RecursiveIterator|IteratorAggregate $iterator
@@ -1378,7 +1378,7 @@ class RecursiveTreeIterator extends RecursiveIteratorIterator implements OuterIt
                                 $mode = RecursiveIteratorIterator::SELF_FIRST) { }
 
     /**
-     * (PHP 5 &gt;= 5.3.0)<br/>
+     * @since 5.3.0
      * Rewind iterator
      * @link http://php.net/manual/en/recursivetreeiterator.rewind.php
      * @return void
@@ -1386,7 +1386,7 @@ class RecursiveTreeIterator extends RecursiveIteratorIterator implements OuterIt
     public function rewind() { }
 
     /**
-     * (PHP 5 &gt;= 5.3.0)<br/>
+     * @since 5.3.0
      * Check validity
      * @link http://php.net/manual/en/recursivetreeiterator.valid.php
      * @return bool true if the current position is valid, otherwise false
@@ -1394,7 +1394,7 @@ class RecursiveTreeIterator extends RecursiveIteratorIterator implements OuterIt
     public function valid() { }
 
     /**
-     * (PHP 5 &gt;= 5.3.0)<br/>
+     * @since 5.3.0
      * Get the key of the current element
      * @link http://php.net/manual/en/recursivetreeiterator.key.php
      * @return string the current key prefixed and postfixed.
@@ -1402,7 +1402,7 @@ class RecursiveTreeIterator extends RecursiveIteratorIterator implements OuterIt
     public function key() { }
 
     /**
-     * (PHP 5 &gt;= 5.3.0)<br/>
+     * @since 5.3.0
      * Get current element
      * @link http://php.net/manual/en/recursivetreeiterator.current.php
      * @return string the current element prefixed and postfixed.
@@ -1410,7 +1410,7 @@ class RecursiveTreeIterator extends RecursiveIteratorIterator implements OuterIt
     public function current() { }
 
     /**
-     * (PHP 5 &gt;= 5.3.0)<br/>
+     * @since 5.3.0
      * Move to next element
      * @link http://php.net/manual/en/recursivetreeiterator.next.php
      * @return void
@@ -1418,7 +1418,7 @@ class RecursiveTreeIterator extends RecursiveIteratorIterator implements OuterIt
     public function next() { }
 
     /**
-     * (PHP 5 &gt;= 5.3.0)<br/>
+     * @since 5.3.0
      * Begin iteration
      * @link http://php.net/manual/en/recursivetreeiterator.beginiteration.php
      * @return RecursiveIterator A <b>RecursiveIterator</b>.
@@ -1426,7 +1426,7 @@ class RecursiveTreeIterator extends RecursiveIteratorIterator implements OuterIt
     public function beginIteration() { }
 
     /**
-     * (PHP 5 &gt;= 5.3.0)<br/>
+     * @since 5.3.0
      * End iteration
      * @link http://php.net/manual/en/recursivetreeiterator.enditeration.php
      * @return void
@@ -1434,7 +1434,7 @@ class RecursiveTreeIterator extends RecursiveIteratorIterator implements OuterIt
     public function endIteration() { }
 
     /**
-     * (PHP 5 &gt;= 5.3.0)<br/>
+     * @since 5.3.0
      * Has children
      * @link http://php.net/manual/en/recursivetreeiterator.callhaschildren.php
      * @return bool true if there are children, otherwise false
@@ -1442,7 +1442,7 @@ class RecursiveTreeIterator extends RecursiveIteratorIterator implements OuterIt
     public function callHasChildren() { }
 
     /**
-     * (PHP 5 &gt;= 5.3.0)<br/>
+     * @since 5.3.0
      * Get children
      * @link http://php.net/manual/en/recursivetreeiterator.callgetchildren.php
      * @return RecursiveIterator A <b>RecursiveIterator</b>.
@@ -1450,7 +1450,7 @@ class RecursiveTreeIterator extends RecursiveIteratorIterator implements OuterIt
     public function callGetChildren() { }
 
     /**
-     * (PHP 5 &gt;= 5.3.0)<br/>
+     * @since 5.3.0
      * Begin children
      * @link http://php.net/manual/en/recursivetreeiterator.beginchildren.php
      * @return void
@@ -1458,7 +1458,7 @@ class RecursiveTreeIterator extends RecursiveIteratorIterator implements OuterIt
     public function beginChildren() { }
 
     /**
-     * (PHP 5 &gt;= 5.3.0)<br/>
+     * @since 5.3.0
      * End children
      * @link http://php.net/manual/en/recursivetreeiterator.endchildren.php
      * @return void
@@ -1466,7 +1466,7 @@ class RecursiveTreeIterator extends RecursiveIteratorIterator implements OuterIt
     public function endChildren() { }
 
     /**
-     * (PHP 5 &gt;= 5.3.0)<br/>
+     * @since 5.3.0
      * Next element
      * @link http://php.net/manual/en/recursivetreeiterator.nextelement.php
      * @return void
@@ -1474,7 +1474,7 @@ class RecursiveTreeIterator extends RecursiveIteratorIterator implements OuterIt
     public function nextElement() { }
 
     /**
-     * (PHP 5 &gt;= 5.3.0)<br/>
+     * @since 5.3.0
      * Get the prefix
      * @link http://php.net/manual/en/recursivetreeiterator.getprefix.php
      * @return string the string to place in front of current element
@@ -1482,7 +1482,7 @@ class RecursiveTreeIterator extends RecursiveIteratorIterator implements OuterIt
     public function getPrefix() { }
 
     /**
-     * (PHP 5 &gt;= 5.3.0)<br/>
+     * @since 5.3.0
      * Set a part of the prefix
      * @link http://php.net/manual/en/recursivetreeiterator.setprefixpart.php
      * @param int $part <p>
@@ -1496,7 +1496,7 @@ class RecursiveTreeIterator extends RecursiveIteratorIterator implements OuterIt
     public function setPrefixPart($part, $value) { }
 
     /**
-     * (PHP 5 &gt;= 5.3.0)<br/>
+     * @since 5.3.0
      * Get current entry
      * @link http://php.net/manual/en/recursivetreeiterator.getentry.php
      * @return string the part of the tree built for the current element.
@@ -1504,7 +1504,7 @@ class RecursiveTreeIterator extends RecursiveIteratorIterator implements OuterIt
     public function getEntry() { }
 
     /**
-     * (PHP 5 &gt;= 5.3.0)<br/>
+     * @since 5.3.0
      * Get the postfix
      * @link http://php.net/manual/en/recursivetreeiterator.getpostfix.php
      * @return string to place after the current element.
@@ -1529,7 +1529,7 @@ class ArrayObject implements IteratorAggregate, Traversable, ArrayAccess, Serial
 
 
     /**
-     * (PHP 5 &gt;= 5.0.0)<br/>
+     * @since 5.0.0
      * Construct a new array object
      * @link http://php.net/manual/en/arrayobject.construct.php
      * @param array|object $input The input parameter accepts an array or an Object.
@@ -1540,7 +1540,7 @@ class ArrayObject implements IteratorAggregate, Traversable, ArrayAccess, Serial
     public function __construct($input = null, $flags = 0, $iterator_class = "ArrayIterator") { }
 
     /**
-     * (PHP 5 &gt;= 5.0.0)<br/>
+     * @since 5.0.0
      * Returns whether the requested index exists
      * @link http://php.net/manual/en/arrayobject.offsetexists.php
      * @param mixed $index <p>
@@ -1551,7 +1551,7 @@ class ArrayObject implements IteratorAggregate, Traversable, ArrayAccess, Serial
     public function offsetExists($index) { }
 
     /**
-     * (PHP 5 &gt;= 5.0.0)<br/>
+     * @since 5.0.0
      * Returns the value at the specified index
      * @link http://php.net/manual/en/arrayobject.offsetget.php
      * @param mixed $index <p>
@@ -1562,7 +1562,7 @@ class ArrayObject implements IteratorAggregate, Traversable, ArrayAccess, Serial
     public function offsetGet($index) { }
 
     /**
-     * (PHP 5 &gt;= 5.0.0)<br/>
+     * @since 5.0.0
      * Sets the value at the specified index to newval
      * @link http://php.net/manual/en/arrayobject.offsetset.php
      * @param mixed $index <p>
@@ -1576,7 +1576,7 @@ class ArrayObject implements IteratorAggregate, Traversable, ArrayAccess, Serial
     public function offsetSet($index, $newval) { }
 
     /**
-     * (PHP 5 &gt;= 5.0.0)<br/>
+     * @since 5.0.0
      * Unsets the value at the specified index
      * @link http://php.net/manual/en/arrayobject.offsetunset.php
      * @param mixed $index <p>
@@ -1587,7 +1587,7 @@ class ArrayObject implements IteratorAggregate, Traversable, ArrayAccess, Serial
     public function offsetUnset($index) { }
 
     /**
-     * (PHP 5 &gt;= 5.0.0)<br/>
+     * @since 5.0.0
      * Appends the value
      * @link http://php.net/manual/en/arrayobject.append.php
      * @param mixed $value <p>
@@ -1598,7 +1598,7 @@ class ArrayObject implements IteratorAggregate, Traversable, ArrayAccess, Serial
     public function append($value) { }
 
     /**
-     * (PHP 5 &gt;= 5.0.0)<br/>
+     * @since 5.0.0
      * Creates a copy of the ArrayObject.
      * @link http://php.net/manual/en/arrayobject.getarraycopy.php
      * @return array a copy of the array. When the <b>ArrayObject</b> refers to an object
@@ -1607,7 +1607,7 @@ class ArrayObject implements IteratorAggregate, Traversable, ArrayAccess, Serial
     public function getArrayCopy() { }
 
     /**
-     * (PHP 5 &gt;= 5.0.0)<br/>
+     * @since 5.0.0
      * Get the number of public properties in the ArrayObject
      * When the <b>ArrayObject</b> is constructed from an array all properties are public.
      * @link http://php.net/manual/en/arrayobject.count.php
@@ -1616,7 +1616,7 @@ class ArrayObject implements IteratorAggregate, Traversable, ArrayAccess, Serial
     public function count() { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Gets the behavior flags.
      * @link http://php.net/manual/en/arrayobject.getflags.php
      * @return int the behavior flags of the ArrayObject.
@@ -1624,7 +1624,7 @@ class ArrayObject implements IteratorAggregate, Traversable, ArrayAccess, Serial
     public function getFlags() { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Sets the behavior flags.
      * @link http://php.net/manual/en/arrayobject.setflags.php
      * @param int $flags <p>
@@ -1662,7 +1662,7 @@ class ArrayObject implements IteratorAggregate, Traversable, ArrayAccess, Serial
     public function setFlags($flags) { }
 
     /**
-     * (PHP 5 &gt;= 5.2.0)<br/>
+     * @since 5.2.0
      * Sort the entries by value
      * @link http://php.net/manual/en/arrayobject.asort.php
      * @return void
@@ -1670,7 +1670,7 @@ class ArrayObject implements IteratorAggregate, Traversable, ArrayAccess, Serial
     public function asort() { }
 
     /**
-     * (PHP 5 &gt;= 5.2.0)<br/>
+     * @since 5.2.0
      * Sort the entries by key
      * @link http://php.net/manual/en/arrayobject.ksort.php
      * @return void
@@ -1678,7 +1678,7 @@ class ArrayObject implements IteratorAggregate, Traversable, ArrayAccess, Serial
     public function ksort() { }
 
     /**
-     * (PHP 5 &gt;= 5.2.0)<br/>
+     * @since 5.2.0
      * Sort the entries with a user-defined comparison function and maintain key association
      * @link http://php.net/manual/en/arrayobject.uasort.php
      * @param callback $cmp_function <p>
@@ -1694,7 +1694,7 @@ class ArrayObject implements IteratorAggregate, Traversable, ArrayAccess, Serial
     public function uasort($cmp_function) { }
 
     /**
-     * (PHP 5 &gt;= 5.2.0)<br/>
+     * @since 5.2.0
      * Sort the entries by keys using a user-defined comparison function
      * @link http://php.net/manual/en/arrayobject.uksort.php
      * @param callback $cmp_function <p>
@@ -1713,7 +1713,7 @@ class ArrayObject implements IteratorAggregate, Traversable, ArrayAccess, Serial
     public function uksort($cmp_function) { }
 
     /**
-     * (PHP 5 &gt;= 5.2.0)<br/>
+     * @since 5.2.0
      * Sort entries using a "natural order" algorithm
      * @link http://php.net/manual/en/arrayobject.natsort.php
      * @return void
@@ -1721,7 +1721,7 @@ class ArrayObject implements IteratorAggregate, Traversable, ArrayAccess, Serial
     public function natsort() { }
 
     /**
-     * (PHP 5 &gt;= 5.2.0)<br/>
+     * @since 5.2.0
      * Sort an array using a case insensitive "natural order" algorithm
      * @link http://php.net/manual/en/arrayobject.natcasesort.php
      * @return void
@@ -1729,7 +1729,7 @@ class ArrayObject implements IteratorAggregate, Traversable, ArrayAccess, Serial
     public function natcasesort() { }
 
     /**
-     * (PHP 5 &gt;= 5.3.0)<br/>
+     * @since 5.3.0
      * Unserialize an ArrayObject
      * @link http://php.net/manual/en/arrayobject.unserialize.php
      * @param string $serialized <p>
@@ -1740,7 +1740,7 @@ class ArrayObject implements IteratorAggregate, Traversable, ArrayAccess, Serial
     public function unserialize($serialized) { }
 
     /**
-     * (PHP 5 &gt;= 5.3.0)<br/>
+     * @since 5.3.0
      * Serialize an ArrayObject
      * @link http://php.net/manual/en/arrayobject.serialize.php
      * @return string The serialized representation of the <b>ArrayObject</b>.
@@ -1748,7 +1748,7 @@ class ArrayObject implements IteratorAggregate, Traversable, ArrayAccess, Serial
     public function serialize() { }
 
     /**
-     * (PHP 5 &gt;= 5.0.0)<br/>
+     * @since 5.0.0
      * Create a new iterator from an ArrayObject instance
      * @link http://php.net/manual/en/arrayobject.getiterator.php
      * @return ArrayIterator An iterator from an <b>ArrayObject</b>.
@@ -1756,7 +1756,7 @@ class ArrayObject implements IteratorAggregate, Traversable, ArrayAccess, Serial
     public function getIterator() { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Exchange the array for another one.
      * @link http://php.net/manual/en/arrayobject.exchangearray.php
      * @param mixed $input <p>
@@ -1767,7 +1767,7 @@ class ArrayObject implements IteratorAggregate, Traversable, ArrayAccess, Serial
     public function exchangeArray($input) { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Sets the iterator classname for the ArrayObject.
      * @link http://php.net/manual/en/arrayobject.setiteratorclass.php
      * @param string $iterator_class <p>
@@ -1778,7 +1778,7 @@ class ArrayObject implements IteratorAggregate, Traversable, ArrayAccess, Serial
     public function setIteratorClass($iterator_class) { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Gets the iterator classname for the ArrayObject.
      * @link http://php.net/manual/en/arrayobject.getiteratorclass.php
      * @return string the iterator class name that is used to iterate over this object.
@@ -1797,7 +1797,7 @@ class ArrayIterator implements Iterator, Traversable, ArrayAccess, SeekableItera
 
 
     /**
-     * (PHP 5 &gt;= 5.0.0)<br/>
+     * @since 5.0.0
      * Construct an ArrayIterator
      * @link http://php.net/manual/en/arrayiterator.construct.php
      * @param array $array The array or object to be iterated on.
@@ -1807,7 +1807,7 @@ class ArrayIterator implements Iterator, Traversable, ArrayAccess, SeekableItera
     public function __construct($array = array(), $flags = 0) { }
 
     /**
-     * (PHP 5 &gt;= 5.0.0)<br/>
+     * @since 5.0.0
      * Check if offset exists
      * @link http://php.net/manual/en/arrayiterator.offsetexists.php
      * @param string $index <p>
@@ -1818,7 +1818,7 @@ class ArrayIterator implements Iterator, Traversable, ArrayAccess, SeekableItera
     public function offsetExists($index) { }
 
     /**
-     * (PHP 5 &gt;= 5.0.0)<br/>
+     * @since 5.0.0
      * Get value for an offset
      * @link http://php.net/manual/en/arrayiterator.offsetget.php
      * @param string $index <p>
@@ -1829,7 +1829,7 @@ class ArrayIterator implements Iterator, Traversable, ArrayAccess, SeekableItera
     public function offsetGet($index) { }
 
     /**
-     * (PHP 5 &gt;= 5.0.0)<br/>
+     * @since 5.0.0
      * Set value for an offset
      * @link http://php.net/manual/en/arrayiterator.offsetset.php
      * @param string $index <p>
@@ -1843,7 +1843,7 @@ class ArrayIterator implements Iterator, Traversable, ArrayAccess, SeekableItera
     public function offsetSet($index, $newval) { }
 
     /**
-     * (PHP 5 &gt;= 5.0.0)<br/>
+     * @since 5.0.0
      * Unset value for an offset
      * @link http://php.net/manual/en/arrayiterator.offsetunset.php
      * @param string $index <p>
@@ -1854,7 +1854,7 @@ class ArrayIterator implements Iterator, Traversable, ArrayAccess, SeekableItera
     public function offsetUnset($index) { }
 
     /**
-     * (PHP 5 &gt;= 5.0.0)<br/>
+     * @since 5.0.0
      * Append an element
      * @link http://php.net/manual/en/arrayiterator.append.php
      * @param mixed $value <p>
@@ -1865,7 +1865,7 @@ class ArrayIterator implements Iterator, Traversable, ArrayAccess, SeekableItera
     public function append($value) { }
 
     /**
-     * (PHP 5 &gt;= 5.0.0)<br/>
+     * @since 5.0.0
      * Get array copy
      * @link http://php.net/manual/en/arrayiterator.getarraycopy.php
      * @return array A copy of the array, or array of public properties
@@ -1874,7 +1874,7 @@ class ArrayIterator implements Iterator, Traversable, ArrayAccess, SeekableItera
     public function getArrayCopy() { }
 
     /**
-     * (PHP 5 &gt;= 5.0.0)<br/>
+     * @since 5.0.0
      * Count elements
      * @link http://php.net/manual/en/arrayiterator.count.php
      * @return int The number of elements or public properties in the associated
@@ -1883,7 +1883,7 @@ class ArrayIterator implements Iterator, Traversable, ArrayAccess, SeekableItera
     public function count() { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Get flags
      * @link http://php.net/manual/en/arrayiterator.getflags.php
      * @return string The current flags.
@@ -1891,7 +1891,7 @@ class ArrayIterator implements Iterator, Traversable, ArrayAccess, SeekableItera
     public function getFlags() { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Set behaviour flags
      * @link http://php.net/manual/en/arrayiterator.setflags.php
      * @param string $flags <p>
@@ -1905,7 +1905,7 @@ class ArrayIterator implements Iterator, Traversable, ArrayAccess, SeekableItera
     public function setFlags($flags) { }
 
     /**
-     * (PHP 5 &gt;= 5.2.0)<br/>
+     * @since 5.2.0
      * Sort array by values
      * @link http://php.net/manual/en/arrayiterator.asort.php
      * @return void
@@ -1913,7 +1913,7 @@ class ArrayIterator implements Iterator, Traversable, ArrayAccess, SeekableItera
     public function asort() { }
 
     /**
-     * (PHP 5 &gt;= 5.2.0)<br/>
+     * @since 5.2.0
      * Sort array by keys
      * @link http://php.net/manual/en/arrayiterator.ksort.php
      * @return void
@@ -1921,7 +1921,7 @@ class ArrayIterator implements Iterator, Traversable, ArrayAccess, SeekableItera
     public function ksort() { }
 
     /**
-     * (PHP 5 &gt;= 5.2.0)<br/>
+     * @since 5.2.0
      * User defined sort
      * @link http://php.net/manual/en/arrayiterator.uasort.php
      * @param string $cmp_function <p>
@@ -1932,7 +1932,7 @@ class ArrayIterator implements Iterator, Traversable, ArrayAccess, SeekableItera
     public function uasort($cmp_function) { }
 
     /**
-     * (PHP 5 &gt;= 5.2.0)<br/>
+     * @since 5.2.0
      * User defined sort
      * @link http://php.net/manual/en/arrayiterator.uksort.php
      * @param string $cmp_function <p>
@@ -1943,7 +1943,7 @@ class ArrayIterator implements Iterator, Traversable, ArrayAccess, SeekableItera
     public function uksort($cmp_function) { }
 
     /**
-     * (PHP 5 &gt;= 5.2.0)<br/>
+     * @since 5.2.0
      * Sort an array naturally
      * @link http://php.net/manual/en/arrayiterator.natsort.php
      * @return void
@@ -1951,7 +1951,7 @@ class ArrayIterator implements Iterator, Traversable, ArrayAccess, SeekableItera
     public function natsort() { }
 
     /**
-     * (PHP 5 &gt;= 5.2.0)<br/>
+     * @since 5.2.0
      * Sort an array naturally, case insensitive
      * @link http://php.net/manual/en/arrayiterator.natcasesort.php
      * @return void
@@ -1959,7 +1959,7 @@ class ArrayIterator implements Iterator, Traversable, ArrayAccess, SeekableItera
     public function natcasesort() { }
 
     /**
-     * (PHP 5 &gt;= 5.3.0)<br/>
+     * @since 5.3.0
      * Unserialize
      * @link http://php.net/manual/en/arrayiterator.unserialize.php
      * @param string $serialized <p>
@@ -1970,7 +1970,7 @@ class ArrayIterator implements Iterator, Traversable, ArrayAccess, SeekableItera
     public function unserialize($serialized) { }
 
     /**
-     * (PHP 5 &gt;= 5.3.0)<br/>
+     * @since 5.3.0
      * Serialize
      * @link http://php.net/manual/en/arrayiterator.serialize.php
      * @return string The serialized <b>ArrayIterator</b>.
@@ -1978,7 +1978,7 @@ class ArrayIterator implements Iterator, Traversable, ArrayAccess, SeekableItera
     public function serialize() { }
 
     /**
-     * (PHP 5 &gt;= 5.0.0)<br/>
+     * @since 5.0.0
      * Rewind array back to the start
      * @link http://php.net/manual/en/arrayiterator.rewind.php
      * @return void
@@ -1986,7 +1986,7 @@ class ArrayIterator implements Iterator, Traversable, ArrayAccess, SeekableItera
     public function rewind() { }
 
     /**
-     * (PHP 5 &gt;= 5.0.0)<br/>
+     * @since 5.0.0
      * Return current array entry
      * @link http://php.net/manual/en/arrayiterator.current.php
      * @return mixed The current array entry.
@@ -1994,7 +1994,7 @@ class ArrayIterator implements Iterator, Traversable, ArrayAccess, SeekableItera
     public function current() { }
 
     /**
-     * (PHP 5 &gt;= 5.0.0)<br/>
+     * @since 5.0.0
      * Return current array key
      * @link http://php.net/manual/en/arrayiterator.key.php
      * @return mixed The current array key.
@@ -2002,7 +2002,7 @@ class ArrayIterator implements Iterator, Traversable, ArrayAccess, SeekableItera
     public function key() { }
 
     /**
-     * (PHP 5 &gt;= 5.0.0)<br/>
+     * @since 5.0.0
      * Move to next entry
      * @link http://php.net/manual/en/arrayiterator.next.php
      * @return void
@@ -2010,7 +2010,7 @@ class ArrayIterator implements Iterator, Traversable, ArrayAccess, SeekableItera
     public function next() { }
 
     /**
-     * (PHP 5 &gt;= 5.0.0)<br/>
+     * @since 5.0.0
      * Check whether array contains more entries
      * @link http://php.net/manual/en/arrayiterator.valid.php
      * @return bool
@@ -2018,7 +2018,7 @@ class ArrayIterator implements Iterator, Traversable, ArrayAccess, SeekableItera
     public function valid() { }
 
     /**
-     * (PHP 5 &gt;= 5.0.0)<br/>
+     * @since 5.0.0
      * Seek to position
      * @link http://php.net/manual/en/arrayiterator.seek.php
      * @param int $position <p>
@@ -2041,7 +2041,7 @@ class RecursiveArrayIterator extends ArrayIterator
 
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Returns whether current entry is an array or an object.
      * @link http://php.net/manual/en/recursivearrayiterator.haschildren.php
      * @return bool true if the current entry is an array or an object,
@@ -2050,7 +2050,7 @@ class RecursiveArrayIterator extends ArrayIterator
     public function hasChildren() { }
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Returns an iterator for the current entry if it is an array or an object.
      * @link http://php.net/manual/en/recursivearrayiterator.getchildren.php
      * @return RecursiveArrayIterator An iterator for the current entry, if it is an array or object.

--- a/SPL_c1.php
+++ b/SPL_c1.php
@@ -10,7 +10,7 @@
 class SplFileInfo  {
 
         /**
-         * (PHP 5 &gt;= 5.1.2)<br/>
+         * @since 5.1.2
          * Construct a new SplFileInfo object
          * @link http://php.net/manual/en/splfileinfo.construct.php
          * @param $file_name
@@ -18,7 +18,7 @@ class SplFileInfo  {
         public function __construct ($file_name) {}
 
         /**
-         * (PHP 5 &gt;= 5.1.2)<br/>
+         * @since 5.1.2
          * Gets the path without filename
          * @link http://php.net/manual/en/splfileinfo.getpath.php
          * @return string the path to the file.
@@ -26,7 +26,7 @@ class SplFileInfo  {
         public function getPath () {}
 
         /**
-         * (PHP 5 &gt;= 5.1.2)<br/>
+         * @since 5.1.2
          * Gets the filename
          * @link http://php.net/manual/en/splfileinfo.getfilename.php
          * @return string The filename.
@@ -34,7 +34,7 @@ class SplFileInfo  {
         public function getFilename () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.6)<br/>
+         * @since 5.3.6
          * Gets the file extension
          * @link http://php.net/manual/en/splfileinfo.getextension.php
 	 * @return string a string containing the file extension, or an
@@ -43,7 +43,7 @@ class SplFileInfo  {
         public function getExtension () {}
 
         /**
-         * (PHP 5 &gt;= 5.2.2)<br/>
+         * @since 5.2.2
          * Gets the base name of the file
          * @link http://php.net/manual/en/splfileinfo.getbasename.php
          * @param string $suffix [optional] <p>
@@ -54,7 +54,7 @@ class SplFileInfo  {
         public function getBasename ($suffix = null) {}
 
         /**
-         * (PHP 5 &gt;= 5.1.2)<br/>
+         * @since 5.1.2
          * Gets the path to the file
          * @link http://php.net/manual/en/splfileinfo.getpathname.php
          * @return string The path to the file.
@@ -62,7 +62,7 @@ class SplFileInfo  {
         public function getPathname () {}
 
         /**
-         * (PHP 5 &gt;= 5.1.2)<br/>
+         * @since 5.1.2
          * Gets file permissions
          * @link http://php.net/manual/en/splfileinfo.getperms.php
          * @return int the file permissions.
@@ -70,7 +70,7 @@ class SplFileInfo  {
         public function getPerms () {}
 
         /**
-         * (PHP 5 &gt;= 5.1.2)<br/>
+         * @since 5.1.2
          * Gets the inode for the file
          * @link http://php.net/manual/en/splfileinfo.getinode.php
          * @return int the inode number for the filesystem object.
@@ -78,7 +78,7 @@ class SplFileInfo  {
         public function getInode () {}
 
         /**
-         * (PHP 5 &gt;= 5.1.2)<br/>
+         * @since 5.1.2
          * Gets file size
          * @link http://php.net/manual/en/splfileinfo.getsize.php
          * @return int The filesize in bytes.
@@ -86,7 +86,7 @@ class SplFileInfo  {
         public function getSize () {}
 
         /**
-         * (PHP 5 &gt;= 5.1.2)<br/>
+         * @since 5.1.2
          * Gets the owner of the file
          * @link http://php.net/manual/en/splfileinfo.getowner.php
          * @return int The owner id in numerical format.
@@ -94,7 +94,7 @@ class SplFileInfo  {
         public function getOwner () {}
 
         /**
-         * (PHP 5 &gt;= 5.1.2)<br/>
+         * @since 5.1.2
          * Gets the file group
          * @link http://php.net/manual/en/splfileinfo.getgroup.php
          * @return int The group id in numerical format.
@@ -102,7 +102,7 @@ class SplFileInfo  {
         public function getGroup () {}
 
         /**
-         * (PHP 5 &gt;= 5.1.2)<br/>
+         * @since 5.1.2
          * Gets last access time of the file
          * @link http://php.net/manual/en/splfileinfo.getatime.php
          * @return int the time the file was last accessed.
@@ -110,7 +110,7 @@ class SplFileInfo  {
         public function getATime () {}
 
         /**
-         * (PHP 5 &gt;= 5.1.2)<br/>
+         * @since 5.1.2
          * Gets the last modified time
          * @link http://php.net/manual/en/splfileinfo.getmtime.php
          * @return int the last modified time for the file, in a Unix timestamp.
@@ -118,7 +118,7 @@ class SplFileInfo  {
         public function getMTime () {}
 
         /**
-         * (PHP 5 &gt;= 5.1.2)<br/>
+         * @since 5.1.2
          * Gets the inode change time
          * @link http://php.net/manual/en/splfileinfo.getctime.php
          * @return int The last change time, in a Unix timestamp.
@@ -126,7 +126,7 @@ class SplFileInfo  {
         public function getCTime () {}
 
         /**
-         * (PHP 5 &gt;= 5.1.2)<br/>
+         * @since 5.1.2
          * Gets file type
          * @link http://php.net/manual/en/splfileinfo.gettype.php
          * @return string A string representing the type of the entry.
@@ -136,7 +136,7 @@ class SplFileInfo  {
         public function getType () {}
 
         /**
-         * (PHP 5 &gt;= 5.1.2)<br/>
+         * @since 5.1.2
          * Tells if the entry is writable
          * @link http://php.net/manual/en/splfileinfo.iswritable.php
          * @return bool true if writable, false otherwise;
@@ -144,7 +144,7 @@ class SplFileInfo  {
         public function isWritable () {}
 
         /**
-         * (PHP 5 &gt;= 5.1.2)<br/>
+         * @since 5.1.2
          * Tells if file is readable
          * @link http://php.net/manual/en/splfileinfo.isreadable.php
          * @return bool true if readable, false otherwise.
@@ -152,7 +152,7 @@ class SplFileInfo  {
         public function isReadable () {}
 
         /**
-         * (PHP 5 &gt;= 5.1.2)<br/>
+         * @since 5.1.2
          * Tells if the file is executable
          * @link http://php.net/manual/en/splfileinfo.isexecutable.php
          * @return bool true if executable, false otherwise.
@@ -160,7 +160,7 @@ class SplFileInfo  {
         public function isExecutable () {}
 
         /**
-         * (PHP 5 &gt;= 5.1.2)<br/>
+         * @since 5.1.2
          * Tells if the object references a regular file
          * @link http://php.net/manual/en/splfileinfo.isfile.php
          * @return bool true if the file exists and is a regular file (not a link), false otherwise.
@@ -168,7 +168,7 @@ class SplFileInfo  {
         public function isFile () {}
 
         /**
-         * (PHP 5 &gt;= 5.1.2)<br/>
+         * @since 5.1.2
          * Tells if the file is a directory
          * @link http://php.net/manual/en/splfileinfo.isdir.php
          * @return bool true if a directory, false otherwise.
@@ -176,7 +176,7 @@ class SplFileInfo  {
         public function isDir () {}
 
         /**
-         * (PHP 5 &gt;= 5.1.2)<br/>
+         * @since 5.1.2
          * Tells if the file is a link
          * @link http://php.net/manual/en/splfileinfo.islink.php
          * @return bool true if the file is a link, false otherwise.
@@ -184,7 +184,7 @@ class SplFileInfo  {
         public function isLink () {}
 
         /**
-         * (PHP 5 &gt;= 5.2.2)<br/>
+         * @since 5.2.2
          * Gets the target of a link
          * @link http://php.net/manual/en/splfileinfo.getlinktarget.php
          * @return string the target of the filesystem link.
@@ -192,7 +192,7 @@ class SplFileInfo  {
         public function getLinkTarget () {}
 
         /**
-         * (PHP 5 &gt;= 5.2.2)<br/>
+         * @since 5.2.2
          * Gets absolute path to file
          * @link http://php.net/manual/en/splfileinfo.getrealpath.php
          * @return string the path to the file.
@@ -200,7 +200,7 @@ class SplFileInfo  {
         public function getRealPath () {}
 
         /**
-         * (PHP 5 &gt;= 5.1.2)<br/>
+         * @since 5.1.2
          * Gets an SplFileInfo object for the file
          * @link http://php.net/manual/en/splfileinfo.getfileinfo.php
          * @param string $class_name [optional] <p>
@@ -211,7 +211,7 @@ class SplFileInfo  {
         public function getFileInfo ($class_name = null) {}
 
         /**
-         * (PHP 5 &gt;= 5.1.2)<br/>
+         * @since 5.1.2
          * Gets an SplFileInfo object for the path
          * @link http://php.net/manual/en/splfileinfo.getpathinfo.php
          * @param string $class_name [optional] <p>
@@ -222,7 +222,7 @@ class SplFileInfo  {
         public function getPathInfo ($class_name = null) {}
 
         /**
-         * (PHP 5 &gt;= 5.1.2)<br/>
+         * @since 5.1.2
          * Gets an SplFileObject object for the file
          * @link http://php.net/manual/en/splfileinfo.openfile.php
          * @param string $open_mode [optional] <p>
@@ -241,7 +241,7 @@ class SplFileInfo  {
 	public function openFile ($open_mode = 'r', $use_include_path = false, $context = null) {}
 
         /**
-         * (PHP 5 &gt;= 5.1.2)<br/>
+         * @since 5.1.2
 	 * Sets the class name used with <b>SplFileInfo::openFile</b>
          * @link http://php.net/manual/en/splfileinfo.setfileclass.php
          * @param string $class_name [optional] <p>
@@ -252,7 +252,7 @@ class SplFileInfo  {
         public function setFileClass ($class_name = null) {}
 
         /**
-         * (PHP 5 &gt;= 5.1.2)<br/>
+         * @since 5.1.2
          * Sets the class used with getFileInfo and getPathInfo
          * @link http://php.net/manual/en/splfileinfo.setinfoclass.php
          * @param string $class_name [optional] <p>
@@ -263,7 +263,7 @@ class SplFileInfo  {
         public function setInfoClass ($class_name = null) {}
 
         /**
-         * (PHP 5 &gt;= 5.1.2)<br/>
+         * @since 5.1.2
          * Returns the path to the file as a string
          * @link http://php.net/manual/en/splfileinfo.tostring.php
          * @return string the path to the file.
@@ -280,7 +280,7 @@ class SplFileInfo  {
 class DirectoryIterator extends SplFileInfo implements Iterator, Traversable, SeekableIterator {
 
         /**
-         * (PHP 5)<br/>
+         * @since 5.0
          * Constructs a new directory iterator from a path
          * @link http://php.net/manual/en/directoryiterator.construct.php
          * @param $path
@@ -289,7 +289,7 @@ class DirectoryIterator extends SplFileInfo implements Iterator, Traversable, Se
 
 
         /**
-	 * (PHP 5)<br/>
+	 * @since 5.0
          * Determine if current DirectoryIterator item is '.' or '..'
          * @link http://php.net/manual/en/directoryiterator.isdot.php
          * @return bool true if the entry is . or ..,
@@ -298,7 +298,7 @@ class DirectoryIterator extends SplFileInfo implements Iterator, Traversable, Se
         public function isDot () {}
 
         /**
-         * (PHP 5)<br/>
+         * @since 5.0
          * Rewind the DirectoryIterator back to the start
          * @link http://php.net/manual/en/directoryiterator.rewind.php
          * @return void 
@@ -306,7 +306,7 @@ class DirectoryIterator extends SplFileInfo implements Iterator, Traversable, Se
         public function rewind () {}
 
         /**
-         * (PHP 5)<br/>
+         * @since 5.0
          * Check whether current DirectoryIterator position is a valid file
          * @link http://php.net/manual/en/directoryiterator.valid.php
          * @return bool true if the position is valid, otherwise false
@@ -314,7 +314,7 @@ class DirectoryIterator extends SplFileInfo implements Iterator, Traversable, Se
         public function valid () {}
 
         /**
-         * (PHP 5)<br/>
+         * @since 5.0
          * Return the key for the current DirectoryIterator item
          * @link http://php.net/manual/en/directoryiterator.key.php
 	 * @return string The key for the current <b>DirectoryIterator</b> item.
@@ -322,7 +322,7 @@ class DirectoryIterator extends SplFileInfo implements Iterator, Traversable, Se
         public function key () {}
 
         /**
-         * (PHP 5)<br/>
+         * @since 5.0
          * Return the current DirectoryIterator item.
          * @link http://php.net/manual/en/directoryiterator.current.php
 	 * @return DirectoryIterator The current <b>DirectoryIterator</b> item.
@@ -330,7 +330,7 @@ class DirectoryIterator extends SplFileInfo implements Iterator, Traversable, Se
         public function current () {}
 
         /**
-         * (PHP 5)<br/>
+         * @since 5.0
          * Move forward to next DirectoryIterator item
          * @link http://php.net/manual/en/directoryiterator.next.php
          * @return void 
@@ -338,7 +338,7 @@ class DirectoryIterator extends SplFileInfo implements Iterator, Traversable, Se
         public function next () {}
 
         /**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
          * Seek to a DirectoryIterator item
          * @link http://php.net/manual/en/directoryiterator.seek.php
          * @param int $position <p>
@@ -367,7 +367,7 @@ class FilesystemIterator extends DirectoryIterator implements SeekableIterator, 
         const UNIX_PATHS = 8192;
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Constructs a new filesystem iterator
          * @link http://php.net/manual/en/filesystemiterator.construct.php
          * @param $path
@@ -376,7 +376,7 @@ class FilesystemIterator extends DirectoryIterator implements SeekableIterator, 
         public function __construct ($path, $flags) {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Rewinds back to the beginning
          * @link http://php.net/manual/en/filesystemiterator.rewind.php
          * @return void 
@@ -384,7 +384,7 @@ class FilesystemIterator extends DirectoryIterator implements SeekableIterator, 
         public function rewind () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Move to the next file
          * @link http://php.net/manual/en/filesystemiterator.next.php
          * @return void 
@@ -392,7 +392,7 @@ class FilesystemIterator extends DirectoryIterator implements SeekableIterator, 
         public function next () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Retrieve the key for the current file
          * @link http://php.net/manual/en/filesystemiterator.key.php
          * @return string the pathname or filename depending on the set flags.
@@ -401,7 +401,7 @@ class FilesystemIterator extends DirectoryIterator implements SeekableIterator, 
         public function key () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * The current file
          * @link http://php.net/manual/en/filesystemiterator.current.php
          * @return mixed The filename, file information, or $this depending on the set flags.
@@ -410,7 +410,7 @@ class FilesystemIterator extends DirectoryIterator implements SeekableIterator, 
         public function current () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Get the handling flags
          * @link http://php.net/manual/en/filesystemiterator.getflags.php
          * @return int The integer value of the set flags.
@@ -418,7 +418,7 @@ class FilesystemIterator extends DirectoryIterator implements SeekableIterator, 
         public function getFlags () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Sets handling flags
          * @link http://php.net/manual/en/filesystemiterator.setflags.php
          * @param int $flags [optional] <p>
@@ -439,7 +439,7 @@ class RecursiveDirectoryIterator extends FilesystemIterator implements Iterator,
 
 
         /**
-         * (PHP 5 &gt;= 5.1.2)<br/>
+         * @since 5.1.2
          * Constructs a RecursiveDirectoryIterator
          * @link http://php.net/manual/en/recursivedirectoryiterator.construct.php
          * @param $path
@@ -448,7 +448,7 @@ class RecursiveDirectoryIterator extends FilesystemIterator implements Iterator,
         public function __construct ($path, $flags) {}
 
         /**
-         * (PHP 5)<br/>
+         * @since 5.0
          * Returns whether current entry is a directory and not '.' or '..'
          * @link http://php.net/manual/en/recursivedirectoryiterator.haschildren.php
          * @param bool $allow_links [optional] <p>
@@ -458,7 +458,7 @@ class RecursiveDirectoryIterator extends FilesystemIterator implements Iterator,
         public function hasChildren ($allow_links = null) {}
 
         /**
-         * (PHP 5 &gt;= 5.1.0)<br/>
+         * @since 5.1.0
          * Returns an iterator for the current entry if it is a directory
          * @link http://php.net/manual/en/recursivedirectoryiterator.getchildren.php
          * @return object An iterator for the current entry, if it is a directory.
@@ -466,7 +466,7 @@ class RecursiveDirectoryIterator extends FilesystemIterator implements Iterator,
         public function getChildren () {}
 
         /**
-         * (PHP 5 &gt;= 5.1.0)<br/>
+         * @since 5.1.0
          * Get sub path
          * @link http://php.net/manual/en/recursivedirectoryiterator.getsubpath.php
          * @return string The sub path (sub directory).
@@ -474,7 +474,7 @@ class RecursiveDirectoryIterator extends FilesystemIterator implements Iterator,
         public function getSubPath () {}
 
         /**
-         * (PHP 5 &gt;= 5.1.0)<br/>
+         * @since 5.1.0
          * Get sub path and name
          * @link http://php.net/manual/en/recursivedirectoryiterator.getsubpathname.php
          * @return string The sub path (sub directory) and filename.
@@ -482,7 +482,7 @@ class RecursiveDirectoryIterator extends FilesystemIterator implements Iterator,
         public function getSubPathname () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Rewinds back to the beginning
          * @link http://php.net/manual/en/filesystemiterator.rewind.php
          * @return void 
@@ -490,7 +490,7 @@ class RecursiveDirectoryIterator extends FilesystemIterator implements Iterator,
         public function rewind () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Move to the next file
          * @link http://php.net/manual/en/filesystemiterator.next.php
          * @return void 
@@ -498,7 +498,7 @@ class RecursiveDirectoryIterator extends FilesystemIterator implements Iterator,
         public function next () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Retrieve the key for the current file
          * @link http://php.net/manual/en/filesystemiterator.key.php
          * @return string the pathname or filename depending on the set flags.
@@ -507,7 +507,7 @@ class RecursiveDirectoryIterator extends FilesystemIterator implements Iterator,
         public function key () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * The current file
          * @link http://php.net/manual/en/filesystemiterator.current.php
          * @return mixed The filename, file information, or $this depending on the set flags.
@@ -525,7 +525,7 @@ class RecursiveDirectoryIterator extends FilesystemIterator implements Iterator,
 class GlobIterator extends FilesystemIterator implements Iterator, Traversable, SeekableIterator, Countable {
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Construct a directory using glob
          * @link http://php.net/manual/en/globiterator.construct.php
          * @param $path
@@ -534,7 +534,7 @@ class GlobIterator extends FilesystemIterator implements Iterator, Traversable, 
         public function __construct ($path, $flags) {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Get the number of directories and files
          * @link http://php.net/manual/en/globiterator.count.php
 	 * @return int The number of returned directories and files, as an
@@ -555,7 +555,7 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, Traversabl
 
 
         /**
-         * (PHP 5 &gt;= 5.1.0)<br/>
+         * @since 5.1.0
          * Construct a new file object.
          * @link http://php.net/manual/en/splfileobject.construct.php
          * @param $file_name
@@ -566,7 +566,7 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, Traversabl
         public function __construct ($file_name, $open_mode, $use_include_path, $context) {}
 
         /**
-         * (PHP 5 &gt;= 5.1.0)<br/>
+         * @since 5.1.0
          * Rewind the file to the first line
          * @link http://php.net/manual/en/splfileobject.rewind.php
          * @return void 
@@ -574,7 +574,7 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, Traversabl
         public function rewind () {}
 
         /**
-         * (PHP 5 &gt;= 5.1.0)<br/>
+         * @since 5.1.0
          * Reached end of file
          * @link http://php.net/manual/en/splfileobject.eof.php
 	 * @return bool true if file is at EOF, false otherwise.
@@ -582,7 +582,7 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, Traversabl
         public function eof () {}
 
         /**
-         * (PHP 5 &gt;= 5.1.0)<br/>
+         * @since 5.1.0
          * Not at EOF
          * @link http://php.net/manual/en/splfileobject.valid.php
          * @return bool true if not reached EOF, false otherwise.
@@ -590,7 +590,7 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, Traversabl
         public function valid () {}
 
         /**
-         * (PHP 5 &gt;= 5.1.0)<br/>
+         * @since 5.1.0
          * Gets line from file
          * @link http://php.net/manual/en/splfileobject.fgets.php
          * @return string a string containing the next line from the file, or false on error.
@@ -598,7 +598,7 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, Traversabl
         public function fgets () {}
 
         /**
-         * (PHP 5 &gt;= 5.5.11)<br/>
+         * @since 5.5.11
          * Read from file
          * @link http://php.net/manual/en/splfileobject.fread.php
          * @param int $length <p>
@@ -609,7 +609,7 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, Traversabl
         public function fread ($length) {}
 
         /**
-         * (PHP 5 &gt;= 5.1.0)<br/>
+         * @since 5.1.0
          * Gets line from file and parse as CSV fields
          * @link http://php.net/manual/en/splfileobject.fgetcsv.php
          * @param string $delimiter [optional] <p>
@@ -631,7 +631,7 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, Traversabl
 	public function fgetcsv ($delimiter = ",", $enclosure = "\"", $escape = "\\") {}
 
 	/**
-         * PHP >= 5.4.0<br/>
+         * @since 5.4.0
          * Write a field array as a CSV line
          * @link http://php.net/manual/en/splfileobject.fputcsv.php
          * @param array $fields <p>
@@ -648,7 +648,7 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, Traversabl
 	public function fputcsv (array $fields, $delimiter = ',' , $enclosure = '"') {}
 
         /**
-         * (PHP 5 &gt;= 5.2.0)<br/>
+         * @since 5.2.0
          * Set the delimiter and enclosure character for CSV
          * @link http://php.net/manual/en/splfileobject.setcsvcontrol.php
          * @param string $delimiter [optional] <p>
@@ -665,7 +665,7 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, Traversabl
 	public function setCsvControl ($delimiter = ",", $enclosure = "\"", $escape = "\\") {}
 
         /**
-         * (PHP 5 &gt;= 5.2.0)<br/>
+         * @since 5.2.0
          * Get the delimiter and enclosure character for CSV
          * @link http://php.net/manual/en/splfileobject.getcsvcontrol.php
          * @return array an indexed array containing the delimiter and enclosure character.
@@ -673,7 +673,7 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, Traversabl
         public function getCsvControl () {}
 
         /**
-         * (PHP 5 &gt;= 5.1.0)<br/>
+         * @since 5.1.0
          * Portable file locking
          * @link http://php.net/manual/en/splfileobject.flock.php
          * @param int $operation <p>
@@ -687,7 +687,7 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, Traversabl
         public function flock ($operation, &$wouldblock = null) {}
 
         /**
-         * (PHP 5 &gt;= 5.1.0)<br/>
+         * @since 5.1.0
          * Flushes the output to the file
          * @link http://php.net/manual/en/splfileobject.fflush.php
 	 * @return bool true on success or false on failure.
@@ -695,7 +695,7 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, Traversabl
         public function fflush () {}
 
         /**
-         * (PHP 5 &gt;= 5.1.0)<br/>
+         * @since 5.1.0
          * Return current file position
          * @link http://php.net/manual/en/splfileobject.ftell.php
          * @return int the position of the file pointer as an integer, or false on error.
@@ -703,7 +703,7 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, Traversabl
         public function ftell () {}
 
         /**
-         * (PHP 5 &gt;= 5.1.0)<br/>
+         * @since 5.1.0
          * Seek to a position
          * @link http://php.net/manual/en/splfileobject.fseek.php
          * @param int $offset <p>
@@ -725,7 +725,7 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, Traversabl
 	public function fseek ($offset, $whence = SEEK_SET) {}
 
         /**
-         * (PHP 5 &gt;= 5.1.0)<br/>
+         * @since 5.1.0
          * Gets character from file
          * @link http://php.net/manual/en/splfileobject.fgetc.php
          * @return string a string containing a single character read from the file or false on EOF.
@@ -733,7 +733,7 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, Traversabl
         public function fgetc () {}
 
         /**
-         * (PHP 5 &gt;= 5.1.0)<br/>
+         * @since 5.1.0
          * Output all remaining data on a file pointer
          * @link http://php.net/manual/en/splfileobject.fpassthru.php
 	 * @return int the number of characters read from <i>handle</i>
@@ -742,7 +742,7 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, Traversabl
         public function fpassthru () {}
 
         /**
-         * (PHP 5 &gt;= 5.1.0)<br/>
+         * @since 5.1.0
          * Gets line from file and strip HTML tags
          * @link http://php.net/manual/en/splfileobject.fgetss.php
          * @param string $allowable_tags [optional] <p>
@@ -755,7 +755,7 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, Traversabl
         public function fgetss ($allowable_tags = null) {}
 
         /**
-         * (PHP 5 &gt;= 5.1.0)<br/>
+         * @since 5.1.0
          * Parses input from file according to a format
          * @link http://php.net/manual/en/splfileobject.fscanf.php
          * @param string $format <p>
@@ -772,7 +772,7 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, Traversabl
         public function fscanf ($format, &$_ = null) {}
 
         /**
-         * (PHP 5 &gt;= 5.1.0)<br/>
+         * @since 5.1.0
          * Write to file
          * @link http://php.net/manual/en/splfileobject.fwrite.php
          * @param string $str <p>
@@ -789,7 +789,7 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, Traversabl
         public function fwrite ($str, $length = null) {}
 
         /**
-         * (PHP 5 &gt;= 5.1.0)<br/>
+         * @since 5.1.0
          * Gets information about the file
          * @link http://php.net/manual/en/splfileobject.fstat.php
          * @return array an array with the statistics of the file; the format of the array
@@ -798,7 +798,7 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, Traversabl
         public function fstat () {}
 
         /**
-         * (PHP 5 &gt;= 5.1.0)<br/>
+         * @since 5.1.0
          * Truncates the file to a given length
          * @link http://php.net/manual/en/splfileobject.ftruncate.php
          * @param int $size <p>
@@ -815,7 +815,7 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, Traversabl
         public function ftruncate ($size) {}
 
         /**
-         * (PHP 5 &gt;= 5.1.0)<br/>
+         * @since 5.1.0
          * Retrieve current line of file
          * @link http://php.net/manual/en/splfileobject.current.php
 	 * @return string|array Retrieves the current line of the file. If the <b>SplFileObject::READ_CSV</b> flag is set, this method returns an array containing the current line parsed as CSV data.
@@ -823,7 +823,7 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, Traversabl
         public function current () {}
 
         /**
-         * (PHP 5 &gt;= 5.1.0)<br/>
+         * @since 5.1.0
          * Get line number
          * @link http://php.net/manual/en/splfileobject.key.php
          * @return int the current line number.
@@ -831,7 +831,7 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, Traversabl
         public function key () {}
 
         /**
-         * (PHP 5 &gt;= 5.1.0)<br/>
+         * @since 5.1.0
          * Read next line
          * @link http://php.net/manual/en/splfileobject.next.php
          * @return void 
@@ -839,7 +839,7 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, Traversabl
         public function next () {}
 
         /**
-         * (PHP 5 &gt;= 5.1.0)<br/>
+         * @since 5.1.0
          * Sets flags for the SplFileObject
          * @link http://php.net/manual/en/splfileobject.setflags.php
          * @param int $flags <p>
@@ -852,7 +852,7 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, Traversabl
         public function setFlags ($flags) {}
 
         /**
-         * (PHP 5 &gt;= 5.1.0)<br/>
+         * @since 5.1.0
          * Gets flags for the SplFileObject
          * @link http://php.net/manual/en/splfileobject.getflags.php
          * @return int an integer representing the flags.
@@ -860,7 +860,7 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, Traversabl
         public function getFlags () {}
 
         /**
-         * (PHP 5 &gt;= 5.1.0)<br/>
+         * @since 5.1.0
          * Set maximum line length
          * @link http://php.net/manual/en/splfileobject.setmaxlinelen.php
          * @param int $max_len <p>
@@ -871,7 +871,7 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, Traversabl
         public function setMaxLineLen ($max_len) {}
 
         /**
-         * (PHP 5 &gt;= 5.1.0)<br/>
+         * @since 5.1.0
          * Get maximum line length
          * @link http://php.net/manual/en/splfileobject.getmaxlinelen.php
          * @return int the maximum line length if one has been set with
@@ -880,7 +880,7 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, Traversabl
         public function getMaxLineLen () {}
 
         /**
-         * (PHP 5 &gt;= 5.1.2)<br/>
+         * @since 5.1.2
          * SplFileObject does not have children
          * @link http://php.net/manual/en/splfileobject.haschildren.php
          * @return bool false
@@ -888,7 +888,7 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, Traversabl
         public function hasChildren () {}
 
         /**
-         * (PHP 5 &gt;= 5.1.0)<br/>
+         * @since 5.1.0
          * No purpose
          * @link http://php.net/manual/en/splfileobject.getchildren.php
          * @return null An SplFileObject does not have children so this method returns NULL.
@@ -896,7 +896,7 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, Traversabl
         public function getChildren () {}
 
         /**
-         * (PHP 5 &gt;= 5.1.0)<br/>
+         * @since 5.1.0
          * Seek to specified line
          * @link http://php.net/manual/en/splfileobject.seek.php
          * @param int $line_pos <p>
@@ -907,7 +907,7 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, Traversabl
         public function seek ($line_pos) {}
 
         /**
-         * (PHP 5 &gt;= 5.1.2)<br/>
+         * @since 5.1.2
 	     * Alias of <b>SplFileObject::fgets</b>
          * @link http://php.net/manual/en/splfileobject.getcurrentline.php
          * @return string Returns a string containing the next line from the file, or FALSE on error.
@@ -915,7 +915,7 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, Traversabl
         public function getCurrentLine () {}
 
         /**
-         * (PHP 5 &gt;= 5.1.0)<br/>
+         * @since 5.1.0
 	 * Alias of <b>SplFileObject::current</b>
          * @link http://php.net/manual/en/splfileobject.tostring.php
          */
@@ -931,7 +931,7 @@ class SplTempFileObject extends SplFileObject implements SeekableIterator, Itera
 
 
         /**
-         * (PHP 5 &gt;= 5.1.2)<br/>
+         * @since 5.1.2
          * Construct a new temporary file object
          * @link http://php.net/manual/en/spltempfileobject.construct.php
          * @param $max_memory [optional]
@@ -951,7 +951,7 @@ class SplDoublyLinkedList implements Iterator, Traversable, Countable, ArrayAcce
 
 
         /**
-         * (PHP 5 &gt;= 5.5.0)<br/>
+         * @since 5.5.0
          * Add/insert a new value at the specified index
          * @param mixed $index The index where the new value is to be inserted.
          * @param mixed $newval The new value for the index.
@@ -961,7 +961,7 @@ class SplDoublyLinkedList implements Iterator, Traversable, Countable, ArrayAcce
         public function add($index, $newval) {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Pops a node from the end of the doubly linked list
          * @link http://php.net/manual/en/spldoublylinkedlist.pop.php
          * @return mixed The value of the popped node.
@@ -969,7 +969,7 @@ class SplDoublyLinkedList implements Iterator, Traversable, Countable, ArrayAcce
         public function pop () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Shifts a node from the beginning of the doubly linked list
          * @link http://php.net/manual/en/spldoublylinkedlist.shift.php
          * @return mixed The value of the shifted node.
@@ -977,7 +977,7 @@ class SplDoublyLinkedList implements Iterator, Traversable, Countable, ArrayAcce
         public function shift () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Pushes an element at the end of the doubly linked list
          * @link http://php.net/manual/en/spldoublylinkedlist.push.php
          * @param mixed $value <p>
@@ -988,7 +988,7 @@ class SplDoublyLinkedList implements Iterator, Traversable, Countable, ArrayAcce
         public function push ($value) {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Prepends the doubly linked list with an element
          * @link http://php.net/manual/en/spldoublylinkedlist.unshift.php
          * @param mixed $value <p>
@@ -999,7 +999,7 @@ class SplDoublyLinkedList implements Iterator, Traversable, Countable, ArrayAcce
         public function unshift ($value) {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Peeks at the node from the end of the doubly linked list
          * @link http://php.net/manual/en/spldoublylinkedlist.top.php
          * @return mixed The value of the last node.
@@ -1007,7 +1007,7 @@ class SplDoublyLinkedList implements Iterator, Traversable, Countable, ArrayAcce
         public function top () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Peeks at the node from the beginning of the doubly linked list
          * @link http://php.net/manual/en/spldoublylinkedlist.bottom.php
          * @return mixed The value of the first node.
@@ -1015,7 +1015,7 @@ class SplDoublyLinkedList implements Iterator, Traversable, Countable, ArrayAcce
         public function bottom () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Counts the number of elements in the doubly linked list.
          * @link http://php.net/manual/en/spldoublylinkedlist.count.php
          * @return int the number of elements in the doubly linked list.
@@ -1023,7 +1023,7 @@ class SplDoublyLinkedList implements Iterator, Traversable, Countable, ArrayAcce
         public function count () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Checks whether the doubly linked list is empty.
          * @link http://php.net/manual/en/spldoublylinkedlist.isempty.php
          * @return bool whether the doubly linked list is empty.
@@ -1031,7 +1031,7 @@ class SplDoublyLinkedList implements Iterator, Traversable, Countable, ArrayAcce
         public function isEmpty () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Sets the mode of iteration
          * @link http://php.net/manual/en/spldoublylinkedlist.setiteratormode.php
          * @param int $mode <p>
@@ -1044,7 +1044,7 @@ class SplDoublyLinkedList implements Iterator, Traversable, Countable, ArrayAcce
         public function setIteratorMode ($mode) {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Returns the mode of iteration
          * @link http://php.net/manual/en/spldoublylinkedlist.getiteratormode.php
          * @return int the different modes and flags that affect the iteration.
@@ -1052,7 +1052,7 @@ class SplDoublyLinkedList implements Iterator, Traversable, Countable, ArrayAcce
         public function getIteratorMode () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Returns whether the requested $index exists
          * @link http://php.net/manual/en/spldoublylinkedlist.offsetexists.php
          * @param mixed $index <p>
@@ -1063,7 +1063,7 @@ class SplDoublyLinkedList implements Iterator, Traversable, Countable, ArrayAcce
         public function offsetExists ($index) {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Returns the value at the specified $index
          * @link http://php.net/manual/en/spldoublylinkedlist.offsetget.php
          * @param mixed $index <p>
@@ -1074,7 +1074,7 @@ class SplDoublyLinkedList implements Iterator, Traversable, Countable, ArrayAcce
         public function offsetGet ($index) {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Sets the value at the specified $index to $newval
          * @link http://php.net/manual/en/spldoublylinkedlist.offsetset.php
          * @param mixed $index <p>
@@ -1088,7 +1088,7 @@ class SplDoublyLinkedList implements Iterator, Traversable, Countable, ArrayAcce
         public function offsetSet ($index, $newval) {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Unsets the value at the specified $index
          * @link http://php.net/manual/en/spldoublylinkedlist.offsetunset.php
          * @param mixed $index <p>
@@ -1099,7 +1099,7 @@ class SplDoublyLinkedList implements Iterator, Traversable, Countable, ArrayAcce
         public function offsetUnset ($index) {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Rewind iterator back to the start
          * @link http://php.net/manual/en/spldoublylinkedlist.rewind.php
          * @return void 
@@ -1107,7 +1107,7 @@ class SplDoublyLinkedList implements Iterator, Traversable, Countable, ArrayAcce
         public function rewind () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Return current array entry
          * @link http://php.net/manual/en/spldoublylinkedlist.current.php
          * @return mixed The current node value.
@@ -1115,7 +1115,7 @@ class SplDoublyLinkedList implements Iterator, Traversable, Countable, ArrayAcce
         public function current () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Return current node index
          * @link http://php.net/manual/en/spldoublylinkedlist.key.php
          * @return mixed The current node index.
@@ -1123,7 +1123,7 @@ class SplDoublyLinkedList implements Iterator, Traversable, Countable, ArrayAcce
         public function key () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Move to next entry
          * @link http://php.net/manual/en/spldoublylinkedlist.next.php
          * @return void 
@@ -1131,7 +1131,7 @@ class SplDoublyLinkedList implements Iterator, Traversable, Countable, ArrayAcce
         public function next () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Move to previous entry
          * @link http://php.net/manual/en/spldoublylinkedlist.prev.php
          * @return void 
@@ -1139,7 +1139,7 @@ class SplDoublyLinkedList implements Iterator, Traversable, Countable, ArrayAcce
         public function prev () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Check whether the doubly linked list contains more nodes
          * @link http://php.net/manual/en/spldoublylinkedlist.valid.php
          * @return bool true if the doubly linked list contains any more nodes, false otherwise.
@@ -1147,7 +1147,7 @@ class SplDoublyLinkedList implements Iterator, Traversable, Countable, ArrayAcce
         public function valid () {}
 
         /**
-         * PHP >= 5.4.0<br/>
+         * @since 5.4.0
          * Unserializes the storage
          * @link http://php.net/manual/ru/spldoublylinkedlist.serialize.php
          * @param string $serialized The serialized string.
@@ -1156,7 +1156,7 @@ class SplDoublyLinkedList implements Iterator, Traversable, Countable, ArrayAcce
          public function unserialize($serialized) {}
 
          /**
-         * PHP >= 5.4.0<br/>
+         * @since 5.4.0
          * Serializes the storage
          * @link http://php.net/manual/ru/spldoublylinkedlist.unserialize.php
          * @return string The serialized string.
@@ -1173,7 +1173,7 @@ class SplQueue extends SplDoublyLinkedList implements ArrayAccess, Countable, Tr
 
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Adds an element to the queue.
          * @link http://php.net/manual/en/splqueue.enqueue.php
          * @param mixed $value <p>
@@ -1184,7 +1184,7 @@ class SplQueue extends SplDoublyLinkedList implements ArrayAccess, Countable, Tr
         public function enqueue ($value) {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Dequeues a node from the queue
          * @link http://php.net/manual/en/splqueue.dequeue.php
          * @return mixed The value of the dequeued node.
@@ -1192,7 +1192,7 @@ class SplQueue extends SplDoublyLinkedList implements ArrayAccess, Countable, Tr
         public function dequeue () {}
 
     /**
-     * (PHP 5 &gt;= 5.3.0)<br/>
+     * @since 5.3.0
      * Sets the mode of iteration
      * @link http://php.net/manual/en/spldoublylinkedlist.setiteratormode.php
      * @param int $mode <p>
@@ -1212,7 +1212,7 @@ class SplQueue extends SplDoublyLinkedList implements ArrayAccess, Countable, Tr
 class SplStack extends SplDoublyLinkedList implements ArrayAccess, Countable, Traversable, Iterator {
 
     /**
-     * (PHP 5 &gt;= 5.3.0)<br/>
+     * @since 5.3.0
      * Sets the mode of iteration
      * @link http://php.net/manual/en/spldoublylinkedlist.setiteratormode.php
      * @param int $mode <p>
@@ -1232,7 +1232,7 @@ class SplStack extends SplDoublyLinkedList implements ArrayAccess, Countable, Tr
 abstract class SplHeap implements Iterator, Traversable, Countable {
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Extracts a node from top of the heap and sift up.
          * @link http://php.net/manual/en/splheap.extract.php
          * @return mixed The value of the extracted node.
@@ -1240,7 +1240,7 @@ abstract class SplHeap implements Iterator, Traversable, Countable {
         public function extract () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Inserts an element in the heap by sifting it up.
          * @link http://php.net/manual/en/splheap.insert.php
          * @param mixed $value <p>
@@ -1251,7 +1251,7 @@ abstract class SplHeap implements Iterator, Traversable, Countable {
         public function insert ($value) {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
 	 * Peeks at the node from the top of the heap
          * @link http://php.net/manual/en/splheap.top.php
          * @return mixed The value of the node on the top.
@@ -1259,7 +1259,7 @@ abstract class SplHeap implements Iterator, Traversable, Countable {
         public function top () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Counts the number of elements in the heap.
          * @link http://php.net/manual/en/splheap.count.php
          * @return int the number of elements in the heap.
@@ -1267,7 +1267,7 @@ abstract class SplHeap implements Iterator, Traversable, Countable {
         public function count () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Checks whether the heap is empty.
          * @link http://php.net/manual/en/splheap.isempty.php
          * @return bool whether the heap is empty.
@@ -1275,7 +1275,7 @@ abstract class SplHeap implements Iterator, Traversable, Countable {
         public function isEmpty () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Rewind iterator back to the start (no-op)
          * @link http://php.net/manual/en/splheap.rewind.php
          * @return void 
@@ -1283,7 +1283,7 @@ abstract class SplHeap implements Iterator, Traversable, Countable {
         public function rewind () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Return current node pointed by the iterator
          * @link http://php.net/manual/en/splheap.current.php
          * @return mixed The current node value.
@@ -1291,7 +1291,7 @@ abstract class SplHeap implements Iterator, Traversable, Countable {
         public function current () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Return current node index
          * @link http://php.net/manual/en/splheap.key.php
          * @return mixed The current node index.
@@ -1299,7 +1299,7 @@ abstract class SplHeap implements Iterator, Traversable, Countable {
         public function key () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Move to the next node
          * @link http://php.net/manual/en/splheap.next.php
          * @return void 
@@ -1307,7 +1307,7 @@ abstract class SplHeap implements Iterator, Traversable, Countable {
         public function next () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Check whether the heap contains more nodes
          * @link http://php.net/manual/en/splheap.valid.php
          * @return bool true if the heap contains any more nodes, false otherwise.
@@ -1315,7 +1315,7 @@ abstract class SplHeap implements Iterator, Traversable, Countable {
         public function valid () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Recover from the corrupted state and allow further actions on the heap.
          * @link http://php.net/manual/en/splheap.recoverfromcorruption.php
          * @return void 
@@ -1323,7 +1323,7 @@ abstract class SplHeap implements Iterator, Traversable, Countable {
         public function recoverFromCorruption () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Compare elements in order to place them correctly in the heap while sifting up.
          * @link http://php.net/manual/en/splheap.compare.php
          * @param mixed $value1 <p>
@@ -1348,7 +1348,7 @@ abstract class SplHeap implements Iterator, Traversable, Countable {
 class SplMinHeap extends SplHeap implements Countable, Traversable, Iterator {
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Compare elements in order to place them correctly in the heap while sifting up.
          * @link http://php.net/manual/en/splminheap.compare.php
          * @param mixed $value1 <p>
@@ -1365,7 +1365,7 @@ class SplMinHeap extends SplHeap implements Countable, Traversable, Iterator {
         protected function compare ($value1, $value2) {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Extracts a node from top of the heap and sift up.
          * @link http://php.net/manual/en/splheap.extract.php
          * @return mixed The value of the extracted node.
@@ -1373,7 +1373,7 @@ class SplMinHeap extends SplHeap implements Countable, Traversable, Iterator {
         public function extract () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Inserts an element in the heap by sifting it up.
          * @link http://php.net/manual/en/splheap.insert.php
          * @param mixed $value <p>
@@ -1384,7 +1384,7 @@ class SplMinHeap extends SplHeap implements Countable, Traversable, Iterator {
         public function insert ($value) {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
 	 * Peeks at the node from the top of the heap
          * @link http://php.net/manual/en/splheap.top.php
          * @return mixed The value of the node on the top.
@@ -1392,7 +1392,7 @@ class SplMinHeap extends SplHeap implements Countable, Traversable, Iterator {
         public function top () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Counts the number of elements in the heap.
          * @link http://php.net/manual/en/splheap.count.php
          * @return int the number of elements in the heap.
@@ -1400,7 +1400,7 @@ class SplMinHeap extends SplHeap implements Countable, Traversable, Iterator {
         public function count () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Checks whether the heap is empty.
          * @link http://php.net/manual/en/splheap.isempty.php
          * @return bool whether the heap is empty.
@@ -1408,7 +1408,7 @@ class SplMinHeap extends SplHeap implements Countable, Traversable, Iterator {
         public function isEmpty () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Rewind iterator back to the start (no-op)
          * @link http://php.net/manual/en/splheap.rewind.php
          * @return void 
@@ -1416,7 +1416,7 @@ class SplMinHeap extends SplHeap implements Countable, Traversable, Iterator {
         public function rewind () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Return current node pointed by the iterator
          * @link http://php.net/manual/en/splheap.current.php
          * @return mixed The current node value.
@@ -1424,7 +1424,7 @@ class SplMinHeap extends SplHeap implements Countable, Traversable, Iterator {
         public function current () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Return current node index
          * @link http://php.net/manual/en/splheap.key.php
          * @return mixed The current node index.
@@ -1432,7 +1432,7 @@ class SplMinHeap extends SplHeap implements Countable, Traversable, Iterator {
         public function key () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Move to the next node
          * @link http://php.net/manual/en/splheap.next.php
          * @return void 
@@ -1440,7 +1440,7 @@ class SplMinHeap extends SplHeap implements Countable, Traversable, Iterator {
         public function next () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Check whether the heap contains more nodes
          * @link http://php.net/manual/en/splheap.valid.php
          * @return bool true if the heap contains any more nodes, false otherwise.
@@ -1448,7 +1448,7 @@ class SplMinHeap extends SplHeap implements Countable, Traversable, Iterator {
         public function valid () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Recover from the corrupted state and allow further actions on the heap.
          * @link http://php.net/manual/en/splheap.recoverfromcorruption.php
          * @return void 
@@ -1464,7 +1464,7 @@ class SplMinHeap extends SplHeap implements Countable, Traversable, Iterator {
 class SplMaxHeap extends SplHeap implements Countable, Traversable, Iterator {
 
     /**
-     * (PHP 5 &gt;= 5.3.0)<br/>
+     * @since 5.3.0
      * Compare elements in order to place them correctly in the heap while sifting up.
      * @link http://php.net/manual/en/splmaxheap.compare.php
      * @param mixed $value1 <p>
@@ -1493,7 +1493,7 @@ class SplPriorityQueue implements Iterator, Traversable, Countable {
 
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Compare priorities in order to place elements correctly in the heap while sifting up.
          * @link http://php.net/manual/en/splpriorityqueue.compare.php
          * @param mixed $priority1 <p>
@@ -1510,7 +1510,7 @@ class SplPriorityQueue implements Iterator, Traversable, Countable {
         public function compare ($priority1, $priority2) {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Inserts an element in the queue by sifting it up.
          * @link http://php.net/manual/en/splpriorityqueue.insert.php
          * @param mixed $value <p>
@@ -1524,7 +1524,7 @@ class SplPriorityQueue implements Iterator, Traversable, Countable {
         public function insert ($value, $priority) {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Sets the mode of extraction
          * @link http://php.net/manual/en/splpriorityqueue.setextractflags.php
          * @param int $flags <p>
@@ -1538,7 +1538,7 @@ class SplPriorityQueue implements Iterator, Traversable, Countable {
         public function setExtractFlags ($flags) {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
 	 * Peeks at the node from the top of the queue
          * @link http://php.net/manual/en/splpriorityqueue.top.php
          * @return mixed The value or priority (or both) of the top node, depending on the extract flag.
@@ -1546,7 +1546,7 @@ class SplPriorityQueue implements Iterator, Traversable, Countable {
         public function top () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Extracts a node from top of the heap and sift up.
          * @link http://php.net/manual/en/splpriorityqueue.extract.php
          * @return mixed The value or priority (or both) of the extracted node, depending on the extract flag.
@@ -1554,7 +1554,7 @@ class SplPriorityQueue implements Iterator, Traversable, Countable {
         public function extract () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Counts the number of elements in the queue.
          * @link http://php.net/manual/en/splpriorityqueue.count.php
          * @return int the number of elements in the queue.
@@ -1562,7 +1562,7 @@ class SplPriorityQueue implements Iterator, Traversable, Countable {
         public function count () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Checks whether the queue is empty.
          * @link http://php.net/manual/en/splpriorityqueue.isempty.php
          * @return bool whether the queue is empty.
@@ -1570,7 +1570,7 @@ class SplPriorityQueue implements Iterator, Traversable, Countable {
         public function isEmpty () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Rewind iterator back to the start (no-op)
          * @link http://php.net/manual/en/splpriorityqueue.rewind.php
          * @return void 
@@ -1578,7 +1578,7 @@ class SplPriorityQueue implements Iterator, Traversable, Countable {
         public function rewind () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Return current node pointed by the iterator
          * @link http://php.net/manual/en/splpriorityqueue.current.php
          * @return mixed The value or priority (or both) of the current node, depending on the extract flag.
@@ -1586,7 +1586,7 @@ class SplPriorityQueue implements Iterator, Traversable, Countable {
         public function current () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Return current node index
          * @link http://php.net/manual/en/splpriorityqueue.key.php
          * @return mixed The current node index.
@@ -1594,7 +1594,7 @@ class SplPriorityQueue implements Iterator, Traversable, Countable {
         public function key () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Move to the next node
          * @link http://php.net/manual/en/splpriorityqueue.next.php
          * @return void 
@@ -1602,7 +1602,7 @@ class SplPriorityQueue implements Iterator, Traversable, Countable {
         public function next () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Check whether the queue contains more nodes
          * @link http://php.net/manual/en/splpriorityqueue.valid.php
          * @return bool true if the queue contains any more nodes, false otherwise.
@@ -1610,7 +1610,7 @@ class SplPriorityQueue implements Iterator, Traversable, Countable {
         public function valid () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Recover from the corrupted state and allow further actions on the queue.
          * @link http://php.net/manual/en/splpriorityqueue.recoverfromcorruption.php
          * @return void 
@@ -1630,7 +1630,7 @@ class SplPriorityQueue implements Iterator, Traversable, Countable {
 class SplFixedArray implements Iterator, Traversable, ArrayAccess, Countable {
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Constructs a new fixed array
          * @link http://php.net/manual/en/splfixedarray.construct.php
          * @param int $size [optional]
@@ -1638,7 +1638,7 @@ class SplFixedArray implements Iterator, Traversable, ArrayAccess, Countable {
         public function __construct ($size = 0) {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Returns the size of the array
          * @link http://php.net/manual/en/splfixedarray.count.php
          * @return int the size of the array.
@@ -1646,7 +1646,7 @@ class SplFixedArray implements Iterator, Traversable, ArrayAccess, Countable {
         public function count () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Returns a PHP array from the fixed array
          * @link http://php.net/manual/en/splfixedarray.toarray.php
          * @return array a PHP array, similar to the fixed array.
@@ -1654,7 +1654,7 @@ class SplFixedArray implements Iterator, Traversable, ArrayAccess, Countable {
         public function toArray () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
 	 * Import a PHP array in a <b>SplFixedArray</b> instance
          * @link http://php.net/manual/en/splfixedarray.fromarray.php
          * @param array $array <p>
@@ -1669,7 +1669,7 @@ class SplFixedArray implements Iterator, Traversable, ArrayAccess, Countable {
 	public static function fromArray (array $array, $save_indexes = true) {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Gets the size of the array
          * @link http://php.net/manual/en/splfixedarray.getsize.php
          * @return int the size of the array, as an integer.
@@ -1677,7 +1677,7 @@ class SplFixedArray implements Iterator, Traversable, ArrayAccess, Countable {
         public function getSize () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Change the size of an array
          * @link http://php.net/manual/en/splfixedarray.setsize.php
          * @param int $size <p>
@@ -1688,7 +1688,7 @@ class SplFixedArray implements Iterator, Traversable, ArrayAccess, Countable {
         public function setSize ($size) {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Returns whether the requested index exists
          * @link http://php.net/manual/en/splfixedarray.offsetexists.php
          * @param int $index <p>
@@ -1699,7 +1699,7 @@ class SplFixedArray implements Iterator, Traversable, ArrayAccess, Countable {
         public function offsetExists ($index) {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Returns the value at the specified index
          * @link http://php.net/manual/en/splfixedarray.offsetget.php
          * @param int $index <p>
@@ -1710,7 +1710,7 @@ class SplFixedArray implements Iterator, Traversable, ArrayAccess, Countable {
         public function offsetGet ($index) {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Sets a new value at a specified index
          * @link http://php.net/manual/en/splfixedarray.offsetset.php
          * @param int $index <p>
@@ -1724,7 +1724,7 @@ class SplFixedArray implements Iterator, Traversable, ArrayAccess, Countable {
         public function offsetSet ($index, $newval) {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Unsets the value at the specified $index
          * @link http://php.net/manual/en/splfixedarray.offsetunset.php
          * @param int $index <p>
@@ -1735,7 +1735,7 @@ class SplFixedArray implements Iterator, Traversable, ArrayAccess, Countable {
         public function offsetUnset ($index) {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Rewind iterator back to the start
          * @link http://php.net/manual/en/splfixedarray.rewind.php
          * @return void 
@@ -1743,7 +1743,7 @@ class SplFixedArray implements Iterator, Traversable, ArrayAccess, Countable {
         public function rewind () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Return current array entry
          * @link http://php.net/manual/en/splfixedarray.current.php
          * @return mixed The current element value.
@@ -1751,7 +1751,7 @@ class SplFixedArray implements Iterator, Traversable, ArrayAccess, Countable {
         public function current () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Return current array index
          * @link http://php.net/manual/en/splfixedarray.key.php
          * @return int The current array index.
@@ -1759,7 +1759,7 @@ class SplFixedArray implements Iterator, Traversable, ArrayAccess, Countable {
         public function key () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Move to next entry
          * @link http://php.net/manual/en/splfixedarray.next.php
          * @return void 
@@ -1767,7 +1767,7 @@ class SplFixedArray implements Iterator, Traversable, ArrayAccess, Countable {
         public function next () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Check whether the array contains more elements
          * @link http://php.net/manual/en/splfixedarray.valid.php
          * @return bool true if the array contains any more elements, false otherwise.
@@ -1784,7 +1784,7 @@ class SplFixedArray implements Iterator, Traversable, ArrayAccess, Countable {
 interface SplObserver  {
 
         /**
-         * (PHP 5 &gt;= 5.1.0)<br/>
+         * @since 5.1.0
          * Receive update from subject
          * @link http://php.net/manual/en/splobserver.update.php
          * @param SplSubject $subject <p>
@@ -1804,7 +1804,7 @@ interface SplObserver  {
 interface SplSubject  {
 
         /**
-         * (PHP 5 &gt;= 5.1.0)<br/>
+         * @since 5.1.0
          * Attach an SplObserver
          * @link http://php.net/manual/en/splsubject.attach.php
          * @param SplObserver $observer <p>
@@ -1815,7 +1815,7 @@ interface SplSubject  {
         public function attach (SplObserver $observer);
 
         /**
-         * (PHP 5 &gt;= 5.1.0)<br/>
+         * @since 5.1.0
          * Detach an observer
          * @link http://php.net/manual/en/splsubject.detach.php
          * @param SplObserver $observer <p>
@@ -1826,7 +1826,7 @@ interface SplSubject  {
         public function detach (SplObserver $observer);
 
         /**
-         * (PHP 5 &gt;= 5.1.0)<br/>
+         * @since 5.1.0
          * Notify an observer
          * @link http://php.net/manual/en/splsubject.notify.php
          * @return void 
@@ -1844,7 +1844,7 @@ interface SplSubject  {
 class SplObjectStorage implements Countable, Iterator, Traversable, Serializable, ArrayAccess {
 
         /**
-         * (PHP 5 &gt;= 5.1.0)<br/>
+         * @since 5.1.0
          * Adds an object in the storage
          * @link http://php.net/manual/en/splobjectstorage.attach.php
          * @param object $object <p>
@@ -1858,7 +1858,7 @@ class SplObjectStorage implements Countable, Iterator, Traversable, Serializable
         public function attach ($object, $data = null) {}
 
         /**
-         * (PHP 5 &gt;= 5.1.0)<br/>
+         * @since 5.1.0
 	 * Removes an object from the storage
          * @link http://php.net/manual/en/splobjectstorage.detach.php
          * @param object $object <p>
@@ -1869,7 +1869,7 @@ class SplObjectStorage implements Countable, Iterator, Traversable, Serializable
         public function detach ($object) {}
 
         /**
-         * (PHP 5 &gt;= 5.1.0)<br/>
+         * @since 5.1.0
          * Checks if the storage contains a specific object
          * @link http://php.net/manual/en/splobjectstorage.contains.php
          * @param object $object <p>
@@ -1880,7 +1880,7 @@ class SplObjectStorage implements Countable, Iterator, Traversable, Serializable
         public function contains ($object) {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Adds all objects from another storage
          * @link http://php.net/manual/en/splobjectstorage.addall.php
          * @param SplObjectStorage $storage <p>
@@ -1891,7 +1891,7 @@ class SplObjectStorage implements Countable, Iterator, Traversable, Serializable
 	public function addAll (SplObjectStorage $storage) {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Removes objects contained in another storage from the current storage
          * @link http://php.net/manual/en/splobjectstorage.removeall.php
          * @param SplObjectStorage $storage <p>
@@ -1902,7 +1902,7 @@ class SplObjectStorage implements Countable, Iterator, Traversable, Serializable
 	public function removeAll (SplObjectStorage $storage) {}
 
         /**
-	 * (PHP 5 &gt;= 5.3.6)<br/>
+	 * @since 5.3.6
 	 * Removes all objects except for those contained in another storage from the current storage
 	 * @link http://php.net/manual/en/splobjectstorage.removeallexcept.php
 	 * @param SplObjectStorage $storage <p>
@@ -1913,7 +1913,7 @@ class SplObjectStorage implements Countable, Iterator, Traversable, Serializable
 	public function removeAllExcept (SplObjectStorage $storage) {}
 
 	/**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Returns the data associated with the current iterator entry
          * @link http://php.net/manual/en/splobjectstorage.getinfo.php
          * @return mixed The data associated with the current iterator position.
@@ -1921,7 +1921,7 @@ class SplObjectStorage implements Countable, Iterator, Traversable, Serializable
         public function getInfo () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Sets the data associated with the current iterator entry
          * @link http://php.net/manual/en/splobjectstorage.setinfo.php
          * @param mixed $data <p>
@@ -1932,7 +1932,7 @@ class SplObjectStorage implements Countable, Iterator, Traversable, Serializable
         public function setInfo ($data) {}
 
         /**
-         * (PHP 5 &gt;= 5.1.0)<br/>
+         * @since 5.1.0
          * Returns the number of objects in the storage
          * @link http://php.net/manual/en/splobjectstorage.count.php
          * @return int The number of objects in the storage.
@@ -1940,7 +1940,7 @@ class SplObjectStorage implements Countable, Iterator, Traversable, Serializable
         public function count () {}
 
         /**
-         * (PHP 5 &gt;= 5.1.0)<br/>
+         * @since 5.1.0
          * Rewind the iterator to the first storage element
          * @link http://php.net/manual/en/splobjectstorage.rewind.php
          * @return void 
@@ -1948,7 +1948,7 @@ class SplObjectStorage implements Countable, Iterator, Traversable, Serializable
         public function rewind () {}
 
         /**
-         * (PHP 5 &gt;= 5.1.0)<br/>
+         * @since 5.1.0
          * Returns if the current iterator entry is valid
          * @link http://php.net/manual/en/splobjectstorage.valid.php
 	 * @return bool true if the iterator entry is valid, false otherwise.
@@ -1956,7 +1956,7 @@ class SplObjectStorage implements Countable, Iterator, Traversable, Serializable
         public function valid () {}
 
         /**
-         * (PHP 5 &gt;= 5.1.0)<br/>
+         * @since 5.1.0
          * Returns the index at which the iterator currently is
          * @link http://php.net/manual/en/splobjectstorage.key.php
          * @return int The index corresponding to the position of the iterator.
@@ -1964,7 +1964,7 @@ class SplObjectStorage implements Countable, Iterator, Traversable, Serializable
         public function key () {}
 
         /**
-         * (PHP 5 &gt;= 5.1.0)<br/>
+         * @since 5.1.0
          * Returns the current storage entry
          * @link http://php.net/manual/en/splobjectstorage.current.php
          * @return object The object at the current iterator position.
@@ -1972,7 +1972,7 @@ class SplObjectStorage implements Countable, Iterator, Traversable, Serializable
         public function current () {}
 
         /**
-         * (PHP 5 &gt;= 5.1.0)<br/>
+         * @since 5.1.0
          * Move to the next entry
          * @link http://php.net/manual/en/splobjectstorage.next.php
          * @return void 
@@ -1980,7 +1980,7 @@ class SplObjectStorage implements Countable, Iterator, Traversable, Serializable
         public function next () {}
 
         /**
-         * (PHP 5 &gt;= 5.2.2)<br/>
+         * @since 5.2.2
          * Unserializes a storage from its string representation
          * @link http://php.net/manual/en/splobjectstorage.unserialize.php
          * @param string $serialized <p>
@@ -1991,7 +1991,7 @@ class SplObjectStorage implements Countable, Iterator, Traversable, Serializable
         public function unserialize ($serialized) {}
 
         /**
-         * (PHP 5 &gt;= 5.2.2)<br/>
+         * @since 5.2.2
          * Serializes the storage
          * @link http://php.net/manual/en/splobjectstorage.serialize.php
          * @return string A string representing the storage.
@@ -1999,7 +1999,7 @@ class SplObjectStorage implements Countable, Iterator, Traversable, Serializable
         public function serialize () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Checks whether an object exists in the storage
          * @link http://php.net/manual/en/splobjectstorage.offsetexists.php
          * @param object $object <p>
@@ -2011,7 +2011,7 @@ class SplObjectStorage implements Countable, Iterator, Traversable, Serializable
         public function offsetExists ($object) {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Associates data to an object in the storage
          * @link http://php.net/manual/en/splobjectstorage.offsetset.php
          * @param object $object <p>
@@ -2025,7 +2025,7 @@ class SplObjectStorage implements Countable, Iterator, Traversable, Serializable
 	public function offsetSet ($object, $data = null) {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Removes an object from the storage
          * @link http://php.net/manual/en/splobjectstorage.offsetunset.php
          * @param object $object <p>
@@ -2036,7 +2036,7 @@ class SplObjectStorage implements Countable, Iterator, Traversable, Serializable
         public function offsetUnset ($object) {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Returns the data associated with an <type>object</type>
          * @link http://php.net/manual/en/splobjectstorage.offsetget.php
          * @param object $object <p>
@@ -2047,7 +2047,7 @@ class SplObjectStorage implements Countable, Iterator, Traversable, Serializable
         public function offsetGet ($object) {}
 
         /**
-         * PHP >= 5.4.0<br/>
+         * @since 5.4.0
          * Calculate a unique identifier for the contained objects
          * @link http://php.net/manual/en/splobjectstorage.gethash.php
          * @param $object  <p>
@@ -2070,7 +2070,7 @@ class MultipleIterator implements Iterator, Traversable {
 
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Constructs a new MultipleIterator
          * @link http://php.net/manual/en/multipleiterator.construct.php
          * @param $flags [optional] Defaults to MultipleIterator::MIT_NEED_ALL | MultipleIterator::MIT_KEYS_NUMERIC
@@ -2078,7 +2078,7 @@ class MultipleIterator implements Iterator, Traversable {
         public function __construct ($flags) {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Gets the flag information
          * @link http://php.net/manual/en/multipleiterator.getflags.php
          * @return int Information about the flags, as an integer.
@@ -2086,7 +2086,7 @@ class MultipleIterator implements Iterator, Traversable {
         public function getFlags () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Sets flags
          * @link http://php.net/manual/en/multipleiterator.setflags.php
 	 * @param int $flags <p>
@@ -2098,7 +2098,7 @@ class MultipleIterator implements Iterator, Traversable {
         public function setFlags ($flags) {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Attaches iterator information
          * @link http://php.net/manual/en/multipleiterator.attachiterator.php
          * @param Iterator $iterator <p>
@@ -2113,7 +2113,7 @@ class MultipleIterator implements Iterator, Traversable {
 	public function attachIterator (Iterator $iterator, $infos = null) {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Detaches an iterator
          * @link http://php.net/manual/en/multipleiterator.detachiterator.php
          * @param Iterator $iterator <p>
@@ -2124,7 +2124,7 @@ class MultipleIterator implements Iterator, Traversable {
 	public function detachIterator (Iterator $iterator) {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Checks if an iterator is attached
          * @link http://php.net/manual/en/multipleiterator.containsiterator.php
          * @param Iterator $iterator <p>
@@ -2135,7 +2135,7 @@ class MultipleIterator implements Iterator, Traversable {
 	public function containsIterator (Iterator $iterator) {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Gets the number of attached iterator instances
          * @link http://php.net/manual/en/multipleiterator.countiterators.php
          * @return void The number of attached iterator instances (as an integer).
@@ -2143,7 +2143,7 @@ class MultipleIterator implements Iterator, Traversable {
         public function countIterators () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Rewinds all attached iterator instances
          * @link http://php.net/manual/en/multipleiterator.rewind.php
          * @return void 
@@ -2151,7 +2151,7 @@ class MultipleIterator implements Iterator, Traversable {
         public function rewind () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Checks the validity of sub iterators
          * @link http://php.net/manual/en/multipleiterator.valid.php
          * @return void true if one or all sub iterators are valid depending on flags,
@@ -2160,7 +2160,7 @@ class MultipleIterator implements Iterator, Traversable {
         public function valid () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Gets the registered iterator instances
          * @link http://php.net/manual/en/multipleiterator.key.php
          * @return array An array of all registered iterator instances,
@@ -2169,7 +2169,7 @@ class MultipleIterator implements Iterator, Traversable {
         public function key () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Gets the registered iterator instances
          * @link http://php.net/manual/en/multipleiterator.current.php
          * @return void An array of all registered iterator instances,
@@ -2178,7 +2178,7 @@ class MultipleIterator implements Iterator, Traversable {
         public function current () {}
 
         /**
-         * (PHP 5 &gt;= 5.3.0)<br/>
+         * @since 5.3.0
          * Moves all attached iterator instances forward
          * @link http://php.net/manual/en/multipleiterator.next.php
          * @return void 

--- a/SPL_f.php
+++ b/SPL_f.php
@@ -4,7 +4,7 @@
 
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Return available SPL classes
  * @link http://php.net/manual/en/function.spl-classes.php
  * @return array 
@@ -12,7 +12,7 @@
 function spl_classes () {}
 
 /**
- * (PHP 5 &gt;= 5.1.2)<br/>
+ * @since 5.1.2
  * Default implementation for __autoload()
  * @link http://php.net/manual/en/function.spl-autoload.php
  * @param string $class_name <p>
@@ -27,7 +27,7 @@ function spl_classes () {}
 function spl_autoload ($class_name, $file_extensions = null) {}
 
 /**
- * (PHP 5 &gt;= 5.1.2)<br/>
+ * @since 5.1.2
  * Register and return default file extensions for spl_autoload
  * @link http://php.net/manual/en/function.spl-autoload-extensions.php
  * @param string $file_extensions [optional] <p>
@@ -43,7 +43,7 @@ function spl_autoload ($class_name, $file_extensions = null) {}
 function spl_autoload_extensions ($file_extensions = null) {}
 
 /**
- * (PHP 5 &gt;= 5.1.2)<br/>
+ * @since 5.1.2
  * Register given function as __autoload() implementation
  * @link http://php.net/manual/en/function.spl-autoload-register.php
  * @param callback $autoload_function [optional] <p>
@@ -60,7 +60,7 @@ function spl_autoload_extensions ($file_extensions = null) {}
 function spl_autoload_register ($autoload_function = null, $throw = true, $prepend = false) {}
 
 /**
- * (PHP 5 &gt;= 5.1.2)<br/>
+ * @since 5.1.2
  * Unregister given function as __autoload() implementation
  * @link http://php.net/manual/en/function.spl-autoload-unregister.php
  * @param mixed $autoload_function <p>
@@ -71,7 +71,7 @@ function spl_autoload_register ($autoload_function = null, $throw = true, $prepe
 function spl_autoload_unregister ($autoload_function) {}
 
 /**
- * (PHP 5 &gt;= 5.1.2)<br/>
+ * @since 5.1.2
  * Return all registered __autoload() functions
  * @link http://php.net/manual/en/function.spl-autoload-functions.php
  * @return array An array of all registered __autoload functions.
@@ -81,7 +81,7 @@ function spl_autoload_unregister ($autoload_function) {}
 function spl_autoload_functions () {}
 
 /**
- * (PHP 5 &gt;= 5.1.2)<br/>
+ * @since 5.1.2
  * Try all registered __autoload() function to load the requested class
  * @link http://php.net/manual/en/function.spl-autoload-call.php
  * @param string $class_name <p>
@@ -92,7 +92,7 @@ function spl_autoload_functions () {}
 function spl_autoload_call ($class_name) {}
 
 /**
- * (PHP 5 &gt;= 5.1.0)<br/>
+ * @since 5.1.0
  * Return the parent classes of the given class
  * @link http://php.net/manual/en/function.class-parents.php
  * @param mixed $class <p>
@@ -108,7 +108,7 @@ function spl_autoload_call ($class_name) {}
 function class_parents ($class, $autoload = null) {}
 
 /**
- * (PHP 5 &gt;= 5.1.0)<br/>
+ * @since 5.1.0
  * Return the interfaces which are implemented by the given class
  * @link http://php.net/manual/en/function.class-implements.php
  * @param mixed $class <p>
@@ -124,7 +124,7 @@ function class_parents ($class, $autoload = null) {}
 function class_implements ($class, $autoload = null) {}
 
 /**
- * (PHP 5 &gt;= 5.2.0)<br/>
+ * @since 5.2.0
  * Return hash id for given object
  * @link http://php.net/manual/en/function.spl-object-hash.php
  * @param object $obj 
@@ -134,7 +134,7 @@ function class_implements ($class, $autoload = null) {}
 function spl_object_hash ($obj) {}
 
 /**
- * (PHP 5 &gt;= 5.1.0)<br/>
+ * @since 5.1.0
  * Copy the iterator into an array
  * @link http://php.net/manual/en/function.iterator-to-array.php
  * @param Traversable $iterator <p>
@@ -148,7 +148,7 @@ function spl_object_hash ($obj) {}
 function iterator_to_array ($iterator, $use_keys = true) {}
 
 /**
- * (PHP 5 &gt;= 5.1.0)<br/>
+ * @since 5.1.0
  * Count the elements in an iterator
  * @link http://php.net/manual/en/function.iterator-count.php
  * @param Traversable $iterator <p>
@@ -159,7 +159,7 @@ function iterator_to_array ($iterator, $use_keys = true) {}
 function iterator_count ($iterator) {}
 
 /**
- * (PHP 5 &gt;= 5.1.0)<br/>
+ * @since 5.1.0
  * Call a function for every element in an iterator
  * @link http://php.net/manual/en/function.iterator-apply.php
  * @param Traversable $iterator <p>
@@ -180,7 +180,7 @@ function iterator_apply ($iterator, $function, array $args = null) {}
 // End of SPL v.0.2
 
 /**
- * (PHP 5 &gt;= 5.4.0)<br/>
+ * @since 5.4.0
  * Return the traits used by the given class
  * @param mixed $class An object (class instance) or a string (class name).
  * @param bool $autoload Whether to allow this function to load the class automatically through the __autoload() magic method.

--- a/SQLite.php
+++ b/SQLite.php
@@ -365,21 +365,21 @@ final class SQLiteResult implements Iterator, Traversable, Countable {
 	 */
 	public function current ($result_type = SQLITE_BOTH , $decode_binary = true) {}
 	/**
-	 * (PHP 5 &gt;= 5.0.0)<br/>
+	 * @since 5.0.0
 	 * Return the key of the current element
 	 * @link http://php.net/manual/en/iterator.key.php
 	 * @return mixed scalar on success, or null on failure.
 	 */
 	public function key () {}
 	/**
-	 * (PHP 5 &gt;= 5.0.0)<br/>
+	 * @since 5.0.0
 	 * Seek to the next row number
 	 * @link http://php.net/manual/en/function.sqlite-next.php
 	 * @return bool Returns <b>TRUE</b> on success, or <b>FALSE</b> if there are no more rows.
 	 */
 	public function next () {}
 	/**
-	 * (PHP 5 &gt;= 5.0.0)<br/>
+	 * @since 5.0.0
 	 * Checks if current position is valid
 	 * @link http://php.net/manual/en/iterator.valid.php
 	 * @return boolean <p>
@@ -389,7 +389,7 @@ final class SQLiteResult implements Iterator, Traversable, Countable {
 	 */
 	public function valid () {}
 	/**
-	 * (PHP 5 &gt;= 5.0.0)<br/>
+	 * @since 5.0.0
 	 * Rewind the Iterator to the first element
 	 * @link http://php.net/manual/en/iterator.rewind.php
 	 * @return void Any returned value is ignored.
@@ -397,7 +397,7 @@ final class SQLiteResult implements Iterator, Traversable, Countable {
 	public function rewind () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.1.0)<br/>
+	 * @since 5.1.0
 	 * Count elements of an object
 	 * @link http://php.net/manual/en/countable.count.php
 	 * @return int <p>The custom count as an integer.
@@ -409,7 +409,7 @@ final class SQLiteResult implements Iterator, Traversable, Countable {
 	public function count () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.4.0)<br/>
+	 * @since 5.4.0
 	 * Seek to the previous row number of a result set
 	 * @link http://php.net/manual/en/function.sqlite-prev.php
 	 * @return boolean <p> Returns <b>TRUE</b> on success, or <b>FALSE</b> if there are no more previous rows.
@@ -418,7 +418,7 @@ final class SQLiteResult implements Iterator, Traversable, Countable {
 	public function prev () {}
 
 	/**
-	 *(PHP 5 &gt;= 5.4.0)<br/>
+	 *@since 5.4.0
 	 * Returns whether or not a previous row is available
 	 * @link http://php.net/manual/en/function.sqlite-has-prev.php
 	 * @return bool <p>
@@ -515,7 +515,7 @@ final class SQLiteException extends RuntimeException  {
 
 
 	/**
-	 * (PHP 5 &gt;= 5.1.0)<br/>
+	 * @since 5.1.0
 	 * Clone the exception
 	 * @link http://php.net/manual/en/exception.clone.php
 	 * @return void 
@@ -523,7 +523,7 @@ final class SQLiteException extends RuntimeException  {
 	final private function __clone () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.1.0)<br/>
+	 * @since 5.1.0
 	 * Construct the exception
 	 * @link http://php.net/manual/en/exception.construct.php
 	 * @param $message [optional]
@@ -533,7 +533,7 @@ final class SQLiteException extends RuntimeException  {
 	public function __construct ($message, $code, $previous) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.1.0)<br/>
+	 * @since 5.1.0
 	 * String representation of the exception
 	 * @link http://php.net/manual/en/exception.tostring.php
 	 * @return string the string representation of the exception.
@@ -737,7 +737,7 @@ function sqlite_single_query ($db, $query, $first_row_only = null, $decode_binar
 function sqlite_fetch_array ($result, $result_type = SQLITE_BOTH, $decode_binary = null) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Fetches the next row from a result set as an object
  * @link http://php.net/manual/en/function.sqlite-fetch-object.php
  * @param resource $result
@@ -944,7 +944,7 @@ function sqlite_rewind ($result) {}
 function sqlite_next ($result) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Seek to the previous row number of a result set
  * @link http://php.net/manual/en/function.sqlite-prev.php
  * @param resource $result <p>
@@ -958,7 +958,7 @@ function sqlite_next ($result) {}
 function sqlite_prev ($result) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Returns whether more rows are available
  * @link http://php.net/manual/en/function.sqlite-valid.php
  * @param resource $result <p>
@@ -985,7 +985,7 @@ function sqlite_valid ($result) {}
 function sqlite_has_more ($result) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Returns whether or not a previous row is available
  * @link http://php.net/manual/en/function.sqlite-has-prev.php
  * @param resource $result <p>
@@ -1138,7 +1138,7 @@ function sqlite_create_aggregate ($dbhandle, $function_name, $step_func, $finali
 function sqlite_create_function ($dbhandle, $function_name, $callback, $num_args = null) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Opens a SQLite database and returns a SQLiteDatabase object
  * @link http://php.net/manual/en/function.sqlite-factory.php
  * @param string $filename <p>
@@ -1183,7 +1183,7 @@ function sqlite_udf_encode_binary ($data) {}
 function sqlite_udf_decode_binary ($data) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Return an array of column types from a particular table
  * @link http://php.net/manual/en/function.sqlite-fetch-column-types.php
  * @param string $table_name <p>

--- a/SessionHandler.php
+++ b/SessionHandler.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PHP >= 5.4.0<br/>
+ * @since 5.4.0
  * <b>SessionHandlerInterface</b> is an interface which defines
  * a prototype for creating a custom session handler.
  * In order to pass a custom session handler to
@@ -11,7 +11,7 @@
 interface SessionHandlerInterface {
 
 	/**
-	 * PHP >= 5.4.0<br/>
+	 * @since 5.4.0
 	 * Close the session
 	 * @link http://php.net/manual/en/sessionhandlerinterface.close.php
 	 * @return bool <p>
@@ -22,7 +22,7 @@ interface SessionHandlerInterface {
 	public function close();
 
 	/**
-	 * PHP >= 5.4.0<br/>
+	 * @since 5.4.0
 	 * Destroy a session
 	 * @link http://php.net/manual/en/sessionhandlerinterface.destroy.php
 	 * @param int $session_id The session ID being destroyed.
@@ -34,7 +34,7 @@ interface SessionHandlerInterface {
 	public function destroy($session_id);
 
 	/**
-	 * PHP >= 5.4.0<br/>
+	 * @since 5.4.0
 	 * Cleanup old sessions
 	 * @link http://php.net/manual/en/sessionhandlerinterface.gc.php
 	 * @param int $maxlifetime <p>
@@ -49,7 +49,7 @@ interface SessionHandlerInterface {
 	public function gc($maxlifetime);
 
 	/**
-	 * PHP >= 5.4.0<br/>
+	 * @since 5.4.0
 	 * Initialize session
 	 * @link http://php.net/manual/en/sessionhandlerinterface.open.php
 	 * @param string $save_path The path where to store/retrieve the session.
@@ -63,7 +63,7 @@ interface SessionHandlerInterface {
 
 
 	/**
-	 * PHP >= 5.4.0<br/>
+	 * @since 5.4.0
 	 * Read session data
 	 * @link http://php.net/manual/en/sessionhandlerinterface.read.php
 	 * @param string $session_id The session id to read data for.
@@ -76,7 +76,7 @@ interface SessionHandlerInterface {
 	public function read($session_id);
 
 	/**
-	 * PHP >= 5.4.0<br/>
+	 * @since 5.4.0
 	 * Write session data
 	 * @link http://php.net/manual/en/sessionhandlerinterface.write.php
 	 * @param string $session_id The session id.
@@ -96,7 +96,7 @@ interface SessionHandlerInterface {
 }
 
 /**
- * PHP >= 5.4.0<br/>
+ * @since 5.4.0
  * <b>SessionHandler</b> a special class that can
  * be used to expose the current internal PHP session
  * save handler by inheritance. There are six methods
@@ -113,7 +113,7 @@ interface SessionHandlerInterface {
 class SessionHandler implements SessionHandlerInterface {
 
 	/**
-	 * PHP >= 5.4.0<br/>
+	 * @since 5.4.0
 	 * Close the session
 	 * @link http://php.net/manual/en/sessionhandler.close.php
 	 * @return bool <p>
@@ -124,7 +124,7 @@ class SessionHandler implements SessionHandlerInterface {
 	public function close() { }
 
 	/**
-	 * PHP >= 5.4.0<br/>
+	 * @since 5.4.0
 	 * Destroy a session
 	 * @link http://php.net/manual/en/sessionhandler.destroy.php
 	 * @param int $session_id The session ID being destroyed.
@@ -136,7 +136,7 @@ class SessionHandler implements SessionHandlerInterface {
 	public function destroy($session_id) { }
 
 	/**
-	 * PHP >= 5.4.0<br/>
+	 * @since 5.4.0
 	 * Cleanup old sessions
 	 * @link http://php.net/manual/en/sessionhandler.gc.php
 	 * @param int $maxlifetime <p>
@@ -151,7 +151,7 @@ class SessionHandler implements SessionHandlerInterface {
 	public function gc($maxlifetime) { }
 
 	/**
-	 * PHP >= 5.4.0<br/>
+	 * @since 5.4.0
 	 * Initialize session
 	 * @link http://php.net/manual/en/sessionhandler.open.php
 	 * @param string $save_path The path where to store/retrieve the session.
@@ -165,7 +165,7 @@ class SessionHandler implements SessionHandlerInterface {
 
 
 	/**
-	 * PHP >= 5.4.0<br/>
+	 * @since 5.4.0
 	 * Read session data
 	 * @link http://php.net/manual/en/sessionhandler.read.php
 	 * @param string $session_id The session id to read data for.
@@ -178,7 +178,7 @@ class SessionHandler implements SessionHandlerInterface {
 	public function read($session_id) { }
 
 	/**
-	 * PHP >= 5.4.0<br/>
+	 * @since 5.4.0
 	 * Write session data
 	 * @link http://php.net/manual/en/sessionhandler.write.php
 	 * @param string $session_id The session id.

--- a/SimpleXML.php
+++ b/SimpleXML.php
@@ -9,7 +9,7 @@
 class SimpleXMLElement implements Traversable {
 
 	/**
-	 * (PHP 5 &gt;= 5.0.1)<br/>
+	 * @since 5.0.1
 	 * Creates a new SimpleXMLElement object
 	 * @link http://php.net/manual/en/simplexmlelement.construct.php
      * @param string $data A well-formed XML string or the path or URL to an XML document if data_is_url is TRUE.
@@ -29,7 +29,7 @@ class SimpleXMLElement implements Traversable {
     function __get($name) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.0.1)<br/>
+	 * @since 5.0.1
 	 * Return a well-formed XML string based on SimpleXML element
 	 * @link http://php.net/manual/en/simplexmlelement.asxml.php
 	 * @param string $filename [optional] <p>
@@ -44,7 +44,7 @@ class SimpleXMLElement implements Traversable {
 	public function asXML ($filename = null) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.2.0)<br/>
+	 * @since 5.2.0
 	 * Alias of <b>SimpleXMLElement::asXML</b>
      * Return a well-formed XML string based on SimpleXML element
 	 * @link http://php.net/manual/en/simplexmlelement.savexml.php
@@ -60,7 +60,7 @@ class SimpleXMLElement implements Traversable {
 	public function saveXML ($filename = null) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.2.0)<br/>
+	 * @since 5.2.0
 	 * Runs XPath query on XML data
 	 * @link http://php.net/manual/en/simplexmlelement.xpath.php
 	 * @param string $path <p>
@@ -72,7 +72,7 @@ class SimpleXMLElement implements Traversable {
 	public function xpath ($path) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.2.0)<br/>
+	 * @since 5.2.0
 	 * Creates a prefix/ns context for the next XPath query
 	 * @link http://php.net/manual/en/simplexmlelement.registerxpathnamespace.php
 	 * @param string $prefix <p>
@@ -89,7 +89,7 @@ class SimpleXMLElement implements Traversable {
 	public function registerXPathNamespace ($prefix, $ns) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.0.1)<br/>
+	 * @since 5.0.1
 	 * Identifies an element's attributes
 	 * @link http://php.net/manual/en/simplexmlelement.attributes.php
 	 * @param string $ns [optional] <p>
@@ -108,7 +108,7 @@ class SimpleXMLElement implements Traversable {
 	public function attributes ($ns = null, $is_prefix = false) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.0.1)<br/>
+	 * @since 5.0.1
 	 * Finds children of given node
 	 * @link http://php.net/manual/en/simplexmlelement.children.php
 	 * @param string $ns [optional] <p>
@@ -126,7 +126,7 @@ class SimpleXMLElement implements Traversable {
 	public function children ($ns = null, $is_prefix = false) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.1.2)<br/>
+	 * @since 5.1.2
 	 * Returns namespaces used in document
 	 * @link http://php.net/manual/en/simplexmlelement.getnamespaces.php
 	 * @param bool $recursive [optional] <p>
@@ -139,7 +139,7 @@ class SimpleXMLElement implements Traversable {
 	public function getNamespaces ($recursive = false) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.1.2)<br/>
+	 * @since 5.1.2
 	 * Returns namespaces declared in document
 	 * @link http://php.net/manual/en/simplexmlelement.getdocnamespaces.php
 	 * @param bool $recursive [optional] <p>
@@ -156,7 +156,7 @@ class SimpleXMLElement implements Traversable {
 	public function getDocNamespaces ($recursive = false, $from_root = true) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.1.3)<br/>
+	 * @since 5.1.3
 	 * Gets the name of the XML element
 	 * @link http://php.net/manual/en/simplexmlelement.getname.php
 	 * @return string The getName method returns as a string the
@@ -165,7 +165,7 @@ class SimpleXMLElement implements Traversable {
 	public function getName () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.1.3)<br/>
+	 * @since 5.1.3
 	 * Adds a child element to the XML node
 	 * @link http://php.net/manual/en/simplexmlelement.addchild.php
 	 * @param string $name <p>
@@ -183,7 +183,7 @@ class SimpleXMLElement implements Traversable {
 	public function addChild ($name, $value = null, $namespace = null) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.1.3)<br/>
+	 * @since 5.1.3
 	 * Adds an attribute to the SimpleXML element
 	 * @link http://php.net/manual/en/simplexmlelement.addattribute.php
 	 * @param string $name <p>
@@ -208,7 +208,7 @@ class SimpleXMLElement implements Traversable {
 	public function __toString () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
 	 * Counts the children of an element
 	 * @link http://php.net/manual/en/simplexmlelement.count.php
 	 * @return int the number of elements of an element.
@@ -224,7 +224,7 @@ class SimpleXMLElement implements Traversable {
 class SimpleXMLIterator extends SimpleXMLElement implements Traversable, RecursiveIterator, Iterator, Countable {
 
 	/**
-	 * (PHP 5 &gt;= 5.1.0)<br/>
+	 * @since 5.1.0
 	 * Rewind to the first element
 	 * @link http://php.net/manual/en/simplexmliterator.rewind.php
 	 * @return void No value is returned.
@@ -232,7 +232,7 @@ class SimpleXMLIterator extends SimpleXMLElement implements Traversable, Recursi
 	public function rewind () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.1.0)<br/>
+	 * @since 5.1.0
 	 * Check whether the current element is valid
 	 * @link http://php.net/manual/en/simplexmliterator.valid.php
 	 * @return bool <b>TRUE</b> if the current element is valid, otherwise <b>FALSE</b>
@@ -240,7 +240,7 @@ class SimpleXMLIterator extends SimpleXMLElement implements Traversable, Recursi
 	public function valid () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.1.0)<br/>
+	 * @since 5.1.0
 	 * Returns the current element
 	 * @link http://php.net/manual/en/simplexmliterator.current.php
 	 * @return mixed the current element as a <b>SimpleXMLIterator</b> object or <b>NULL</b> on failure.
@@ -248,7 +248,7 @@ class SimpleXMLIterator extends SimpleXMLElement implements Traversable, Recursi
 	public function current () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.1.0)<br/>
+	 * @since 5.1.0
 	 * Return current key
 	 * @link http://php.net/manual/en/simplexmliterator.key.php
 	 * @return mixed the XML tag name of the element referenced by the current <b>SimpleXMLIterator</b> object or <b>FALSE</b>
@@ -256,7 +256,7 @@ class SimpleXMLIterator extends SimpleXMLElement implements Traversable, Recursi
 	public function key () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.1.0)<br/>
+	 * @since 5.1.0
 	 * Move to next element
 	 * @link http://php.net/manual/en/simplexmliterator.next.php
 	 * @return void No value is returned.
@@ -264,7 +264,7 @@ class SimpleXMLIterator extends SimpleXMLElement implements Traversable, Recursi
 	public function next () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.1.0)<br/>
+	 * @since 5.1.0
 	 * Checks whether the current element has sub elements.
 	 * @link http://php.net/manual/en/simplexmliterator.haschildren.php
 	 * @return bool <b>TRUE</b> if the current element has sub-elements, otherwise <b>FALSE</b>
@@ -272,7 +272,7 @@ class SimpleXMLIterator extends SimpleXMLElement implements Traversable, Recursi
 	public function hasChildren () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.1.0)<br/>
+	 * @since 5.1.0
 	 * Returns the sub-elements of the current element
 	 * @link http://php.net/manual/en/simplexmliterator.getchildren.php
 	 * @return SimpleXMLIterator a <b>SimpleXMLIterator</b> object containing
@@ -289,7 +289,7 @@ class SimpleXMLIterator extends SimpleXMLElement implements Traversable, Recursi
 	public function __toString () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
 	 * Counts the children of an element
 	 * @link http://php.net/manual/en/simplexmlelement.count.php
 	 * @return int the number of elements of an element.
@@ -299,7 +299,7 @@ class SimpleXMLIterator extends SimpleXMLElement implements Traversable, Recursi
 }
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Interprets an XML file into an object
  * @link http://php.net/manual/en/function.simplexml-load-file.php
  * @param string $filename <p>
@@ -336,7 +336,7 @@ class SimpleXMLIterator extends SimpleXMLElement implements Traversable, Recursi
 function simplexml_load_file ($filename, $class_name = "SimpleXMLElement", $options = 0, $ns = "", $is_prefix = false) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Interprets a string of XML into an object
  * @link http://php.net/manual/en/function.simplexml-load-string.php
  * @param string $data <p>
@@ -365,7 +365,7 @@ function simplexml_load_file ($filename, $class_name = "SimpleXMLElement", $opti
 function simplexml_load_string ($data, $class_name = "SimpleXMLElement", $options = 0, $ns = "", $is_prefix = false) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Get a SimpleXMLElement object from a DOM node.
  * @link http://php.net/manual/en/function.simplexml-import-dom.php
  * @param DOMNode $node <p>

--- a/_standard_manual.php
+++ b/_standard_manual.php
@@ -28,7 +28,7 @@ define("__COMPILER_HALT_OFFSET__",0);
 
 
 /**
- * PHP >= 5.4.0<br/>
+ * @since 5.4.0
  * Convert hex to binary
  * @link http://php.net/manual/en/function.hex2bin.php
  * @param string $data

--- a/_superglobals.php
+++ b/_superglobals.php
@@ -31,7 +31,7 @@ $_COOKIE = array();
  */
 $_ENV = array();
 /**
- * @deprecated
+ * @deprecated 4.1.0
  */
 $HTTP_ENV_VARS = array();
 
@@ -48,7 +48,7 @@ $HTTP_ENV_VARS = array();
  */
 $_FILES = array();
 /**
- * @deprecated
+ * @deprecated 4.1.0
  */
 $HTTP_POST_FILES = array();
 
@@ -65,7 +65,7 @@ $HTTP_POST_FILES = array();
  */
 $_GET = array();
 /**
- * @deprecated
+ * @deprecated 4.1.0
  */
 $HTTP_GET_VARS = array();
 
@@ -82,7 +82,7 @@ $HTTP_GET_VARS = array();
  */
 $_POST = array();
 /**
- * @deprecated
+ * @deprecated 4.1.0
  */
 $HTTP_POST_VARS = array();
 
@@ -118,7 +118,7 @@ $_REQUEST = array();
  */
 $_SERVER = array();
 /**
- * @deprecated
+ * @deprecated 4.1.0
  */
 $HTTP_SERVER_VARS = array();
 
@@ -173,7 +173,7 @@ $_SERVER['ORIG_PATH_INFO'] = '';
  */
 $_SESSION = array();
 /**
- * @deprecated
+ * @deprecated 4.1.0
  */
 $HTTP_SESSION_VARS = array();
 
@@ -205,7 +205,7 @@ $argv = array();
  * <p><a href="http://www.php.net/manual/en/reserved.variables.php">
  * http://us2.php.net/manual/en/reserved.variables.php</a>
  * 
- * @deprecated Deprecated as of PHP 5.6.0. Use the php://input stream instead.
+ * @deprecated 5.6.0 Deprecated as of PHP 5.6.0. Use the php://input stream instead.
  */
 $HTTP_RAW_POST_DATA = '';
 

--- a/_types.php
+++ b/_types.php
@@ -202,6 +202,7 @@ class object {
     function __debugInfo(){}
 
   /**
+   * @since 5.1.0
    * This static method is called for classes exported by var_export() since PHP 5.1.0.
    * The only parameter of this method is an array containing exported properties in the form array('property' => value, ...).
    *

--- a/apache.php
+++ b/apache.php
@@ -3,7 +3,8 @@
 // Start of apache v.
 
 /**
- * (PHP 4 &gt;= 4.0.5, PHP 5)<br/>
+ * @since 4.0.5
+ * @since 5.0
  * Terminate apache process after this request
  * apache_child_terminate() will register the Apache process executing the current PHP request for termination once execution of PHP code is completed. It may be used to terminate a process after a script with high memory consumption has been run as memory will usually only be freed internally but not given back to the operating system.
  * @link http://php.net/manual/en/function.apache-child-terminate.php
@@ -12,7 +13,8 @@
 function apache_child_terminate () {}
 
 /**
- * (PHP 4 &gt;= 4.3.2, PHP 5)<br/>
+ * @since 4.3.2
+ * @since 5.0
  * Get a list of loaded Apache modules
  * @link http://php.net/manual/en/function.apache-get-modules.php
  * @return array of loaded Apache modules.
@@ -20,7 +22,8 @@ function apache_child_terminate () {}
 function apache_get_modules () {}
 
 /**
- * (PHP 4 &gt;= 4.3.2, PHP 5)<br/>
+ * @since 4.3.2
+ * @since 5.0
  * Fetch the Apache version
  * @link http://php.net/manual/en/function.apache-get-version.php
  * @return string|false the Apache version on success or <b>FALSE</b> on failure.
@@ -28,7 +31,8 @@ function apache_get_modules () {}
 function apache_get_version () {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Get an Apache subprocess_env variable
  * Retrieve an Apache environment variable specified by $variable.
  * This function requires Apache 2 otherwise it's undefined.
@@ -44,7 +48,8 @@ function apache_get_version () {}
 function apache_getenv ( $variable, $walk_to_top = false ) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Perform a partial request for the specified URI and return all info about it
  * This performs a partial request for a URI. It goes just far enough to obtain all the important information about the given resource.
  * This function is supported when PHP is installed as an Apache module or by the NSAPI server module in Netscape/iPlanet/SunONE webservers.
@@ -57,7 +62,8 @@ function apache_getenv ( $variable, $walk_to_top = false ) {}
 function apache_lookup_uri ( $filename ) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get and set apache request notes
  * This function is a wrapper for Apache's table_get and table_set. It edits the table of notes that exists during a request. The table's purpose is to allow Apache modules to communicate.
  * The main use for apache_note() is to pass information from one module to another within the same request.
@@ -73,7 +79,8 @@ function apache_lookup_uri ( $filename ) {}
 function apache_note ( $note_name, $note_value = '' ) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Fetches all HTTP request headers from the current request
  * @link http://php.net/manual/en/function.apache-request-headers.php
  * @return array|false An associative array of all the HTTP headers in the current request, or <b>FALSE</b on failure.
@@ -81,7 +88,7 @@ function apache_note ( $note_name, $note_value = '' ) {}
 function apache_request_headers () {}
 
 /**
- * (PHP 5 &gt;= 5.1.0)<br/>
+ * @since 5.1.0
  * Reset the Apache write timer
  * apache_reset_timeout() resets the Apache write timer, which defaults to 300 seconds. With set_time_limit(0); ignore_user_abort(true) and periodic apache_reset_timeout() calls, Apache can theoretically run forever.
  * This function requires Apache 1.
@@ -91,7 +98,8 @@ function apache_request_headers () {}
 function apache_reset_timeout () {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Fetch all HTTP response headers
  * @link http://php.net/manual/en/function.apache-response-headers.php
  * @return array|false An array of all Apache response headers on success or <b>FALSE</b> on failure.
@@ -99,7 +107,8 @@ function apache_reset_timeout () {}
 array function apache_response_headers () {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Sets the value of the Apache environment variable specified by variable.
  * Note: When setting an Apache environment variable, the corresponding $_SERVER variable is not changed.
  * @link http://php.net/manual/en/function.apache-setenv.php
@@ -117,7 +126,8 @@ array function apache_response_headers () {}
 function apache_setenv ( $variable, $value, $walk_to_top = false ) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Fetches all HTTP headers from the current request.
  * This function is an alias for apache_request_headers(). Please read the apache_request_headers() documentation for more information on how this function works.
  * @link http://php.net/manual/en/function.getallheaders.php
@@ -126,7 +136,8 @@ function apache_setenv ( $variable, $value, $walk_to_top = false ) {}
 function getallheaders () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Perform an Apache sub-request
  * virtual() is an Apache-specific function which is similar to <!--#include virtual...--> in mod_include. It performs an Apache sub-request. It is useful for including CGI scripts or .shtml files, or anything else that you would parse through Apache. Note that for a CGI script, the script must generate valid CGI headers. At the minimum that means it must generate a Content-Type header.
  * To run the sub-request, all buffers are terminated and flushed to the browser, pending headers are sent too.

--- a/basic.php
+++ b/basic.php
@@ -1,7 +1,8 @@
 <?php
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * @deprecated since 5.3.0
  * Loads a PHP extension at runtime
  * @link http://php.net/manual/en/function.dl.php
@@ -38,7 +39,7 @@
 function dl ($library) {}
 
 /**
- * (PHP 5 &gt;= 5.5.0)<br/>
+ * @since 5.5.0
  * Sets the process title
  * @link http://php.net/manual/en/function.cli-set-process-title.php
  * @param string $title <p>
@@ -49,7 +50,7 @@ function dl ($library) {}
 function cli_set_process_title ($title) {}
 
 /**
- * (PHP 5 &gt;= 5.5.0)<br/>
+ * @since 5.5.0
  * Returns the current process title
  * @link http://php.net/manual/en/function.cli-get-process-title.php
  * @return string Return a string with the current process title or <b>NULL</b> on error.
@@ -104,6 +105,7 @@ define ('__METHOD__', '', true);
  * The trait name. (Added in PHP 5.4.0) As of PHP 5.4 this constant
  * returns the trait as it was declared (case-sensitive). The trait name includes the namespace
  * it was declared in (e.g. Foo\Bar).
+ * @since 5.4.0
  * @link http://php.net/manual/en/language.constants.predefined.php
  */
 define ('__TRAIT__', '', true);
@@ -113,7 +115,7 @@ define ('__TRAIT__', '', true);
  * the directory of the included file is returned. This is equivalent
  * to dirname(__FILE__). This directory name
  * does not have a trailing slash unless it is the root directory.
- * (Added in PHP 5.3.0.)
+ * @since 5.3.0
  * @link http://php.net/manual/en/language.constants.predefined.php
  */
 define ('__DIR__', '', true);
@@ -121,6 +123,7 @@ define ('__DIR__', '', true);
 /**
  * The name of the current namespace (case-sensitive). This constant
  * is defined in compile-time (Added in PHP 5.3.0).
+ * @since 5.3.0
  * @link http://php.net/manual/en/language.constants.predefined.php
  */
 define ('__NAMESPACE__', '', true);

--- a/basic.php
+++ b/basic.php
@@ -3,7 +3,7 @@
 /**
  * @since 4.0
  * @since 5.0
- * @deprecated since 5.3.0
+ * @deprecated 5.3.0 since 5.3.0
  * Loads a PHP extension at runtime
  * @link http://php.net/manual/en/function.dl.php
  * @param string $library <p>

--- a/bcmath.php
+++ b/bcmath.php
@@ -3,7 +3,8 @@
 // Start of bcmath v.
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Add two arbitrary precision numbers
  * @link http://php.net/manual/en/function.bcadd.php
  * @param string $left_operand <p>
@@ -18,7 +19,8 @@
 function bcadd ($left_operand, $right_operand, $scale = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Subtract one arbitrary precision number from another
  * @link http://php.net/manual/en/function.bcsub.php
  * @param string $left_operand <p>
@@ -33,7 +35,8 @@ function bcadd ($left_operand, $right_operand, $scale = null) {}
 function bcsub ($left_operand, $right_operand, $scale = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Multiply two arbitrary precision numbers
  * @link http://php.net/manual/en/function.bcmul.php
  * @param string $left_operand <p>
@@ -48,7 +51,8 @@ function bcsub ($left_operand, $right_operand, $scale = null) {}
 function bcmul ($left_operand, $right_operand, $scale = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Divide two arbitrary precision numbers
  * @link http://php.net/manual/en/function.bcdiv.php
  * @param string $left_operand <p>
@@ -64,7 +68,8 @@ function bcmul ($left_operand, $right_operand, $scale = null) {}
 function bcdiv ($left_operand, $right_operand, $scale = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get modulus of an arbitrary precision number
  * @link http://php.net/manual/en/function.bcmod.php
  * @param string $left_operand <p>
@@ -79,7 +84,8 @@ function bcdiv ($left_operand, $right_operand, $scale = null) {}
 function bcmod ($left_operand, $modulus) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Raise an arbitrary precision number to another
  * @link http://php.net/manual/en/function.bcpow.php
  * @param string $left_operand <p>
@@ -94,7 +100,8 @@ function bcmod ($left_operand, $modulus) {}
 function bcpow ($left_operand, $right_operand, $scale = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get the square root of an arbitrary precision number
  * @link http://php.net/manual/en/function.bcsqrt.php
  * @param string $operand <p>
@@ -107,7 +114,8 @@ function bcpow ($left_operand, $right_operand, $scale = null) {}
 function bcsqrt ($operand, $scale = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Set default scale parameter for all bc math functions
  * @link http://php.net/manual/en/function.bcscale.php
  * @param int $scale <p>
@@ -118,7 +126,8 @@ function bcsqrt ($operand, $scale = null) {}
 function bcscale ($scale) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Compare two arbitrary precision numbers
  * @link http://php.net/manual/en/function.bccomp.php
  * @param string $left_operand <p>
@@ -139,7 +148,7 @@ function bcscale ($scale) {}
 function bccomp ($left_operand, $right_operand, $scale = null) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Raise an arbitrary precision number to another, reduced by a specified modulus
  * @link http://php.net/manual/en/function.bcpowmod.php
  * @param string $left_operand <p>

--- a/bz2.php
+++ b/bz2.php
@@ -3,7 +3,8 @@
 // Start of bz2 v.
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Opens a bzip2 compressed file
  * @link http://php.net/manual/en/function.bzopen.php
  * @param string $filename <p>
@@ -20,7 +21,8 @@
 function bzopen ($filename, $mode) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Binary safe bzip2 file read
  * @link http://php.net/manual/en/function.bzread.php
  * @param resource $bz <p>
@@ -37,7 +39,8 @@ function bzopen ($filename, $mode) {}
 function bzread ($bz, $length = 1024) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Binary safe bzip2 file write
  * @link http://php.net/manual/en/function.bzwrite.php
  * @param resource $bz <p>
@@ -57,7 +60,8 @@ function bzread ($bz, $length = 1024) {}
 function bzwrite ($bz, $data, $length = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Force a write of all buffered data
  * @link http://php.net/manual/en/function.bzflush.php
  * @param resource $bz <p>
@@ -69,7 +73,8 @@ function bzwrite ($bz, $data, $length = null) {}
 function bzflush ($bz) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Close a bzip2 file
  * @link http://php.net/manual/en/function.bzclose.php
  * @param resource $bz <p>
@@ -81,7 +86,8 @@ function bzflush ($bz) {}
 function bzclose ($bz) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Returns a bzip2 error number
  * @link http://php.net/manual/en/function.bzerrno.php
  * @param resource $bz <p>
@@ -93,7 +99,8 @@ function bzclose ($bz) {}
 function bzerrno ($bz) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Returns a bzip2 error string
  * @link http://php.net/manual/en/function.bzerrstr.php
  * @param resource $bz <p>
@@ -105,7 +112,8 @@ function bzerrno ($bz) {}
 function bzerrstr ($bz) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Returns the bzip2 error number and error string in an array
  * @link http://php.net/manual/en/function.bzerror.php
  * @param resource $bz <p>
@@ -119,7 +127,8 @@ function bzerrstr ($bz) {}
 function bzerror ($bz) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Compress a string into bzip2 encoded data
  * @link http://php.net/manual/en/function.bzcompress.php
  * @param string $source <p>
@@ -144,7 +153,8 @@ function bzerror ($bz) {}
 function bzcompress ($source, $blocksize = 4, $workfactor = 0) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Decompresses bzip2 encoded data
  * @link http://php.net/manual/en/function.bzdecompress.php
  * @param string $source <p>

--- a/calendar.php
+++ b/calendar.php
@@ -3,7 +3,8 @@
 // Start of calendar v.
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Converts Julian Day Count to Gregorian date
  * @link http://php.net/manual/en/function.jdtogregorian.php
  * @param int $julianday <p>
@@ -14,7 +15,8 @@
 function jdtogregorian ($julianday) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Converts a Gregorian date to Julian Day Count
  * @link http://php.net/manual/en/function.gregoriantojd.php
  * @param int $month <p>
@@ -31,7 +33,8 @@ function jdtogregorian ($julianday) {}
 function gregoriantojd ($month, $day, $year) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Converts a Julian Day Count to a Julian Calendar Date
  * @link http://php.net/manual/en/function.jdtojulian.php
  * @param int $julianday <p>
@@ -42,7 +45,8 @@ function gregoriantojd ($month, $day, $year) {}
 function jdtojulian ($julianday) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Converts a Julian Calendar date to Julian Day Count
  * @link http://php.net/manual/en/function.juliantojd.php
  * @param int $month <p>
@@ -59,7 +63,8 @@ function jdtojulian ($julianday) {}
 function juliantojd ($month, $day, $year) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Converts a Julian day count to a Jewish calendar date
  * @link http://php.net/manual/en/function.jdtojewish.php
  * @param int $juliandaycount
@@ -79,7 +84,8 @@ function juliantojd ($month, $day, $year) {}
 function jdtojewish ($juliandaycount, $hebrew = false, $fl = 0) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Converts a date in the Jewish Calendar to Julian Day Count
  * @link http://php.net/manual/en/function.jewishtojd.php
  * @param int $month <p>
@@ -96,7 +102,8 @@ function jdtojewish ($juliandaycount, $hebrew = false, $fl = 0) {}
 function jewishtojd ($month, $day, $year) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Converts a Julian Day Count to the French Republican Calendar
  * @link http://php.net/manual/en/function.jdtofrench.php
  * @param int $juliandaycount
@@ -105,7 +112,8 @@ function jewishtojd ($month, $day, $year) {}
 function jdtofrench ($juliandaycount) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Converts a date from the French Republican Calendar to a Julian Day Count
  * @link http://php.net/manual/en/function.frenchtojd.php
  * @param int $month <p>
@@ -122,7 +130,8 @@ function jdtofrench ($juliandaycount) {}
 function frenchtojd ($month, $day, $year) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Returns the day of the week
  * @link http://php.net/manual/en/function.jddayofweek.php
  * @param int $julianday <p>
@@ -160,7 +169,8 @@ function frenchtojd ($month, $day, $year) {}
 function jddayofweek ($julianday, $mode = CAL_DOW_DAYNO) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Returns a month name
  * @link http://php.net/manual/en/function.jdmonthname.php
  * @param int $julianday
@@ -170,7 +180,8 @@ function jddayofweek ($julianday, $mode = CAL_DOW_DAYNO) {}
 function jdmonthname ($julianday, $mode) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get Unix timestamp for midnight on Easter of a given year
  * @link http://php.net/manual/en/function.easter-date.php
  * @param int $year [optional] <p>
@@ -181,7 +192,8 @@ function jdmonthname ($julianday, $mode) {}
 function easter_date ($year = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get number of days after March 21 on which Easter falls for a given year
  * @link http://php.net/manual/en/function.easter-days.php
  * @param int $year [optional] <p>
@@ -199,7 +211,8 @@ function easter_date ($year = null) {}
 function easter_days ($year = null, $method = CAL_EASTER_DEFAULT) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Convert Unix timestamp to Julian Day
  * @link http://php.net/manual/en/function.unixtojd.php
  * @param int $timestamp [optional] defaults to time() <p>
@@ -210,7 +223,8 @@ function easter_days ($year = null, $method = CAL_EASTER_DEFAULT) {}
 function unixtojd ($timestamp = 0) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Convert Julian Day to Unix timestamp
  * @link http://php.net/manual/en/function.jdtounix.php
  * @param int $jday <p>
@@ -221,7 +235,8 @@ function unixtojd ($timestamp = 0) {}
 function jdtounix ($jday) {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Converts from a supported calendar to Julian Day Count
  * @link http://php.net/manual/en/function.cal-to-jd.php
  * @param int $calendar <p>
@@ -248,7 +263,8 @@ function jdtounix ($jday) {}
 function cal_to_jd ($calendar, $month, $day, $year) {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Converts from Julian Day Count to a supported calendar
  * @link http://php.net/manual/en/function.cal-from-jd.php
  * @param int $jd <p>
@@ -264,7 +280,8 @@ function cal_to_jd ($calendar, $month, $day, $year) {}
 function cal_from_jd ($jd, $calendar) {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Return the number of days in a month for a given year and calendar
  * @link http://php.net/manual/en/function.cal-days-in-month.php
  * @param int $calendar <p>
@@ -281,7 +298,8 @@ function cal_from_jd ($jd, $calendar) {}
 function cal_days_in_month ($calendar, $month, $year) {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Returns information about a particular calendar
  * @link http://php.net/manual/en/function.cal-info.php
  * @param int $calendar [optional] <p>

--- a/ctype.php
+++ b/ctype.php
@@ -3,7 +3,8 @@
 // Start of ctype v.
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Check for alphanumeric character(s)
  * @link http://php.net/manual/en/function.ctype-alnum.php
  * @param string $text <p>
@@ -15,7 +16,8 @@
 function ctype_alnum ($text) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Check for alphabetic character(s)
  * @link http://php.net/manual/en/function.ctype-alpha.php
  * @param string $text <p>
@@ -27,7 +29,8 @@ function ctype_alnum ($text) {}
 function ctype_alpha ($text) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Check for control character(s)
  * @link http://php.net/manual/en/function.ctype-cntrl.php
  * @param string $text <p>
@@ -39,7 +42,8 @@ function ctype_alpha ($text) {}
 function ctype_cntrl ($text) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Check for numeric character(s)
  * @link http://php.net/manual/en/function.ctype-digit.php
  * @param string $text <p>
@@ -51,7 +55,8 @@ function ctype_cntrl ($text) {}
 function ctype_digit ($text) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Check for lowercase character(s)
  * @link http://php.net/manual/en/function.ctype-lower.php
  * @param string $text <p>
@@ -63,7 +68,8 @@ function ctype_digit ($text) {}
 function ctype_lower ($text) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Check for any printable character(s) except space
  * @link http://php.net/manual/en/function.ctype-graph.php
  * @param string $text <p>
@@ -76,7 +82,8 @@ function ctype_lower ($text) {}
 function ctype_graph ($text) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Check for printable character(s)
  * @link http://php.net/manual/en/function.ctype-print.php
  * @param string $text <p>
@@ -90,7 +97,8 @@ function ctype_graph ($text) {}
 function ctype_print ($text) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Check for any printable character which is not whitespace or an
 alphanumeric character
  * @link http://php.net/manual/en/function.ctype-punct.php
@@ -103,7 +111,8 @@ alphanumeric character
 function ctype_punct ($text) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Check for whitespace character(s)
  * @link http://php.net/manual/en/function.ctype-space.php
  * @param string $text <p>
@@ -117,7 +126,8 @@ function ctype_punct ($text) {}
 function ctype_space ($text) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Check for uppercase character(s)
  * @link http://php.net/manual/en/function.ctype-upper.php
  * @param string $text <p>
@@ -129,7 +139,8 @@ function ctype_space ($text) {}
 function ctype_upper ($text) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Check for character(s) representing a hexadecimal digit
  * @link http://php.net/manual/en/function.ctype-xdigit.php
  * @param string $text <p>

--- a/curl.php
+++ b/curl.php
@@ -8,7 +8,7 @@ class CURLFile {
     public $postname;
 
     /**
-     * (PHP 5 &gt;= 5.5.0)<br/>
+     * @since 5.5.0
      * Create a CURLFile object
      * @link http://www.php.net/manual/en/curlfile.construct.php
      * @param string $filename <p>Path to the file which will be uploaded.</p>
@@ -19,7 +19,7 @@ class CURLFile {
     }
 
     /**
-     * (PHP 5 &gt;= 5.5.0)<br/>
+     * @since 5.5.0
      * Get file name
      * @link http://www.php.net/manual/en/curlfile.getfilename.php
      * @return string Returns file name.
@@ -28,7 +28,7 @@ class CURLFile {
     }
 
     /**
-     * (PHP 5 &gt;= 5.5.0)<br/>
+     * @since 5.5.0
      * Get MIME type
      * @link http://www.php.net/manual/en/curlfile.getmimetype.php
      * @return string Returns MIME type.
@@ -37,7 +37,7 @@ class CURLFile {
     }
 
     /**
-     * (PHP 5 &gt;= 5.5.0)<br/>
+     * @since 5.5.0
      * Get file name for POST
      * @link http://www.php.net/manual/en/curlfile.getpostfilename.php
      * @return string Returns file name for POST.
@@ -46,7 +46,7 @@ class CURLFile {
     }
 
     /**
-     * (PHP 5 &gt;= 5.5.0)<br/>
+     * @since 5.5.0
      * Set MIME type
      * @link http://www.php.net/manual/en/curlfile.setmimetype.php
      * @param string $mime
@@ -55,7 +55,7 @@ class CURLFile {
     }
 
     /**
-     * (PHP 5 &gt;= 5.5.0)<br/>
+     * @since 5.5.0
      * Set file name for POST
      * http://www.php.net/manual/en/curlfile.setpostfilename.php
      * @param string $postname
@@ -64,7 +64,7 @@ class CURLFile {
     }
 
     /**
-     * (PHP 5 &gt;= 5.5.0)<br/>
+     * @since 5.5.0
      * @link http://www.php.net/manual/en/curlfile.wakeup.php
      * Unserialization handler
      */
@@ -72,7 +72,8 @@ class CURLFile {
     }
 }
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Initialize a cURL session
  * @link http://php.net/manual/en/function.curl-init.php
  * @param string $url [optional] <p>
@@ -85,7 +86,7 @@ class CURLFile {
 function curl_init ($url = null) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Copy a cURL handle along with all of its preferences
  * @link http://php.net/manual/en/function.curl-copy-handle.php
  * @param resource $ch 
@@ -94,7 +95,8 @@ function curl_init ($url = null) {}
 function curl_copy_handle ($ch) {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Gets cURL version information
  * @link http://php.net/manual/en/function.curl-version.php
  * @param int $age [optional] <p>
@@ -144,7 +146,8 @@ function curl_copy_handle ($ch) {}
 function curl_version ($age = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Set an option for a cURL transfer
  * @link http://php.net/manual/en/function.curl-setopt.php
  * @param resource $ch 
@@ -1294,7 +1297,7 @@ function curl_version ($age = null) {}
 function curl_setopt ($ch, $option, $value) {}
 
 /**
- * (PHP 5 &gt;= 5.1.3)<br/>
+ * @since 5.1.3
  * Set multiple options for a cURL transfer
  * @link http://php.net/manual/en/function.curl-setopt-array.php
  * @param resource $ch 
@@ -1432,7 +1435,8 @@ function curl_strerror ($errornum ) {}
  */
 function  curl_unescape ($ch, $str)  {}
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Perform a cURL session
  * @link http://php.net/manual/en/function.curl-exec.php
  * @param resource $ch 
@@ -1442,7 +1446,8 @@ function  curl_unescape ($ch, $str)  {}
 function curl_exec ($ch) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Get information regarding a specific transfer
  * @link http://php.net/manual/en/function.curl-getinfo.php
  * @param resource $ch 
@@ -1476,7 +1481,8 @@ function curl_exec ($ch) {}
 function curl_getinfo ($ch, $opt = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.3, PHP 5)<br/>
+ * @since 4.0.3
+ * @since 5.0
  * Return a string containing the last error for the current session
  * @link http://php.net/manual/en/function.curl-error.php
  * @param resource $ch 
@@ -1486,7 +1492,8 @@ function curl_getinfo ($ch, $opt = null) {}
 function curl_error ($ch) {}
 
 /**
- * (PHP 4 &gt;= 4.0.3, PHP 5)<br/>
+ * @since 4.0.3
+ * @since 5.0
  * Return the last error number
  * @link http://php.net/manual/en/function.curl-errno.php
  * @param resource $ch 
@@ -1496,7 +1503,7 @@ function curl_error ($ch) {}
 function curl_errno ($ch) {}
 
 /**
- * (PHP 5 &gt;= 5.5.0)<br/>
+ * @since 5.5.0
  * URL encodes the given string
  * @link http://www.php.net/manual/en/function.curl-escape.php
  * @param resource $ch <p>
@@ -1521,7 +1528,8 @@ function curl_escape($ch, $str) {}
 function curl_file_create($filename, $mimetype, $postname) {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Close a cURL session
  * @link http://php.net/manual/en/function.curl-close.php
  * @param resource $ch 
@@ -1530,7 +1538,7 @@ function curl_file_create($filename, $mimetype, $postname) {}
 function curl_close ($ch) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Returns a new cURL multi handle
  * @link http://php.net/manual/en/function.curl-multi-init.php
  * @return resource a cURL multi handle resource on success, false on failure.
@@ -1538,7 +1546,7 @@ function curl_close ($ch) {}
 function curl_multi_init () {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Add a normal cURL handle to a cURL multi handle
  * @link http://php.net/manual/en/function.curl-multi-add-handle.php
  * @param resource $mh 
@@ -1549,7 +1557,7 @@ function curl_multi_init () {}
 function curl_multi_add_handle ($mh, $ch) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Remove a multi handle from a set of cURL handles
  * @link http://php.net/manual/en/function.curl-multi-remove-handle.php
  * @param resource $mh 
@@ -1559,7 +1567,7 @@ function curl_multi_add_handle ($mh, $ch) {}
 function curl_multi_remove_handle ($mh, $ch) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Wait for activity on any curl_multi connection
  * @link http://php.net/manual/en/function.curl-multi-select.php
  * @param resource $mh 
@@ -1656,7 +1664,7 @@ function curl_pause ($ch, $bitmask ) {}
 function curl_reset ($ch) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Run the sub-connections of the current cURL handle
  * @link http://php.net/manual/en/function.curl-multi-exec.php
  * @param resource $mh 
@@ -1673,7 +1681,7 @@ function curl_reset ($ch) {}
 function curl_multi_exec ($mh, &$still_running) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Return the content of a cURL handle if <constant>CURLOPT_RETURNTRANSFER</constant> is set
  * @link http://php.net/manual/en/function.curl-multi-getcontent.php
  * @param resource $ch 
@@ -1682,7 +1690,7 @@ function curl_multi_exec ($mh, &$still_running) {}
 function curl_multi_getcontent ($ch) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Get information about the current transfers
  * @link http://php.net/manual/en/function.curl-multi-info-read.php
  * @param resource $mh 
@@ -1694,7 +1702,7 @@ function curl_multi_getcontent ($ch) {}
 function curl_multi_info_read ($mh, &$msgs_in_queue = null) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Close a set of cURL handles
  * @link http://php.net/manual/en/function.curl-multi-close.php
  * @param resource $mh 

--- a/curl_d.php
+++ b/curl_d.php
@@ -23,7 +23,7 @@ define ('CURLOPT_HTTPHEADER', 10023);
 define ('CURLOPT_NOPROGRESS', 43);
 
 /**
- * Available since PHP 5.3.0
+ * @since 5.3.0
  * @link http://php.net/manual/en/curl.constants.php
  */
 define ('CURLOPT_PROGRESSFUNCTION', 20056);
@@ -36,7 +36,7 @@ define ('CURLOPT_FTPAPPEND', 50);
 define ('CURLOPT_NETRC', 51);
 
 /**
- * Available since PHP 5.3.2
+ * @since 5.3.2
  * @link http://us.php.net/manual/en/function.curl-setopt.php
  */
 define ('CURLOPT_CERTINFO', -1);
@@ -71,13 +71,13 @@ define ('CURLOPT_RESUME_FROM', 21);
 define ('CURLOPT_COOKIE', 10022);
 
 /**
- * Available since PHP 5.1.0
+ * @since 5.1.0
  * @link http://php.net/manual/en/curl.constants.php
  */
 define ('CURLOPT_COOKIESESSION', 96);
 
 /**
- * Available since PHP 5.1.0
+ * @since 5.1.0
  * @link http://php.net/manual/en/curl.constants.php
  */
 define ('CURLOPT_AUTOREFERER', 58);
@@ -93,17 +93,20 @@ define ('CURL_SSLVERSION_SSLv2',2);
 define ('CURL_SSLVERSION_SSLv3',3);
 
 /**
- * Available since PHP 5.5.19 and 5.6.3
+ * @since 5.5.19
+ * @since 5.6.3
  */
 define ('CURL_SSLVERSION_TLSv1_0',4);
 
 /**
- * Available since PHP 5.5.19 and 5.6.3
+ * @since 5.5.19
+ * @since 5.6.3
  */
 define ('CURL_SSLVERSION_TLSv1_1',5);
 
 /**
- * Available since PHP 5.5.19 and 5.6.3
+ * @since 5.5.19
+ * @since 5.6.3
  */
 define('CURL_SSLVERSION_TLSv1_2', 6);
 
@@ -155,7 +158,7 @@ define ('CURLOPT_UNRESTRICTED_AUTH', 105);
 define ('CURLOPT_FTP_USE_EPRT', 106);
 
 /**
- * Available since PHP 5.2.1
+ * @since 5.2.1
  * @link http://php.net/manual/en/curl.constants.php
  */
 define ('CURLOPT_TCP_NODELAY', 121);
@@ -174,7 +177,7 @@ define ('CURLOPT_PROXYAUTH', 111);
 define ('CURLOPT_FTP_CREATE_MISSING_DIRS', 110);
 
 /**
- * Available since PHP 5.2.4
+ * @since 5.2.4
  * @link http://php.net/manual/en/curl.constants.php
  */
 define ('CURLOPT_PRIVATE', 10103);
@@ -205,13 +208,13 @@ define ('CURLINFO_REDIRECT_TIME', 3145747);
 define ('CURLINFO_REDIRECT_COUNT', 2097172);
 
 /**
- * Available since PHP 5.1.3
+ * @since 5.1.3
  * @link http://php.net/manual/en/curl.constants.php
  */
 define ('CURLINFO_HEADER_OUT', 2);
 
 /**
- * Available since PHP 5.2.4
+ * @since 5.2.4
  * @link http://php.net/manual/en/curl.constants.php
  */
 define ('CURLINFO_PRIVATE', 1048597);
@@ -303,55 +306,55 @@ define ('CURLM_INTERNAL_ERROR', 4);
 define ('CURLMSG_DONE', 1);
 
 /**
- * Available since PHP 5.1.0
+ * @since 5.1.0
  * @link http://php.net/manual/en/curl.constants.php
  */
 define ('CURLOPT_FTPSSLAUTH', 129);
 
 /**
- * Available since PHP 5.1.0
+ * @since 5.1.0
  * @link http://php.net/manual/en/curl.constants.php
  */
 define ('CURLFTPAUTH_DEFAULT', 0);
 
 /**
- * Available since PHP 5.1.0
+ * @since 5.1.0
  * @link http://php.net/manual/en/curl.constants.php
  */
 define ('CURLFTPAUTH_SSL', 1);
 
 /**
- * Available since PHP 5.1.0
+ * @since 5.1.0
  * @link http://php.net/manual/en/curl.constants.php
  */
 define ('CURLFTPAUTH_TLS', 2);
 
 /**
- * Available since PHP 5.2.0
+ * @since 5.2.0
  * @link http://php.net/manual/en/curl.constants.php
  */
 define ('CURLOPT_FTP_SSL', 119);
 
 /**
- * Available since PHP 5.2.0
+ * @since 5.2.0
  * @link http://php.net/manual/en/curl.constants.php
  */
 define ('CURLFTPSSL_NONE', 0);
 
 /**
- * Available since PHP 5.2.0
+ * @since 5.2.0
  * @link http://php.net/manual/en/curl.constants.php
  */
 define ('CURLFTPSSL_TRY', 1);
 
 /**
- * Available since PHP 5.2.0
+ * @since 5.2.0
  * @link http://php.net/manual/en/curl.constants.php
  */
 define ('CURLFTPSSL_CONTROL', 2);
 
 /**
- * Available since PHP 5.2.0
+ * @since 5.2.0
  * @link http://php.net/manual/en/curl.constants.php
  */
 define ('CURLFTPSSL_ALL', 3);
@@ -377,13 +380,13 @@ define ('CURLPROTO_TFTP', 2048);
 define ('CURLPROTO_ALL', -1);
 
 /**
- * Available since PHP 5.5.0
+ * @since 5.5.0
  * @link http://php.net/manual/en/curl.constants.php
  */
 define ('CURLMOPT_PIPELINING', 3);
 
 /**
- * Available since PHP 5.5.0
+ * @since 5.5.0
  * @link http://php.net/manual/en/curl.constants.php
  */
 define ('CURLMOPT_MAXCONNECTS', 6);

--- a/date.php
+++ b/date.php
@@ -3,7 +3,8 @@
 // Start of date v.5.3.2-0.dotdeb.1
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Parse about any English textual datetime description into a Unix timestamp
  * @link http://php.net/manual/en/function.strtotime.php
  * @param string $time <p>
@@ -20,7 +21,8 @@
 function strtotime ($time, $now = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Format a local time/date
  * @link http://php.net/manual/en/function.date.php
  * @param string $format <p>
@@ -290,7 +292,7 @@ function strtotime ($time, $now = null) {}
 function date ($format, $timestamp = null) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Format a local time/date as integer
  * @link http://php.net/manual/en/function.idate.php
  * @param string $format <p>
@@ -386,7 +388,8 @@ function date ($format, $timestamp = null) {}
 function idate ($format, $timestamp = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Format a GMT/UTC date/time
  * @link http://php.net/manual/en/function.gmdate.php
  * @param string $format <p>
@@ -401,7 +404,8 @@ function idate ($format, $timestamp = null) {}
 function gmdate ($format, $timestamp = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get Unix timestamp for a date
  * @link http://php.net/manual/en/function.mktime.php
  * @param int $hour [optional] <p>
@@ -452,7 +456,8 @@ function gmdate ($format, $timestamp = null) {}
 function mktime ($hour = null, $minute = null, $second = null, $month = null, $day = null, $year = null, $is_dst = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get Unix timestamp for a GMT date
  * @link http://php.net/manual/en/function.gmmktime.php
  * @param int $hour [optional] <p>
@@ -482,7 +487,8 @@ function mktime ($hour = null, $minute = null, $second = null, $month = null, $d
 function gmmktime ($hour = null, $minute = null, $second = null, $month = null, $day = null, $year = null, $is_dst = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Validate a Gregorian date
  * @link http://php.net/manual/en/function.checkdate.php
  * @param int $month <p>
@@ -501,7 +507,8 @@ function gmmktime ($hour = null, $minute = null, $second = null, $month = null, 
 function checkdate ($month, $day, $year) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Format a local time/date according to locale settings
  * The following characters are recognized in the
  * format parameter string
@@ -762,7 +769,8 @@ function checkdate ($month, $day, $year) {}
 function strftime ($format, $timestamp) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Format a GMT/UTC time/date according to locale settings
  * @link http://php.net/manual/en/function.gmstrftime.php
  * @param string $format <p>
@@ -778,7 +786,8 @@ function strftime ($format, $timestamp) {}
 function gmstrftime ($format, $timestamp = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Return current Unix timestamp
  * @link http://php.net/manual/en/function.time.php
  * @return int <p>Returns the current time measured in the number of seconds since the Unix Epoch (January 1 1970 00:00:00 GMT).</p>
@@ -786,7 +795,8 @@ function gmstrftime ($format, $timestamp = null) {}
 function time () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get the local time
  * @link http://php.net/manual/en/function.localtime.php
  * @param int $timestamp [optional] 
@@ -805,7 +815,8 @@ function time () {}
 function localtime ($timestamp = null, $is_associative = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get date/time information
  * @link http://php.net/manual/en/function.getdate.php
  * @param int $timestamp [optional] 
@@ -887,7 +898,7 @@ function localtime ($timestamp = null, $is_associative = null) {}
 function getdate ($timestamp = null) {}
 
 /**
- * (PHP 5 &gt;= 5.2.0)<br/>
+ * @since 5.2.0
  * Returns new DateTime object
  * @link http://php.net/manual/en/function.date-create.php
  * @param string $time [optional] <p>
@@ -917,7 +928,7 @@ function date_create ($time = null, DateTimeZone $timezone = null ) {}
 function date_create_immutable ($time = null, DateTimeZone $timezone = null ) {}
 
 /**
- * (PHP 5 &gt;= 5.3.0)<br/>
+ * @since 5.3.0
  * Alias:
  * {@see DateTime::createFromFormat}
  * @link http://php.net/manual/en/function.date-create-from-format.php
@@ -933,7 +944,7 @@ function date_create_immutable ($time = null, DateTimeZone $timezone = null ) {}
 function date_create_from_format ($format, $time, $timezone = null) {}
 
 /**
- * (PHP 5 &gt;= 5.2.0)<br/>
+ * @since 5.2.0
  * Returns associative array with detailed info about given date
  * @link http://php.net/manual/en/function.date-parse.php
  * @param string $date <p>
@@ -945,7 +956,7 @@ function date_create_from_format ($format, $time, $timezone = null) {}
 function date_parse ($date) {}
 
 /**
- * (PHP 5 &gt;= 5.3.0)<br/>
+ * @since 5.3.0
  * Get info about given date
  * @link http://php.net/manual/en/function.date-parse-from-format.php
  * @param string $format <p>
@@ -959,7 +970,7 @@ function date_parse ($date) {}
 function date_parse_from_format ($format, $date) {}
 
 /**
- * (PHP 5 &gt;= 5.3.0)<br/>
+ * @since 5.3.0
  * Alias:
  * {@see DateTime::getLastErrors}
  * @link http://php.net/manual/en/function.date-get-last-errors.php
@@ -968,7 +979,7 @@ function date_parse_from_format ($format, $date) {}
 function date_get_last_errors () {}
 
 /**
- * (PHP 5 &gt;= 5.2.0)<br/>
+ * @since 5.2.0
  * Alias:
  * {@see DateTime::format}
  * @link http://php.net/manual/en/function.date-format.php
@@ -979,7 +990,7 @@ function date_get_last_errors () {}
 function date_format ($object, $format) {}
 
 /**
- * (PHP 5 &gt;= 5.2.0)<br/>
+ * @since 5.2.0
  * Alter the timestamp of a DateTime object by incrementing or decrementing
  * in a format accepted by strtotime().
  * Alias:
@@ -992,7 +1003,7 @@ function date_format ($object, $format) {}
 function date_modify ($object, $modify) {}
 
 /**
- * (PHP 5 &gt;= 5.3.0)<br/>
+ * @since 5.3.0
  * &Alias; <methodname>DateTime::add</methodname>
  * @link http://php.net/manual/en/function.date-add.php
  * @param $object <p>Procedural style only: A
@@ -1006,7 +1017,7 @@ function date_modify ($object, $modify) {}
 function date_add ($object, $interval) {}
 
 /**
- * (PHP 5 &gt;= 5.3.0)<br/>
+ * @since 5.3.0
  * Alias:
  * {@see DateTime::sub}
  * @link http://php.net/manual/en/function.date-sub.php
@@ -1021,7 +1032,7 @@ function date_add ($object, $interval) {}
 function date_sub ($object, $interval) {}
 
 /**
- * (PHP 5 &gt;= 5.2.0)<br/>
+ * @since 5.2.0
  * Alias:
  * {@see DateTime::getTimezone}
  * @link http://php.net/manual/en/function.date-timezone-get.php
@@ -1039,7 +1050,7 @@ function date_sub ($object, $interval) {}
 function date_timezone_get ($object) {}
 
 /**
- * (PHP 5 &gt;= 5.2.0)<br/>
+ * @since 5.2.0
  * Alias:
  * {@see DateTime::setTimezone}
  * @link http://php.net/manual/en/function.date-timezone-set.php
@@ -1054,7 +1065,7 @@ function date_timezone_get ($object) {}
 function date_timezone_set ($object, $timezone) {}
 
 /**
- * (PHP 5 &gt;= 5.2.0)<br/>
+ * @since 5.2.0
  * Alias:
  * {@see DateTime::getOffset}
  * @link http://php.net/manual/en/function.date-offset-get.php
@@ -1065,7 +1076,7 @@ function date_timezone_set ($object, $timezone) {}
 function date_offset_get ($object) {}
 
 /**
- * (PHP 5 &gt;= 5.3.0)<br/>
+ * @since 5.3.0
  * Alias:
  * {@see DateTime::diff}
  * @link http://php.net/manual/en/function.date-diff.php
@@ -1077,7 +1088,7 @@ function date_offset_get ($object) {}
 function date_diff ($object, $object2, $absolute) {}
 
 /**
- * (PHP 5 &gt;= 5.2.0)<br/>
+ * @since 5.2.0
  * &Alias; <methodname>DateTime::setTime</methodname>
  * @link http://php.net/manual/en/function.date-time-set.php
  * @param $object
@@ -1090,7 +1101,7 @@ function date_diff ($object, $object2, $absolute) {}
 function date_time_set ($object, $hour, $minute, $second) {}
 
 /**
- * (PHP 5 &gt;= 5.2.0)<br/>
+ * @since 5.2.0
  * &Alias; <methodname>DateTime::setDate</methodname>
  * @link http://php.net/manual/en/function.date-date-set.php
  * @param $object <p>Procedural style only: A {@see DateTime} object
@@ -1108,7 +1119,7 @@ function date_time_set ($object, $hour, $minute, $second) {}
 function date_date_set ($object, $year, $month, $day) {}
 
 /**
- * (PHP 5 &gt;= 5.2.0)<br/>
+ * @since 5.2.0
  * Alias:
  * {@see DateTime::setISODate}
  * @link http://php.net/manual/en/function.date-isodate-set.php
@@ -1123,7 +1134,7 @@ function date_date_set ($object, $year, $month, $day) {}
 function date_isodate_set ($object, $year, $week, $day = 1) {}
 
 /**
- * (PHP 5 &gt;= 5.3.0)<br/>
+ * @since 5.3.0
  * &Alias; <methodname>DateTime::setTimestamp</methodname>
  * @link http://php.net/manual/en/function.date-timestamp-set.php
  * @param DateTime $object <p>Procedural style only: A
@@ -1136,7 +1147,7 @@ function date_isodate_set ($object, $year, $week, $day = 1) {}
 function date_timestamp_set ($object, $unixtimestamp) {}
 
 /**
- * (PHP 5 &gt;= 5.3.0)<br/>
+ * @since 5.3.0
  * Alias:
  * {@see DateTime::getTimestamp}
  * @link http://php.net/manual/en/function.date-timestamp-get.php
@@ -1146,7 +1157,7 @@ function date_timestamp_set ($object, $unixtimestamp) {}
 function date_timestamp_get ($object) {}
 
 /**
- * (PHP 5 &gt;= 5.1.0)<br/>
+ * @since 5.1.0
  * Returns new DateTimeZone object
  * @link http://php.net/manual/en/function.timezone-open.php
  * @param string $timezone <p>
@@ -1158,7 +1169,7 @@ function date_timestamp_get ($object) {}
 function timezone_open ($timezone) {}
 
 /**
- * (PHP 5 &gt;= 5.1.0)<br/>
+ * @since 5.1.0
  * Alias: {@see DateTimeZone::getName}
  * @link http://php.net/manual/en/function.timezone-name-get.php
  * @param $object <p>The
@@ -1168,7 +1179,7 @@ function timezone_open ($timezone) {}
 function timezone_name_get ($object) {}
 
 /**
- * (PHP 5 &gt;= 5.1.3)<br/>
+ * @since 5.1.3
  * Returns the timezone name from abbreviation
  * @link http://php.net/manual/en/function.timezone-name-from-abbr.php
  * @param string $abbr <p>
@@ -1190,7 +1201,7 @@ function timezone_name_get ($object) {}
 function timezone_name_from_abbr ($abbr, $gmtOffset = null, $isdst = null) {}
 
 /**
- * (PHP 5 &gt;= 5.1.0)<br/>
+ * @since 5.1.0
  * Alias:
  * {@link DateTimeZone::getOffset}
  * @link http://php.net/manual/en/function.timezone-offset-get.php
@@ -1204,7 +1215,7 @@ function timezone_name_from_abbr ($abbr, $gmtOffset = null, $isdst = null) {}
 function timezone_offset_get ($object, $datetime) {}
 
 /**
- * (PHP 5 &gt;= 5.2.0)<br/>
+ * @since 5.2.0
  * Alias:
  * {@see DateTimeZone::getTransitions}
  * @link http://php.net/manual/en/function.timezone-transitions-get.php
@@ -1218,7 +1229,7 @@ function timezone_offset_get ($object, $datetime) {}
 function timezone_transitions_get ($object, $timestamp_begin, $timestamp_end) {}
 
 /**
- * (PHP 5 &gt;= 5.3.0)<br/>
+ * @since 5.3.0
  * &Alias; {@see DateTimeZone::getLocation}
  * @link http://php.net/manual/en/function.timezone-location-get.php
  * @param $object <p>Procedural style only: A {@see DateTimeZone} object returned by {@see timezone_open()}
@@ -1227,7 +1238,7 @@ function timezone_transitions_get ($object, $timestamp_begin, $timestamp_end) {}
 function timezone_location_get ($object) {}
 
 /**
- * (PHP 5 &gt;= 5.1.0)<br/>
+ * @since 5.1.0
  * Alias:
  * {@see DateTimeZone::listIdentifiers()}
  * @link http://php.net/manual/en/function.timezone-identifiers-list.php
@@ -1239,7 +1250,7 @@ function timezone_location_get ($object) {}
 function timezone_identifiers_list ($what = DateTimeZone::ALL, $country = null) {}
 
 /**
- * (PHP 5 &gt;= 5.2.0)<br/>
+ * @since 5.2.0
  * Returns associative array containing dst, offset and the timezone name
  * Alias:
  * {@see DateTimeZone::listAbbreviations}
@@ -1249,7 +1260,7 @@ function timezone_identifiers_list ($what = DateTimeZone::ALL, $country = null) 
 function timezone_abbreviations_list () {}
 
 /**
- * (PHP 5 &gt;= 5.3.0)<br/>
+ * @since 5.3.0
  * Gets the version of the timezonedb
  * @link http://php.net/manual/en/function.timezone-version-get.php
  * @return string a string.
@@ -1257,7 +1268,7 @@ function timezone_abbreviations_list () {}
 function timezone_version_get () {}
 
 /**
- * (PHP 5 &gt;= 5.3.0)<br/>
+ * @since 5.3.0
  * Alias:
  * {@see DateInterval::createFromDateString}
  * @link http://php.net/manual/en/function.date-interval-create-from-date-string.php
@@ -1271,7 +1282,7 @@ function timezone_version_get () {}
 function date_interval_create_from_date_string ($time) {}
 
 /**
- * (PHP 5 &gt;= 5.3.0)<br/>
+ * @since 5.3.0
  * &Alias; <methodname>DateInterval::format</methodname>
  * @link http://php.net/manual/en/function.date-interval-format.php
  * @param $object
@@ -1281,7 +1292,7 @@ function date_interval_create_from_date_string ($time) {}
 function date_interval_format ($object, $format) {}
 
 /**
- * (PHP 5 &gt;= 5.1.0)<br/>
+ * @since 5.1.0
  * Sets the default timezone used by all date/time functions in a script
  * @link http://php.net/manual/en/function.date-default-timezone-set.php
  * @param string $timezone_identifier <p>
@@ -1296,7 +1307,7 @@ function date_interval_format ($object, $format) {}
 function date_default_timezone_set ($timezone_identifier) {}
 
 /**
- * (PHP 5 &gt;= 5.1.0)<br/>
+ * @since 5.1.0
  * Gets the default timezone used by all date/time functions in a script
  * @link http://php.net/manual/en/function.date-default-timezone-get.php
  * @return string a string.
@@ -1304,7 +1315,7 @@ function date_default_timezone_set ($timezone_identifier) {}
 function date_default_timezone_get () {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Returns time of sunrise for a given day and location
  * @link http://php.net/manual/en/function.date-sunrise.php
  * @param int $timestamp <p>
@@ -1354,7 +1365,7 @@ function date_default_timezone_get () {}
 function date_sunrise ($timestamp, $format = null, $latitude = null, $longitude = null, $zenith = null, $gmt_offset = null) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Returns time of sunset for a given day and location
  * @link http://php.net/manual/en/function.date-sunset.php
  * @param int $timestamp <p>
@@ -1404,7 +1415,7 @@ function date_sunrise ($timestamp, $format = null, $latitude = null, $longitude 
 function date_sunset ($timestamp, $format = null, $latitude = null, $longitude = null, $zenith = null, $gmt_offset = null) {}
 
 /**
- * (PHP 5 &gt;= 5.1.2)<br/>
+ * @since 5.1.2
  * Returns an array with information about sunset/sunrise and twilight begin/end
  * @link http://php.net/manual/en/function.date-sun-info.php
  * @param int $time <p>

--- a/dba.php
+++ b/dba.php
@@ -3,7 +3,8 @@
 // Start of dba v.
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Open database
  * @link http://php.net/manual/en/function.dba-open.php
  * @param string $path <p>
@@ -123,7 +124,8 @@
 function dba_open ($path, $mode, $handler = null, $_ = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Open database persistently
  * @link http://php.net/manual/en/function.dba-popen.php
  * @param string $path <p>
@@ -147,7 +149,8 @@ function dba_open ($path, $mode, $handler = null, $_ = null) {}
 function dba_popen ($path, $mode, $handler = null, $_ = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Close a DBA database
  * @link http://php.net/manual/en/function.dba-close.php
  * @param resource $handle <p>
@@ -159,7 +162,8 @@ function dba_popen ($path, $mode, $handler = null, $_ = null) {}
 function dba_close ($handle) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Delete DBA entry specified by key
  * @link http://php.net/manual/en/function.dba-delete.php
  * @param string $key <p>
@@ -174,7 +178,8 @@ function dba_close ($handle) {}
 function dba_delete ($key, $handle) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Check whether key exists
  * @link http://php.net/manual/en/function.dba-exists.php
  * @param string $key <p>
@@ -189,7 +194,8 @@ function dba_delete ($key, $handle) {}
 function dba_exists ($key, $handle) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Fetch data specified by key
  * @link http://php.net/manual/en/function.dba-fetch.php
  * @param string $key <p>
@@ -210,7 +216,8 @@ function dba_exists ($key, $handle) {}
 function dba_fetch ($key, $handle) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Insert entry
  * @link http://php.net/manual/en/function.dba-insert.php
  * @param string $key <p>
@@ -230,7 +237,8 @@ function dba_fetch ($key, $handle) {}
 function dba_insert ($key, $value, $handle) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Replace or insert entry
  * @link http://php.net/manual/en/function.dba-replace.php
  * @param string $key <p>
@@ -248,7 +256,8 @@ function dba_insert ($key, $value, $handle) {}
 function dba_replace ($key, $value, $handle) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Fetch first key
  * @link http://php.net/manual/en/function.dba-firstkey.php
  * @param resource $handle <p>
@@ -260,7 +269,8 @@ function dba_replace ($key, $value, $handle) {}
 function dba_firstkey ($handle) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Fetch next key
  * @link http://php.net/manual/en/function.dba-nextkey.php
  * @param resource $handle <p>
@@ -272,7 +282,8 @@ function dba_firstkey ($handle) {}
 function dba_nextkey ($handle) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Optimize database
  * @link http://php.net/manual/en/function.dba-optimize.php
  * @param resource $handle <p>
@@ -284,7 +295,8 @@ function dba_nextkey ($handle) {}
 function dba_optimize ($handle) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Synchronize database
  * @link http://php.net/manual/en/function.dba-sync.php
  * @param resource $handle <p>
@@ -296,7 +308,8 @@ function dba_optimize ($handle) {}
 function dba_sync ($handle) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * List all the handlers available
  * @link http://php.net/manual/en/function.dba-handlers.php
  * @param bool $full_info [optional] <p>
@@ -314,7 +327,8 @@ function dba_sync ($handle) {}
 function dba_handlers ($full_info = false) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * List all open database files
  * @link http://php.net/manual/en/function.dba-list.php
  * @return array An associative array, in the form resourceid =&gt; filename.
@@ -322,7 +336,7 @@ function dba_handlers ($full_info = false) {}
 function dba_list () {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Splits a key in string representation into array representation
  * @link http://php.net/manual/en/function.dba-key-split.php
  * @param mixed $key <p>

--- a/dom.php
+++ b/dom.php
@@ -4,7 +4,7 @@
 
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Gets a <b>DOMElement</b> object from a
 <b>SimpleXMLElement</b> object
  * @link http://php.net/manual/en/function.dom-import-simplexml.php

--- a/dom_c.php
+++ b/dom_c.php
@@ -10,7 +10,7 @@ class DOMNode  {
 
     /**
      * @var string
-     * (PHP 5)<br/>
+     * @since 5.0
      * Returns the most accurate name for the current node type
      * @link http://php.net/manual/en/class.domnode.php#domnode.props.nodename
      */
@@ -18,7 +18,7 @@ class DOMNode  {
 
     /**
      * @var string
-     * (PHP 5)<br/>
+     * @since 5.0
      * The value of this node, depending on its type
      * @link http://php.net/manual/en/class.domnode.php#domnode.props.nodevalue
      */
@@ -26,7 +26,7 @@ class DOMNode  {
 
     /**
      * @var int
-     * (PHP 5)<br/>
+     * @since 5.0
      * Gets the type of the node. One of the predefined
      * <a href="http://www.php.net/manual/en/dom.constants.php">XML_xxx_NODE</a> constants
      * @link http://php.net/manual/en/class.domnode.php#domnode.props.nodetype
@@ -35,7 +35,7 @@ class DOMNode  {
 
     /**
      * @var DOMNode
-     * (PHP 5)<br/>
+     * @since 5.0
      * The parent of this node
      * @link http://php.net/manual/en/class.domnode.php#domnode.props.parentnode
      */
@@ -43,7 +43,7 @@ class DOMNode  {
 
     /**
      * @var DOMNodeList
-     * (PHP 5)<br/>
+     * @since 5.0
      * A <classname>DOMNodeList</classname> that contains all children of this node. If there are no children, this is an empty <classname>DOMNodeList</classname>.
      * @link http://php.net/manual/en/class.domnode.php#domnode.props.childnodes
      */
@@ -51,7 +51,7 @@ class DOMNode  {
 
     /**
      * @var DOMNode
-     * (PHP 5)<br/>
+     * @since 5.0
      * The first child of this node. If there is no such node, this returns NULL.
      * @link http://php.net/manual/en/class.domnode.php#domnode.props.firstchild
      */
@@ -59,7 +59,7 @@ class DOMNode  {
 
     /**
      * @var DOMNode
-     * (PHP 5)<br/>
+     * @since 5.0
      * The last child of this node. If there is no such node, this returns NULL.
      * @link http://php.net/manual/en/class.domnode.php#domnode.props.lastchild
      */
@@ -67,7 +67,7 @@ class DOMNode  {
 
     /**
      * @var DOMNode
-     * (PHP 5)<br/>
+     * @since 5.0
      * The node immediately preceding this node. If there is no such node, this returns NULL.
      * @link http://php.net/manual/en/class.domnode.php#domnode.props.previoussibling
      */
@@ -75,7 +75,7 @@ class DOMNode  {
 
     /**
      * @var DOMNode
-     * (PHP 5)<br/>
+     * @since 5.0
      * The node immediately following this node. If there is no such node, this returns NULL.
      * @link http://php.net/manual/en/class.domnode.php#domnode.props.nextsibling
      */
@@ -83,7 +83,7 @@ class DOMNode  {
 
     /**
      * @var DOMNamedNodeMap
-     * (PHP 5)<br/>
+     * @since 5.0
      * A <classname>DOMNamedNodeMap</classname> containing the attributes of this node (if it is a <classname>DOMElement</classname>) or NULL otherwise.
      * @link http://php.net/manual/en/class.domnode.php#domnode.props.attributes
      */
@@ -91,7 +91,7 @@ class DOMNode  {
 
     /**
      * @var DOMDocument
-     * (PHP 5)<br/>
+     * @since 5.0
      * The <classname>DOMDocument</classname> object associated with this node.
      * @link http://php.net/manual/en/class.domnode.php#domnode.props.ownerdocument
      */
@@ -99,7 +99,7 @@ class DOMNode  {
 
     /**
      * @var string
-     * (PHP 5)<br/>
+     * @since 5.0
      * The namespace URI of this node, or NULL if it is unspecified.
      * @link http://php.net/manual/en/class.domnode.php#domnode.props.namespaceuri
      */
@@ -107,7 +107,7 @@ class DOMNode  {
 
     /**
      * @var string
-     * (PHP 5)<br/>
+     * @since 5.0
      * The namespace prefix of this node, or NULL if it is unspecified.
      * @link http://php.net/manual/en/class.domnode.php#domnode.props.prefix
      */
@@ -115,7 +115,7 @@ class DOMNode  {
 
     /**
      * @var string
-     * (PHP 5)<br/>
+     * @since 5.0
      * Returns the local part of the qualified name of this node.
      * @link http://php.net/manual/en/class.domnode.php#domnode.props.localname
      */
@@ -123,7 +123,7 @@ class DOMNode  {
 
     /**
      * @var string
-     * (PHP 5)<br/>
+     * @since 5.0
      * The absolute base URI of this node or NULL if the implementation wasn't able to obtain an absolute URI.
      * @link http://php.net/manual/en/class.domnode.php#domnode.props.baseuri
      */
@@ -131,14 +131,14 @@ class DOMNode  {
 
     /**
      * @var string
-     * (PHP 5)<br/>
+     * @since 5.0
      * This attribute returns the text content of this node and its descendants.
      * @link http://php.net/manual/en/class.domnode.php#domnode.props.textcontent
      */
     public $textContent;
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Adds a new child before a reference node
      * @link http://php.net/manual/en/domnode.insertbefore.php
      * @param DOMNode $newnode <p>
@@ -153,7 +153,7 @@ class DOMNode  {
     public function insertBefore (DOMNode $newnode, DOMNode $refnode = null) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Replaces a child
      * @link http://php.net/manual/en/domnode.replacechild.php
      * @param DOMNode $newnode <p>
@@ -169,7 +169,7 @@ class DOMNode  {
     public function replaceChild (DOMNode $newnode , DOMNode $oldnode ) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Removes child from list of children
      * @link http://php.net/manual/en/domnode.removechild.php
      * @param DOMNode $oldnode <p>
@@ -180,7 +180,7 @@ class DOMNode  {
     public function removeChild (DOMNode $oldnode ) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Adds new child at the end of the children
      * @link http://php.net/manual/en/domnode.appendchild.php
      * @param DOMNode $newnode <p>
@@ -191,7 +191,7 @@ class DOMNode  {
     public function appendChild (DOMNode $newnode ) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Checks if node has children
      * @link http://php.net/manual/en/domnode.haschildnodes.php
      * @return bool true on success or false on failure.
@@ -199,7 +199,7 @@ class DOMNode  {
     public function hasChildNodes () {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Clones a node
      * @link http://php.net/manual/en/domnode.clonenode.php
      * @param bool $deep [optional] <p>
@@ -211,7 +211,7 @@ class DOMNode  {
     public function cloneNode ($deep = null) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Normalizes the node
      * @link http://php.net/manual/en/domnode.normalize.php
      * @return void
@@ -219,7 +219,7 @@ class DOMNode  {
     public function normalize () {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Checks if feature is supported for specified version
      * @link http://php.net/manual/en/domnode.issupported.php
      * @param string $feature <p>
@@ -235,7 +235,7 @@ class DOMNode  {
     public function isSupported ($feature, $version) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Checks if node has attributes
      * @link http://php.net/manual/en/domnode.hasattributes.php
      * @return bool true on success or false on failure.
@@ -248,7 +248,7 @@ class DOMNode  {
     public function compareDocumentPosition (DOMNode $other) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Indicates if two nodes are the same node
      * @link http://php.net/manual/en/domnode.issamenode.php
      * @param DOMNode $node <p>
@@ -259,7 +259,7 @@ class DOMNode  {
     public function isSameNode (DOMNode $node ) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Gets the namespace prefix of the node based on the namespace URI
      * @link http://php.net/manual/en/domnode.lookupprefix.php
      * @param string $namespaceURI <p>
@@ -270,7 +270,7 @@ class DOMNode  {
     public function lookupPrefix ($namespaceURI) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Checks if the specified namespaceURI is the default namespace or not
      * @link http://php.net/manual/en/domnode.isdefaultnamespace.php
      * @param string $namespaceURI <p>
@@ -282,7 +282,7 @@ class DOMNode  {
     public function isDefaultNamespace ($namespaceURI) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Gets the namespace URI of the node based on the prefix
      * @link http://php.net/manual/en/domnode.lookupnamespaceuri.php
      * @param string $prefix <p>
@@ -319,7 +319,7 @@ class DOMNode  {
     public function getUserData ($key) {}
 
     /**
-     * (PHP 5 &gt;= 5.3.0)<br/>
+     * @since 5.3.0
      * Gets an XPath location path for the node
      * @return string the XPath, or NULL in case of an error.
      * @link http://www.php.net/manual/en/domnode.getnodepath.php
@@ -328,7 +328,7 @@ class DOMNode  {
 
 
 	/**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
 	 * Get line number for a node
 	 * @link http://php.net/manual/en/domnode.getlineno.php
 	 * @return int Always returns the line number where the node was defined in.
@@ -367,7 +367,7 @@ class DOMException extends Exception  {
 
     /**
      * @var
-     * (PHP 5)<br/>
+     * @since 5.0
      * An integer indicating the type of error generated
      * @link http://php.net/manual/en/class.domexception.php#domexception.props.code
      */
@@ -438,7 +438,7 @@ class DOMImplementationSource  {
 class DOMImplementation  {
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Creates a new DOMImplementation object
      * @link http://http://php.net/manual/en/domimplementation.construct.php
      */
@@ -452,7 +452,7 @@ class DOMImplementation  {
     public function getFeature ($feature, $version) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Test if the DOM implementation implements a specific feature
 	 * @link http://php.net/manual/en/domimplementation.hasfeature.php
 	 * @param string $feature <p>
@@ -468,7 +468,7 @@ class DOMImplementation  {
 	public function hasFeature ($feature, $version) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Creates an empty DOMDocumentType object
      * @link http://php.net/manual/en/domimplementation.createdocumenttype.php
      * @param string $qualifiedName [optional] <p>
@@ -486,7 +486,7 @@ class DOMImplementation  {
     public function createDocumentType ($qualifiedName = null, $publicId = null, $systemId = null) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Creates a DOMDocument object of the specified type with its document element
      * @link http://php.net/manual/en/domimplementation.createdocument.php
      * @param string $namespaceURI [optional] <p>
@@ -520,7 +520,7 @@ class DOMDocumentFragment extends DOMNode  {
     public function __construct () {}
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Append raw XML data
      * @link http://php.net/manual/en/domdocumentfragment.appendxml.php
      * @param string $data <p>
@@ -541,7 +541,7 @@ class DOMDocument extends DOMNode  {
 
     /**
      * @var string
-     * (PHP 5)<br/>
+     * @since 5.0
      * Deprecated. Actual encoding of the document, is a readonly equivalent to encoding.
      * @link http://php.net/manual/class.domdocument.php#domdocument.props.actualencoding
      * @deprecated
@@ -550,7 +550,7 @@ class DOMDocument extends DOMNode  {
 
     /**
      * @var DOMConfiguration
-     * (PHP 5)<br/>
+     * @since 5.0
      * Deprecated. Configuration used when {@link DOMDocument::normalizeDocument()} is invoked.
      * @link http://php.net/manual/class.domdocument.php#domdocument.props.config
      * @deprecated
@@ -559,7 +559,7 @@ class DOMDocument extends DOMNode  {
 
     /**
      * @var DOMDocumentType
-     * (PHP 5)<br/>
+     * @since 5.0
      * The Document Type Declaration associated with this document.
      * @link http://php.net/manual/class.domdocument.php#domdocument.props.doctype
      */
@@ -567,7 +567,7 @@ class DOMDocument extends DOMNode  {
 
     /**
      * @var DOMElement
-     * (PHP 5)<br/>
+     * @since 5.0
      * This is a convenience attribute that allows direct access to the child node
      * that is the document element of the document.
      * @link http://php.net/manual/class.domdocument.php#domdocument.props.documentelement
@@ -576,7 +576,7 @@ class DOMDocument extends DOMNode  {
 
     /**
      * @var string
-     * (PHP 5)<br/>
+     * @since 5.0
      * The location of the document or NULL if undefined.
      * @link http://php.net/manual/class.domdocument.php#domdocument.props.documenturi
      */
@@ -584,7 +584,7 @@ class DOMDocument extends DOMNode  {
 
     /**
      * @var string
-     * (PHP 5)<br/>
+     * @since 5.0
      * Encoding of the document, as specified by the XML declaration. This attribute is not present
      * in the final DOM Level 3 specification, but is the only way of manipulating XML document
      * encoding in this implementation.
@@ -594,7 +594,7 @@ class DOMDocument extends DOMNode  {
 
     /**
      * @var bool
-     * (PHP 5)<br/>
+     * @since 5.0
      * Nicely formats output with indentation and extra space.
      * @link http://php.net/manual/class.domdocument.php#domdocument.props.formatoutput
      */
@@ -602,7 +602,7 @@ class DOMDocument extends DOMNode  {
 
     /**
      * @var DOMImplementation
-     * (PHP 5)<br/>
+     * @since 5.0
      * The <classname>DOMImplementation</classname> object that handles this document.
      * @link http://php.net/manual/class.domdocument.php#domdocument.props.implementation
      */
@@ -610,7 +610,7 @@ class DOMDocument extends DOMNode  {
 
     /**
      * @var bool
-     * (PHP 5)<br/>
+     * @since 5.0
      * Do not remove redundant white space. Default to TRUE.
      * @link http://php.net/manual/class.domdocument.php#domdocument.props.preservewhitespace
      */
@@ -618,7 +618,7 @@ class DOMDocument extends DOMNode  {
 
     /**
      * @var bool
-     * (PHP 5)<br/>
+     * @since 5.0
      * Proprietary. Enables recovery mode, i.e. trying to parse non-well formed documents.
      * This attribute is not part of the DOM specification and is specific to libxml.
      * @link http://php.net/manual/class.domdocument.php#domdocument.props.recover
@@ -627,7 +627,7 @@ class DOMDocument extends DOMNode  {
 
     /**
      * @var bool
-     * (PHP 5)<br/>
+     * @since 5.0
      * Set it to TRUE to load external entities from a doctype declaration. This is useful for
      * including character entities in your XML document.
      * @link http://php.net/manual/class.domdocument.php#domdocument.props.resolveexternals
@@ -636,7 +636,7 @@ class DOMDocument extends DOMNode  {
 
     /**
      * @var bool
-     * (PHP 5)<br/>
+     * @since 5.0
      * Deprecated. Whether or not the document is standalone, as specified by the XML declaration,
      * corresponds to xmlStandalone.
      * @link http://php.net/manual/class.domdocument.php#domdocument.props.standalone
@@ -646,7 +646,7 @@ class DOMDocument extends DOMNode  {
 
     /**
      * @var bool
-     * (PHP 5)<br/>
+     * @since 5.0
      * Throws <classname>DOMException</classname> on errors. Default to TRUE.
      * @link http://php.net/manual/class.domdocument.php#domdocument.props.stricterrorchecking
      */
@@ -654,7 +654,7 @@ class DOMDocument extends DOMNode  {
 
     /**
      * @var bool
-     * (PHP 5)<br/>
+     * @since 5.0
      * Proprietary. Whether or not to substitute entities. This attribute is not part of the DOM
      * specification and is specific to libxml.
      * @link http://php.net/manual/class.domdocument.php#domdocument.props.substituteentities
@@ -663,7 +663,7 @@ class DOMDocument extends DOMNode  {
 
     /**
      * @var bool
-     * (PHP 5)<br/>
+     * @since 5.0
      * Loads and validates against the DTD. Default to FALSE.
      * @link http://php.net/manual/class.domdocument.php#domdocument.props.validateonparse
      */
@@ -671,7 +671,7 @@ class DOMDocument extends DOMNode  {
 
     /**
      * @var string
-     * (PHP 5)<br/>
+     * @since 5.0
      * Deprecated. Version of XML, corresponds to xmlVersion
      * @link http://php.net/manual/class.domdocument.php#domdocument.props.version
      */
@@ -679,7 +679,7 @@ class DOMDocument extends DOMNode  {
 
     /**
      * @var string
-     * (PHP 5)<br/>
+     * @since 5.0
      * An attribute specifying, as part of the XML declaration, the encoding of this document. This is NULL when
      * unspecified or when it is not known, such as when the Document was created in memory.
      * @link http://php.net/manual/class.domdocument.php#domdocument.props.xmlencoding
@@ -688,7 +688,7 @@ class DOMDocument extends DOMNode  {
 
     /**
      * @var bool
-     * (PHP 5)<br/>
+     * @since 5.0
      * An attribute specifying, as part of the XML declaration, whether this document is standalone.
      * This is FALSE when unspecified.
      * @link http://php.net/manual/class.domdocument.php#domdocument.props.xmlstandalone
@@ -697,7 +697,7 @@ class DOMDocument extends DOMNode  {
 
     /**
      * @var string
-     * (PHP 5)<br/>
+     * @since 5.0
      * An attribute specifying, as part of the XML declaration, the version number of this document. If there is no
      * declaration and if this document supports the "XML" feature, the value is "1.0".
      * @link http://php.net/manual/class.domdocument.php#domdocument.props.xmlversion
@@ -705,7 +705,7 @@ class DOMDocument extends DOMNode  {
     public $xmlVersion ;
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Create new element node
      * @link http://php.net/manual/domdocument.createelement.php
      * @param string $name <p>
@@ -721,7 +721,7 @@ class DOMDocument extends DOMNode  {
     public function createElement ($name, $value = null) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Create new document fragment
      * @link http://php.net/manual/domdocument.createdocumentfragment.php
      * @return DOMDocumentFragment The new DOMDocumentFragment or false if an error occured.
@@ -729,7 +729,7 @@ class DOMDocument extends DOMNode  {
     public function createDocumentFragment () {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Create new text node
      * @link http://php.net/manual/domdocument.createtextnode.php
      * @param string $content <p>
@@ -740,7 +740,7 @@ class DOMDocument extends DOMNode  {
     public function createTextNode ($content) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Create new comment node
      * @link http://php.net/manual/domdocument.createcomment.php
      * @param string $data <p>
@@ -751,7 +751,7 @@ class DOMDocument extends DOMNode  {
     public function createComment ($data) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Create new cdata node
      * @link http://php.net/manual/domdocument.createcdatasection.php
      * @param string $data <p>
@@ -762,7 +762,7 @@ class DOMDocument extends DOMNode  {
     public function createCDATASection ($data) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Creates new PI node
      * @link http://php.net/manual/domdocument.createprocessinginstruction.php
      * @param string $target <p>
@@ -776,7 +776,7 @@ class DOMDocument extends DOMNode  {
     public function createProcessingInstruction ($target, $data = null) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Create new attribute
      * @link http://php.net/manual/domdocument.createattribute.php
      * @param string $name <p>
@@ -787,7 +787,7 @@ class DOMDocument extends DOMNode  {
     public function createAttribute ($name) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Create new entity reference node
      * @link http://php.net/manual/domdocument.createentityreference.php
      * @param string $name <p>
@@ -801,7 +801,7 @@ class DOMDocument extends DOMNode  {
     public function createEntityReference ($name) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Searches for all elements with given tag name
      * @link http://php.net/manual/domdocument.getelementsbytagname.php
      * @param string $name <p>
@@ -814,7 +814,7 @@ class DOMDocument extends DOMNode  {
     public function getElementsByTagName ($name) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Import node into current document
      * @link http://php.net/manual/domdocument.importnode.php
      * @param DOMNode $importedNode <p>
@@ -832,7 +832,7 @@ class DOMDocument extends DOMNode  {
     public function importNode (DOMNode $importedNode , $deep = null) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Create new element node with an associated namespace
      * @link http://php.net/manual/domdocument.createelementns.php
      * @param string $namespaceURI <p>
@@ -850,7 +850,7 @@ class DOMDocument extends DOMNode  {
     public function createElementNS ($namespaceURI, $qualifiedName, $value = null) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Create new attribute node with an associated namespace
      * @link http://php.net/manual/domdocument.createattributens.php
      * @param string $namespaceURI <p>
@@ -864,7 +864,7 @@ class DOMDocument extends DOMNode  {
     public function createAttributeNS ($namespaceURI, $qualifiedName) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Searches for all elements with given tag name in specified namespace
      * @link http://php.net/manual/domdocument.getelementsbytagnamens.php
      * @param string $namespaceURI <p>
@@ -881,7 +881,7 @@ class DOMDocument extends DOMNode  {
     public function getElementsByTagNameNS ($namespaceURI, $localName) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Searches for an element with a certain id
      * @link http://php.net/manual/domdocument.getelementbyid.php
      * @param string $elementId <p>
@@ -898,7 +898,7 @@ class DOMDocument extends DOMNode  {
     public function adoptNode (DOMNode $source) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Normalizes the document
      * @link http://php.net/manual/domdocument.normalizedocument.php
      * @return void
@@ -913,7 +913,7 @@ class DOMDocument extends DOMNode  {
     public function renameNode (DOMNode $node, $namespaceURI, $qualifiedName) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Load XML from a file
      * @link http://php.net/manual/domdocument.load.php
      * @param string $filename <p>
@@ -930,7 +930,7 @@ class DOMDocument extends DOMNode  {
     public function load ($filename, $options = null) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Dumps the internal XML tree back into a file
      * @link http://php.net/manual/domdocument.save.php
      * @param string $filename <p>
@@ -944,7 +944,7 @@ class DOMDocument extends DOMNode  {
     public function save ($filename, $options = null) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Load XML from a string
      * @link http://php.net/manual/domdocument.loadxml.php
      * @param string $source <p>
@@ -961,7 +961,7 @@ class DOMDocument extends DOMNode  {
     public function loadXML ($source, $options = null) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Dumps the internal XML tree back into a string
      * @link http://php.net/manual/domdocument.savexml.php
      * @param DOMNode $node [optional] <p>
@@ -976,7 +976,7 @@ class DOMDocument extends DOMNode  {
     public function saveXML ($node = null , $options = null) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Creates a new DOMDocument object
      * @link http://php.net/manual/domdocument.construct.php
      * @param $version [optional] The version number of the document as part of the XML declaration.
@@ -985,7 +985,7 @@ class DOMDocument extends DOMNode  {
     public function __construct ($version, $encoding) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Validates the document based on its DTD
      * @link http://php.net/manual/domdocument.validate.php
      * @return bool true on success or false on failure.
@@ -994,7 +994,7 @@ class DOMDocument extends DOMNode  {
     public function validate () {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Substitutes XIncludes in a DOMDocument Object
      * @link http://php.net/manual/domdocument.xinclude.php
      * @param int $options [optional] <p>
@@ -1006,7 +1006,7 @@ class DOMDocument extends DOMNode  {
     public function xinclude ($options = null) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Load HTML from a string
      * @link http://php.net/manual/domdocument.loadhtml.php
      * @param string $source <p>
@@ -1019,7 +1019,7 @@ class DOMDocument extends DOMNode  {
     public function loadHTML ($source) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Load HTML from a file
      * @link http://php.net/manual/domdocument.loadhtmlfile.php
      * @param string $filename <p>
@@ -1032,7 +1032,7 @@ class DOMDocument extends DOMNode  {
     public function loadHTMLFile ($filename) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Dumps the internal document into a string using HTML formatting
      * @link http://php.net/manual/domdocument.savehtml.php
      * @return string the HTML, or false if an error occurred.
@@ -1040,7 +1040,7 @@ class DOMDocument extends DOMNode  {
     public function saveHTML () {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Dumps the internal document into a file using HTML formatting
      * @link http://php.net/manual/domdocument.savehtmlfile.php
      * @param string $filename <p>
@@ -1051,7 +1051,7 @@ class DOMDocument extends DOMNode  {
     public function saveHTMLFile ($filename) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Validates a document based on a schema
      * @link http://php.net/manual/domdocument.schemavalidate.php
      * @param string $filename <p>
@@ -1062,7 +1062,7 @@ class DOMDocument extends DOMNode  {
     public function schemaValidate ($filename) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Validates a document based on a schema
      * @link http://php.net/manual/domdocument.schemavalidatesource.php
      * @param string $source <p>
@@ -1073,7 +1073,7 @@ class DOMDocument extends DOMNode  {
     public function schemaValidateSource ($source) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Performs relaxNG validation on the document
      * @link http://php.net/manual/domdocument.relaxngvalidate.php
      * @param string $filename <p>
@@ -1084,7 +1084,7 @@ class DOMDocument extends DOMNode  {
     public function relaxNGValidate ($filename) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Performs relaxNG validation on the document
      * @link http://php.net/manual/domdocument.relaxngvalidatesource.php
      * @param string $source <p>
@@ -1095,7 +1095,7 @@ class DOMDocument extends DOMNode  {
     public function relaxNGValidateSource ($source) {}
 
     /**
-     * (PHP 5 &gt;= 5.2.0)<br/>
+     * @since 5.2.0
      * Register extended class used to create base node type
      * @link http://php.net/manual/domdocument.registernodeclass.php
      * @param string $baseclass <p>
@@ -1121,14 +1121,14 @@ class DOMNodeList implements Traversable {
 
     /**
      * @var int
-     * (PHP 5)<br/>
+     * @since 5.0
      * The number of nodes in the list. The range of valid child node indices is 0 to length - 1 inclusive.
      * @link http://php.net/manual/en/class.domnodelist.php#domnodelist.props.length
      */
     public $length;
 
   /**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Retrieves a node specified by index
 	 * @link http://php.net/manual/en/domnodelist.item.php
 	 * @param int $index <p>
@@ -1150,7 +1150,7 @@ class DOMNodeList implements Traversable {
 class DOMNamedNodeMap  {
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Retrieves a node specified by name
      * @link http://php.net/manual/en/domnamednodemap.getnameditem.php
      * @param string $name <p>
@@ -1172,7 +1172,7 @@ class DOMNamedNodeMap  {
     public function removeNamedItem ($name) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Retrieves a node specified by index
      * @link http://php.net/manual/en/domnamednodemap.item.php
      * @param int $index <p>
@@ -1185,7 +1185,7 @@ class DOMNamedNodeMap  {
     public function item ($index) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Retrieves a node specified by local name and namespace URI
      * @link http://php.net/manual/en/domnamednodemap.getnameditemns.php
      * @param string $namespaceURI <p>
@@ -1222,7 +1222,7 @@ class DOMCharacterData extends DOMNode  {
 
     /**
      * @var string
-     * (PHP 5)<br/>
+     * @since 5.0
      * The contents of the node.
      * @link http://php.net/manual/en/class.domcharacterdata.php#domcharacterdata.props.data
      */
@@ -1230,14 +1230,14 @@ class DOMCharacterData extends DOMNode  {
 
     /**
      * @var int
-     * (PHP 5)<br/>
+     * @since 5.0
      * The length of the contents.
      * @link http://php.net/manual/en/class.domcharacterdata.php#domcharacterdata.props.length
      */
     public $length;
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Extracts a range of data from the node
      * @link http://php.net/manual/en/domcharacterdata.substringdata.php
      * @param int $offset <p>
@@ -1253,7 +1253,7 @@ class DOMCharacterData extends DOMNode  {
     public function substringData ($offset, $count) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Append the string to the end of the character data of the node
      * @link http://php.net/manual/en/domcharacterdata.appenddata.php
      * @param string $data <p>
@@ -1264,7 +1264,7 @@ class DOMCharacterData extends DOMNode  {
     public function appendData ($data) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Insert a string at the specified 16-bit unit offset
      * @link http://php.net/manual/en/domcharacterdata.insertdata.php
      * @param int $offset <p>
@@ -1278,7 +1278,7 @@ class DOMCharacterData extends DOMNode  {
     public function insertData ($offset, $data) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Remove a range of characters from the node
      * @link http://php.net/manual/en/domcharacterdata.deletedata.php
      * @param int $offset <p>
@@ -1294,7 +1294,7 @@ class DOMCharacterData extends DOMNode  {
     public function deleteData ($offset, $count) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Replace a substring within the DOMCharacterData node
      * @link http://php.net/manual/en/domcharacterdata.replacedata.php
      * @param int $offset <p>
@@ -1362,7 +1362,7 @@ class DOMAttr extends DOMNode
     public $value;
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Checks if attribute is a defined ID
      * @link http://php.net/manual/en/domattr.isid.php
      * @return bool true on success or false on failure.
@@ -1370,7 +1370,7 @@ class DOMAttr extends DOMNode
     public function isId() {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Creates a new <classname>DOMAttr</classname> object
      * @link http://php.net/manual/en/domattr.construct.php
      * @param $name
@@ -1388,7 +1388,7 @@ class DOMElement extends DOMNode  {
 
     /**
      * @var DOMElement
-     * (PHP 5)<br/>
+     * @since 5.0
      * The parent of this node
      * @link http://php.net/manual/en/class.domnode.php#domnode.props.parentnode
      */
@@ -1396,7 +1396,7 @@ class DOMElement extends DOMNode  {
 
     /**
      * @var DOMElement
-     * (PHP 5)<br/>
+     * @since 5.0
      * The first child of this node. If there is no such node, this returns NULL.
      * @link http://php.net/manual/en/class.domnode.php#domnode.props.firstchild
      */
@@ -1404,7 +1404,7 @@ class DOMElement extends DOMNode  {
 
     /**
      * @var DOMElement
-     * (PHP 5)<br/>
+     * @since 5.0
      * The last child of this node. If there is no such node, this returns NULL.
      * @link http://php.net/manual/en/class.domnode.php#domnode.props.lastchild
      */
@@ -1412,7 +1412,7 @@ class DOMElement extends DOMNode  {
 
     /**
      * @var DOMElement
-     * (PHP 5)<br/>
+     * @since 5.0
      * The node immediately preceding this node. If there is no such node, this returns NULL.
      * @link http://php.net/manual/en/class.domnode.php#domnode.props.previoussibling
      */
@@ -1420,7 +1420,7 @@ class DOMElement extends DOMNode  {
 
     /**
      * @var DOMElement
-     * (PHP 5)<br/>
+     * @since 5.0
      * The node immediately following this node. If there is no such node, this returns NULL.
      * @link http://php.net/manual/en/class.domnode.php#domnode.props.nextsibling
      */
@@ -1428,7 +1428,7 @@ class DOMElement extends DOMNode  {
 
     /**
      * @var bool
-     * (PHP 5)<br/>
+     * @since 5.0
      * Not implemented yet, always return NULL
      * @link http://php.net/manual/en/class.domelement.php#domelement.props.schematypeinfo
      */
@@ -1436,14 +1436,14 @@ class DOMElement extends DOMNode  {
 
     /**
      * @var string
-     * (PHP 5)<br/>
+     * @since 5.0
      * The element name
      * @link http://php.net/manual/en/class.domelement.php#domelement.props.tagname
      */
     public $tagName ;
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Returns value of attribute
      * @link http://php.net/manual/en/domelement.getattribute.php
      * @param string $name <p>
@@ -1455,7 +1455,7 @@ class DOMElement extends DOMNode  {
     public function getAttribute ($name) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Adds new attribute
      * @link http://php.net/manual/en/domelement.setattribute.php
      * @param string $name <p>
@@ -1469,7 +1469,7 @@ class DOMElement extends DOMNode  {
     public function setAttribute ($name, $value) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Removes attribute
      * @link http://php.net/manual/en/domelement.removeattribute.php
      * @param string $name <p>
@@ -1480,7 +1480,7 @@ class DOMElement extends DOMNode  {
     public function removeAttribute ($name) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Returns attribute node
      * @link http://php.net/manual/en/domelement.getattributenode.php
      * @param string $name <p>
@@ -1491,7 +1491,7 @@ class DOMElement extends DOMNode  {
     public function getAttributeNode ($name) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Adds new attribute node to element
      * @link http://php.net/manual/en/domelement.setattributenode.php
      * @param DOMAttr $attr <p>
@@ -1502,7 +1502,7 @@ class DOMElement extends DOMNode  {
     public function setAttributeNode ($attrDOMAttr ) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Removes attribute
      * @link http://php.net/manual/en/domelement.removeattributenode.php
      * @param DOMAttr $oldnode <p>
@@ -1513,7 +1513,7 @@ class DOMElement extends DOMNode  {
     public function removeAttributeNode ($oldnodeDOMAttr ) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Gets elements by tagname
      * @link http://php.net/manual/en/domelement.getelementsbytagname.php
      * @param string $name <p>
@@ -1526,7 +1526,7 @@ class DOMElement extends DOMNode  {
     public function getElementsByTagName ($name) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Returns value of attribute
      * @link http://php.net/manual/en/domelement.getattributens.php
      * @param string $namespaceURI <p>
@@ -1542,7 +1542,7 @@ class DOMElement extends DOMNode  {
     public function getAttributeNS ($namespaceURI, $localName) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Adds new attribute
      * @link http://php.net/manual/en/domelement.setattributens.php
      * @param string $namespaceURI <p>
@@ -1559,7 +1559,7 @@ class DOMElement extends DOMNode  {
     public function setAttributeNS ($namespaceURI, $qualifiedName, $value) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Removes attribute
      * @link http://php.net/manual/en/domelement.removeattributens.php
      * @param string $namespaceURI <p>
@@ -1573,7 +1573,7 @@ class DOMElement extends DOMNode  {
     public function removeAttributeNS ($namespaceURI, $localName) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Returns attribute node
      * @link http://php.net/manual/en/domelement.getattributenodens.php
      * @param string $namespaceURI <p>
@@ -1587,7 +1587,7 @@ class DOMElement extends DOMNode  {
     public function getAttributeNodeNS ($namespaceURI, $localName) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Adds new attribute node to element
      * @link http://php.net/manual/en/domelement.setattributenodens.php
      * @param DOMAttr $attr
@@ -1596,7 +1596,7 @@ class DOMElement extends DOMNode  {
     public function setAttributeNodeNS ($attrDOMAttr ) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Get elements by namespaceURI and localName
      * @link http://php.net/manual/en/domelement.getelementsbytagnamens.php
      * @param string $namespaceURI <p>
@@ -1613,7 +1613,7 @@ class DOMElement extends DOMNode  {
     public function getElementsByTagNameNS ($namespaceURI, $localName) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Checks to see if attribute exists
      * @link http://php.net/manual/en/domelement.hasattribute.php
      * @param string $name <p>
@@ -1624,7 +1624,7 @@ class DOMElement extends DOMNode  {
     public function hasAttribute ($name) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Checks to see if attribute exists
      * @link http://php.net/manual/en/domelement.hasattributens.php
      * @param string $namespaceURI <p>
@@ -1638,7 +1638,7 @@ class DOMElement extends DOMNode  {
     public function hasAttributeNS ($namespaceURI, $localName) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Declares the attribute specified by name to be of type ID
      * @link http://php.net/manual/en/domelement.setidattribute.php
      * @param string $name <p>
@@ -1653,7 +1653,7 @@ class DOMElement extends DOMNode  {
     public function setIdAttribute ($name, $isId) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Declares the attribute specified by local name and namespace URI to be of type ID
      * @link http://php.net/manual/en/domelement.setidattributens.php
      * @param string $namespaceURI <p>
@@ -1671,7 +1671,7 @@ class DOMElement extends DOMNode  {
     public function setIdAttributeNS ($namespaceURI, $localName, $isId) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Declares the attribute specified by node to be of type ID
      * @link http://php.net/manual/en/domelement.setidattributenode.php
      * @param DOMAttr $attr <p>
@@ -1686,7 +1686,7 @@ class DOMElement extends DOMNode  {
     public function setIdAttributeNode ($attrDOMAttr , $isId) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Creates a new DOMElement object
      * @link http://php.net/manual/en/domelement.construct.php
      * @param $name string The tag name of the element. When also passing in namespaceURI, the element name may take a prefix to be associated with the URI.
@@ -1696,7 +1696,7 @@ class DOMElement extends DOMNode  {
     public function __construct ($name, $value, $uri) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Adds a new child before a reference node
      * @link http://php.net/manual/en/domnode.insertbefore.php
      * @param DOMNode $newnode <p>
@@ -1711,7 +1711,7 @@ class DOMElement extends DOMNode  {
     public function insertBefore (DOMNode $newnode , $refnode = null) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Replaces a child
      * @link http://php.net/manual/en/domnode.replacechild.php
      * @param DOMNode $newnode <p>
@@ -1727,7 +1727,7 @@ class DOMElement extends DOMNode  {
     public function replaceChild (DOMNode $newnode , DOMNode $oldnode ) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Removes child from list of children
      * @link http://php.net/manual/en/domnode.removechild.php
      * @param DOMNode $oldnode <p>
@@ -1748,14 +1748,14 @@ class DOMText extends DOMCharacterData  {
 
     /**
      * @var
-     * (PHP 5)<br/>
+     * @since 5.0
      * Holds all the text of logically-adjacent (not separated by Element, Comment or Processing Instruction) Text nodes.
      * @link http://php.net/manual/en/class.domtext.php#domtext.props.wholeText
      */
     public $wholeText;
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Breaks this node into two nodes at the specified offset
      * @link http://php.net/manual/en/domtext.splittext.php
      * @param int $offset <p>
@@ -1767,7 +1767,7 @@ class DOMText extends DOMCharacterData  {
     public function splitText ($offset) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Indicates whether this text node contains whitespace
      * @link http://php.net/manual/en/domtext.iswhitespaceinelementcontent.php
      * @return bool true on success or false on failure.
@@ -1782,7 +1782,7 @@ class DOMText extends DOMCharacterData  {
     public function replaceWholeText ($content) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Creates a new <classname>DOMText</classname> object
      * @link http://php.net/manual/en/domtext.construct.php
      * @param $value [optional] The value of the text node. If not supplied an empty text node is created.
@@ -1799,7 +1799,7 @@ class DOMText extends DOMCharacterData  {
 class DOMComment extends DOMCharacterData  {
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Creates a new DOMComment object
      * @link http://php.net/manual/en/domcomment.construct.php
      * @param $value [optional] The value of the comment
@@ -1859,7 +1859,7 @@ class DOMConfiguration  {
 class DOMCdataSection extends DOMText  {
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * The value of the CDATA node. If not supplied, an empty CDATA node is created.
      * @param string $value The value of the CDATA node. If not supplied, an empty CDATA node is created.
      * @link http://www.php.net/manual/en/domcdatasection.construct.php
@@ -1876,7 +1876,7 @@ class DOMDocumentType extends DOMNode
 
     /**
      * @var string
-     * (PHP 5)<br/>
+     * @since 5.0
      * The public identifier of the external subset.
      * @link http://php.net/manual/en/class.domdocumenttype.php#domdocumenttype.props.publicid
      */
@@ -1884,7 +1884,7 @@ class DOMDocumentType extends DOMNode
 
     /**
      * @var string
-     * (PHP 5)<br/>
+     * @since 5.0
      * The system identifier of the external subset. This may be an absolute URI or not.
      * @link http://php.net/manual/en/class.domdocumenttype.php#domdocumenttype.props.systemid
      */
@@ -1892,7 +1892,7 @@ class DOMDocumentType extends DOMNode
 
     /**
      * @var string
-     * (PHP 5)<br/>
+     * @since 5.0
      * The name of DTD; i.e., the name immediately following the DOCTYPE keyword.
      * @link http://php.net/manual/en/class.domdocumenttype.php#domdocumenttype.props.name
      */
@@ -1900,7 +1900,7 @@ class DOMDocumentType extends DOMNode
 
     /**
      * @var DOMNamedNodeMap
-     * (PHP 5)<br/>
+     * @since 5.0
      * A <classname>DOMNamedNodeMap</classname> containing the general entities, both external and internal, declared in the DTD.
      * @link http://php.net/manual/en/class.domdocumenttype.php#domdocumenttype.props.entities
      */
@@ -1908,7 +1908,7 @@ class DOMDocumentType extends DOMNode
 
     /**
      * @var DOMNamedNodeMap
-     * (PHP 5)<br/>
+     * @since 5.0
      * A <clasname>DOMNamedNodeMap</classname> containing the notations declared in the DTD.
      * @link http://php.net/manual/en/class.domdocumenttype.php#domdocumenttype.props.notations
      */
@@ -1916,7 +1916,7 @@ class DOMDocumentType extends DOMNode
 
     /**
      * @var string
-     * (PHP 5)<br/>
+     * @since 5.0
      * The internal subset as a string, or null if there is none. This is does not contain the delimiting square brackets.
      * @link http://php.net/manual/en/class.domdocumenttype.php#domdocumenttype.props.internalsubset
      */
@@ -1932,7 +1932,7 @@ class DOMNotation  extends DOMNode{
 
     /**
      * @var string
-     * (PHP 5)<br/>
+     * @since 5.0
      *
      * @link http://php.net/manual/en/class.domnotation.php#domnotation.props.publicid
      */
@@ -1940,7 +1940,7 @@ class DOMNotation  extends DOMNode{
 
     /**
      * @var string
-     * (PHP 5)<br/>
+     * @since 5.0
      *
      * @link http://php.net/manual/en/class.domnotation.php#domnotation.props.systemid
      */
@@ -1956,7 +1956,7 @@ class DOMEntity extends DOMNode  {
 
     /**
      * @var string
-     * (PHP 5)<br/>
+     * @since 5.0
      * The public identifier associated with the entity if specified, and NULL otherwise.
      * @link http://php.net/manual/en/class.domentity.php#domentity.props.publicid
      */
@@ -1964,7 +1964,7 @@ class DOMEntity extends DOMNode  {
 
     /**
      * @var string
-     * (PHP 5)<br/>
+     * @since 5.0
      * The system identifier associated with the entity if specified, and NULL otherwise. This may be an
      * absolute URI or not.
      * @link http://php.net/manual/en/class.domentity.php#domentity.props.systemid
@@ -1973,7 +1973,7 @@ class DOMEntity extends DOMNode  {
 
     /**
      * @var string
-     * (PHP 5)<br/>
+     * @since 5.0
      * For unparsed entities, the name of the notation for the entity. For parsed entities, this is NULL.
      * @link http://php.net/manual/en/class.domentity.php#domentity.props.notationname
      */
@@ -1981,7 +1981,7 @@ class DOMEntity extends DOMNode  {
 
     /**
      * @var string
-     * (PHP 5)<br/>
+     * @since 5.0
      * An attribute specifying the encoding used for this entity at the time of parsing, when it is an external
      * parsed entity. This is NULL if it an entity from the internal subset or if it is not known.
      * @link http://php.net/manual/en/class.domentity.php#domentity.props.actualencoding
@@ -1990,7 +1990,7 @@ class DOMEntity extends DOMNode  {
 
     /**
      * @var string
-     * (PHP 5)<br/>
+     * @since 5.0
      * An attribute specifying, as part of the text declaration, the encoding of this entity, when it is an external
      * parsed entity. This is NULL otherwise.
      * @link http://php.net/manual/en/class.domentity.php#domentity.props.encoding
@@ -1999,7 +1999,7 @@ class DOMEntity extends DOMNode  {
 
     /**
      * @var string
-     * (PHP 5)<br/>
+     * @since 5.0
      * An attribute specifying, as part of the text declaration, the version number of this entity, when it is an
      * external parsed entity. This is NULL otherwise.
      * @link http://php.net/manual/en/class.domentity.php#domentity.props.version
@@ -2015,7 +2015,7 @@ class DOMEntity extends DOMNode  {
 class DOMEntityReference extends DOMNode  {
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Creates a new DOMEntityReference object
      * @link http://php.net/manual/en/domentityreference.construct.php
      * @param $name string The name of the entity reference.
@@ -2032,7 +2032,7 @@ class DOMProcessingInstruction extends DOMNode  {
 
     /**
      * @var
-     * (PHP 5)<br/>
+     * @since 5.0
      *
      * @link http://php.net/manual/en/class.domprocessinginstruction.php#domprocessinginstruction.props.target
      */
@@ -2040,14 +2040,14 @@ class DOMProcessingInstruction extends DOMNode  {
 
     /**
      * @var
-     * (PHP 5)<br/>
+     * @since 5.0
      *
      * @link http://php.net/manual/en/class.domprocessinginstruction.php#domprocessinginstruction.props.data
      */
     public $data;
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Creates a new <classname>DOMProcessingInstruction</classname> object
      * @link http://php.net/manual/en/domprocessinginstruction.construct.php
      * @param $name string The tag name of the processing instruction.
@@ -2081,14 +2081,14 @@ class DOMXPath  {
 
     /**
      * @var DOMDocument
-     * (PHP 5)<br/>
+     * @since 5.0
      *
      * @link http://php.net/manual/en/class.domxpath.php#domxpath.props.document
      */
     public $document;
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Creates a new <classname>DOMXPath</classname> object
      * @link http://php.net/manual/en/domxpath.construct.php
      * @param DOMDocument $doc The <classname>DOMDocument</classname> associated with the <classname>DOMXPath</classname>.
@@ -2096,7 +2096,7 @@ class DOMXPath  {
     public function __construct (DOMDocument $doc) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Registers the namespace with the <classname>DOMXPath</classname> object
      * @link http://php.net/manual/en/domxpath.registernamespace.php
      * @param string $prefix <p>
@@ -2110,7 +2110,7 @@ class DOMXPath  {
     public function registerNamespace ($prefix, $namespaceURI) {}
 
     /**
-     * (PHP 5)<br/>
+     * @since 5.0
      * Evaluates the given XPath expression
      * @link http://php.net/manual/en/domxpath.query.php
      * @param string $expression <p>
@@ -2128,7 +2128,7 @@ class DOMXPath  {
     public function query ($expression, $contextnode = null) {}
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Evaluates the given XPath expression and returns a typed result if possible.
      * @link http://php.net/manual/en/domxpath.evaluate.php
      * @param string $expression <p>
@@ -2145,7 +2145,7 @@ class DOMXPath  {
     public function evaluate ($expression, $contextnode = null) {}
 
     /**
-     * (PHP 5 &gt;= 5.3.0)<br/>
+     * @since 5.3.0
      * Register PHP functions as XPath functions
      * @link http://php.net/manual/en/domxpath.registerphpfunctions.php
      * @param mixed $restrict [optional] <p>

--- a/ereg.php
+++ b/ereg.php
@@ -7,7 +7,7 @@
  * @since 5.0
  * Regular expression match
  * @link http://php.net/manual/en/function.ereg.php
- * @deprecated since 5.3.0, use preg_match() instead
+ * @deprecated 5.3.0 Use preg_match() instead
  * @param string $pattern <p>
  * Case sensitive regular expression.
  * </p>
@@ -42,7 +42,7 @@ function ereg ($pattern, $string, array &$regs = null) {}
  * @since 5.0
  * Replace regular expression
  * @link http://php.net/manual/en/function.ereg-replace.php
- * @deprecated since 5.3.0, use preg_replace() instead
+ * @deprecated 5.3.0 Use preg_replace() instead
  * @param string $pattern <p>
  * A POSIX extended regular expression.
  * </p>
@@ -68,7 +68,7 @@ function ereg_replace ($pattern, $replacement, $string) {}
  * @since 5.0
  * Case insensitive regular expression match
  * @link http://php.net/manual/en/function.eregi.php
- * @deprecated since 5.3.0, use preg_match() instead
+ * @deprecated 5.3.0 Use preg_match() instead
  * @param string $pattern <p>
  * Case insensitive regular expression.
  * </p>
@@ -102,7 +102,7 @@ function eregi ($pattern, $string, array &$regs = null) {}
  * @since 5.0
  * Replace regular expression case insensitive
  * @link http://php.net/manual/en/function.eregi-replace.php
- * @deprecated since 5.3.0, use preg_replace() instead
+ * @deprecated 5.3.0 Use preg_replace() instead
  * @param string $pattern <p>
  * A POSIX extended regular expression.
  * </p>
@@ -128,7 +128,7 @@ function eregi_replace ($pattern, $replacement, $string) {}
  * @since 5.0
  * Split string into array by regular expression
  * @link http://php.net/manual/en/function.split.php
- * @deprecated since 5.3.0, use preg_split() instead
+ * @deprecated 5.3.0 Use preg_split() instead
  * @param string $pattern <p>
  * Case sensitive regular expression.
  * </p>
@@ -171,7 +171,7 @@ function split ($pattern, $string, $limit = -1) {}
  * @since 5.0
  * Split string into array by regular expression case insensitive
  * @link http://php.net/manual/en/function.spliti.php
- * @deprecated since 5.3.0, use preg_split() with the 'i' modifier instead
+ * @deprecated 5.3.0 Use preg_split() with the 'i' modifier instead
  * @param string $pattern <p>
  * Case insensitive regular expression.
  * </p>
@@ -214,7 +214,7 @@ function spliti ($pattern, $string, $limit = -1) {}
  * @since 5.0
  * Make regular expression for case insensitive match
  * @link http://php.net/manual/en/function.sql-regcase.php
- * @deprecated since 5.3.0
+ * @deprecated 5.3.0
  * @param string $string <p>
  * The input string.
  * </p>

--- a/ereg.php
+++ b/ereg.php
@@ -3,7 +3,8 @@
 // Start of ereg v.
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Regular expression match
  * @link http://php.net/manual/en/function.ereg.php
  * @deprecated since 5.3.0, use preg_match() instead
@@ -37,7 +38,8 @@
 function ereg ($pattern, $string, array &$regs = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Replace regular expression
  * @link http://php.net/manual/en/function.ereg-replace.php
  * @deprecated since 5.3.0, use preg_replace() instead
@@ -62,7 +64,8 @@ function ereg ($pattern, $string, array &$regs = null) {}
 function ereg_replace ($pattern, $replacement, $string) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Case insensitive regular expression match
  * @link http://php.net/manual/en/function.eregi.php
  * @deprecated since 5.3.0, use preg_match() instead
@@ -95,7 +98,8 @@ function ereg_replace ($pattern, $replacement, $string) {}
 function eregi ($pattern, $string, array &$regs = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Replace regular expression case insensitive
  * @link http://php.net/manual/en/function.eregi-replace.php
  * @deprecated since 5.3.0, use preg_replace() instead
@@ -120,7 +124,8 @@ function eregi ($pattern, $string, array &$regs = null) {}
 function eregi_replace ($pattern, $replacement, $string) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Split string into array by regular expression
  * @link http://php.net/manual/en/function.split.php
  * @deprecated since 5.3.0, use preg_split() instead
@@ -162,7 +167,8 @@ function eregi_replace ($pattern, $replacement, $string) {}
 function split ($pattern, $string, $limit = -1) {}
 
 /**
- * (PHP 4 &gt;= 4.0.1, PHP 5)<br/>
+ * @since 4.0.1
+ * @since 5.0
  * Split string into array by regular expression case insensitive
  * @link http://php.net/manual/en/function.spliti.php
  * @deprecated since 5.3.0, use preg_split() with the 'i' modifier instead
@@ -204,7 +210,8 @@ function split ($pattern, $string, $limit = -1) {}
 function spliti ($pattern, $string, $limit = -1) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Make regular expression for case insensitive match
  * @link http://php.net/manual/en/function.sql-regcase.php
  * @deprecated since 5.3.0

--- a/exif.php
+++ b/exif.php
@@ -3,7 +3,8 @@
 // Start of exif v.1.4 $Id$
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Reads the EXIF headers from JPEG or TIFF
  * @link http://php.net/manual/en/function.exif-read-data.php
  * @param string $filename <p>
@@ -79,7 +80,8 @@
 function exif_read_data ($filename, $sections = null, $arrays = false, $thumbnail = false) {}
 
 /**
- * (PHP 4 &gt;= 4.0.1, PHP 5)<br/>
+ * @since 4.0.1
+ * @since 5.0
  * Alias of <b>exif_read_data</b>
  * @link http://php.net/manual/en/function.read-exif-data.php
  * @param $filename
@@ -90,7 +92,8 @@ function exif_read_data ($filename, $sections = null, $arrays = false, $thumbnai
 function read_exif_data ($filename, $sections_needed, $sub_arrays, $read_thumbnail) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Get the header name for an index
  * @link http://php.net/manual/en/function.exif-tagname.php
  * @param int $index <p>
@@ -102,7 +105,8 @@ function read_exif_data ($filename, $sections_needed, $sub_arrays, $read_thumbna
 function exif_tagname ($index) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Retrieve the embedded thumbnail of a TIFF or JPEG image
  * @link http://php.net/manual/en/function.exif-thumbnail.php
  * @param string $filename <p>
@@ -125,7 +129,8 @@ function exif_tagname ($index) {}
 function exif_thumbnail ($filename, &$width = null, &$height = null, &$imagetype = null) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Determine the type of an image
  * @link http://php.net/manual/en/function.exif-imagetype.php
  * @param string $filename The image being checked.

--- a/fileinfo.php
+++ b/fileinfo.php
@@ -154,7 +154,8 @@ function finfo_file ($finfo, $file_name, $options = null, $context = null) {}
 function finfo_buffer ($finfo ,$string, $options = FILEINFO_NONE, $context = NULL) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Detect MIME Content-type for a file (deprecated)
  * @link http://php.net/manual/en/function.mime-content-type.php
  * @param string $filename <p>
@@ -186,14 +187,14 @@ define ('FILEINFO_MIME', 1040);
 
 /**
  * Return the mime type.
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/fileinfo.constants.php
  */
 define ('FILEINFO_MIME_TYPE', 16);
 
 /**
  * Return the mime encoding of the file.
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/fileinfo.constants.php
  */
 define ('FILEINFO_MIME_ENCODING', 1024);

--- a/filter.php
+++ b/filter.php
@@ -3,7 +3,7 @@
 // Start of filter v.0.11.0
 
 /**
- * (PHP 5 &gt;= 5.2.0)<br/>
+ * @since 5.2.0
  * Gets a specific external variable by name and optionally filters it
  * @link http://php.net/manual/en/function.filter-input.php
  * @param int $type <p>
@@ -30,7 +30,7 @@
 function filter_input ($type, $variable_name, $filter = FILTER_DEFAULT, $options = null) {}
 
 /**
- * (PHP 5 &gt;= 5.2.0)<br/>
+ * @since 5.2.0
  * Filters a variable with a specified filter
  * @link http://php.net/manual/en/function.filter-var.php
  * @param mixed $variable <p>
@@ -86,7 +86,7 @@ function filter_input ($type, $variable_name, $filter = FILTER_DEFAULT, $options
 function filter_var ($variable, $filter = FILTER_DEFAULT, $options = null) {}
 
 /**
- * (PHP 5 &gt;= 5.2.0)<br/>
+ * @since 5.2.0
  * Gets external variables and optionally filters them
  * @link http://php.net/manual/en/function.filter-input-array.php
  * @param int $type <p>
@@ -120,7 +120,7 @@ function filter_var ($variable, $filter = FILTER_DEFAULT, $options = null) {}
 function filter_input_array ($type, $definition = null, $add_empty = true) {}
 
 /**
- * (PHP 5 &gt;= 5.2.0)<br/>
+ * @since 5.2.0
  * Gets multiple variables and optionally filters them
  * @link http://php.net/manual/en/function.filter-var-array.php
  * @param array $data <p>
@@ -151,7 +151,7 @@ function filter_input_array ($type, $definition = null, $add_empty = true) {}
 function filter_var_array (array $data, $definition = null, $add_empty = true) {}
 
 /**
- * (PHP 5 &gt;= 5.2.0)<br/>
+ * @since 5.2.0
  * Returns a list of all supported filters
  * @link http://php.net/manual/en/function.filter-list.php
  * @return array an array of names of all supported filters, empty array if there
@@ -161,7 +161,7 @@ function filter_var_array (array $data, $definition = null, $add_empty = true) {
 function filter_list () {}
 
 /**
- * (PHP 5 &gt;= 5.2.0)<br/>
+ * @since 5.2.0
  * Checks if variable of specified type exists
  * @link http://php.net/manual/en/function.filter-has-var.php
  * @param int $type <p>
@@ -177,7 +177,7 @@ function filter_list () {}
 function filter_has_var ($type, $variable_name) {}
 
 /**
- * (PHP 5 &gt;= 5.2.0)<br/>
+ * @since 5.2.0
  * Returns the filter ID belonging to a named filter
  * @link http://php.net/manual/en/function.filter-id.php
  * @param string $filtername <p>

--- a/ftp.php
+++ b/ftp.php
@@ -3,7 +3,8 @@
 // Start of ftp v.
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Opens an FTP connection
  * @link http://php.net/manual/en/function.ftp-connect.php
  * @param string $host <p>
@@ -25,7 +26,8 @@
 function ftp_connect ($host, $port = 21, $timeout = 90) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Opens an Secure SSL-FTP connection
  * @link http://php.net/manual/en/function.ftp-ssl-connect.php
  * @param string $host <p>
@@ -47,7 +49,8 @@ function ftp_connect ($host, $port = 21, $timeout = 90) {}
 function ftp_ssl_connect ($host, $port = 21, $timeout = 90) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Logs in to an FTP connection
  * @link http://php.net/manual/en/function.ftp-login.php
  * @param resource $ftp_stream <p>
@@ -65,7 +68,8 @@ function ftp_ssl_connect ($host, $port = 21, $timeout = 90) {}
 function ftp_login ($ftp_stream, $username, $password) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Returns the current directory name
  * @link http://php.net/manual/en/function.ftp-pwd.php
  * @param resource $ftp_stream <p>
@@ -76,7 +80,8 @@ function ftp_login ($ftp_stream, $username, $password) {}
 function ftp_pwd ($ftp_stream) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Changes to the parent directory
  * @link http://php.net/manual/en/function.ftp-cdup.php
  * @param resource $ftp_stream <p>
@@ -87,7 +92,8 @@ function ftp_pwd ($ftp_stream) {}
 function ftp_cdup ($ftp_stream) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Changes the current directory on a FTP server
  * @link http://php.net/manual/en/function.ftp-chdir.php
  * @param resource $ftp_stream <p>
@@ -102,7 +108,8 @@ function ftp_cdup ($ftp_stream) {}
 function ftp_chdir ($ftp_stream, $directory) {}
 
 /**
- * (PHP 4 &gt;= 4.0.3, PHP 5)<br/>
+ * @since 4.0.3
+ * @since 5.0
  * Requests execution of a command on the FTP server
  * @link http://php.net/manual/en/function.ftp-exec.php
  * @param resource $ftp_stream <p>
@@ -117,7 +124,7 @@ function ftp_chdir ($ftp_stream, $directory) {}
 function ftp_exec ($ftp_stream, $command) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Sends an arbitrary command to an FTP server
  * @link http://php.net/manual/en/function.ftp-raw.php
  * @param resource $ftp_stream <p>
@@ -133,7 +140,8 @@ function ftp_exec ($ftp_stream, $command) {}
 function ftp_raw ($ftp_stream, $command) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Creates a directory
  * @link http://php.net/manual/en/function.ftp-mkdir.php
  * @param resource $ftp_stream <p>
@@ -147,7 +155,8 @@ function ftp_raw ($ftp_stream, $command) {}
 function ftp_mkdir ($ftp_stream, $directory) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Removes a directory
  * @link http://php.net/manual/en/function.ftp-rmdir.php
  * @param resource $ftp_stream <p>
@@ -162,7 +171,7 @@ function ftp_mkdir ($ftp_stream, $directory) {}
 function ftp_rmdir ($ftp_stream, $directory) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Set permissions on a file via FTP
  * @link http://php.net/manual/en/function.ftp-chmod.php
  * @param resource $ftp_stream <p>
@@ -179,7 +188,7 @@ function ftp_rmdir ($ftp_stream, $directory) {}
 function ftp_chmod ($ftp_stream, $mode, $filename) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Allocates space for a file to be uploaded
  * @link http://php.net/manual/en/function.ftp-alloc.php
  * @param resource $ftp_stream <p>
@@ -197,7 +206,8 @@ function ftp_chmod ($ftp_stream, $mode, $filename) {}
 function ftp_alloc ($ftp_stream, $filesize, &$result = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Returns a list of files in the given directory
  * @link http://php.net/manual/en/function.ftp-nlist.php
  * @param resource $ftp_stream <p>
@@ -215,7 +225,8 @@ function ftp_alloc ($ftp_stream, $filesize, &$result = null) {}
 function ftp_nlist ($ftp_stream, $directory) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Returns a detailed list of files in the given directory
  * @link http://php.net/manual/en/function.ftp-rawlist.php
  * @param resource $ftp_stream <p>
@@ -238,7 +249,8 @@ function ftp_nlist ($ftp_stream, $directory) {}
 function ftp_rawlist ($ftp_stream, $directory, $recursive = false) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Returns the system type identifier of the remote FTP server
  * @link http://php.net/manual/en/function.ftp-systype.php
  * @param resource $ftp_stream <p>
@@ -249,7 +261,8 @@ function ftp_rawlist ($ftp_stream, $directory, $recursive = false) {}
 function ftp_systype ($ftp_stream) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Turns passive mode on or off
  * @link http://php.net/manual/en/function.ftp-pasv.php
  * @param resource $ftp_stream <p>
@@ -263,7 +276,8 @@ function ftp_systype ($ftp_stream) {}
 function ftp_pasv ($ftp_stream, $pasv) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Downloads a file from the FTP server
  * @link http://php.net/manual/en/function.ftp-get.php
  * @param resource $ftp_stream <p>
@@ -287,7 +301,8 @@ function ftp_pasv ($ftp_stream, $pasv) {}
 function ftp_get ($ftp_stream, $local_file, $remote_file, $mode, $resumepos = 0) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Downloads a file from the FTP server and saves to an open file
  * @link http://php.net/manual/en/function.ftp-fget.php
  * @param resource $ftp_stream <p>
@@ -311,7 +326,8 @@ function ftp_get ($ftp_stream, $local_file, $remote_file, $mode, $resumepos = 0)
 function ftp_fget ($ftp_stream, $handle, $remote_file, $mode, $resumepos = 0) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Uploads a file to the FTP server
  * @link http://php.net/manual/en/function.ftp-put.php
  * @param resource $ftp_stream <p>
@@ -333,7 +349,8 @@ function ftp_fget ($ftp_stream, $handle, $remote_file, $mode, $resumepos = 0) {}
 function ftp_put ($ftp_stream, $remote_file, $local_file, $mode, $startpos = 0) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Uploads from an open file to the FTP server
  * @link http://php.net/manual/en/function.ftp-fput.php
  * @param resource $ftp_stream <p>
@@ -355,7 +372,8 @@ function ftp_put ($ftp_stream, $remote_file, $local_file, $mode, $startpos = 0) 
 function ftp_fput ($ftp_stream, $remote_file, $handle, $mode, $startpos = 0) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Returns the size of the given file
  * @link http://php.net/manual/en/function.ftp-size.php
  * @param resource $ftp_stream <p>
@@ -369,7 +387,8 @@ function ftp_fput ($ftp_stream, $remote_file, $handle, $mode, $startpos = 0) {}
 function ftp_size ($ftp_stream, $remote_file) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Returns the last modified time of the given file
  * @link http://php.net/manual/en/function.ftp-mdtm.php
  * @param resource $ftp_stream <p>
@@ -384,7 +403,8 @@ function ftp_size ($ftp_stream, $remote_file) {}
 function ftp_mdtm ($ftp_stream, $remote_file) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Renames a file or a directory on the FTP server
  * @link http://php.net/manual/en/function.ftp-rename.php
  * @param resource $ftp_stream <p>
@@ -401,7 +421,8 @@ function ftp_mdtm ($ftp_stream, $remote_file) {}
 function ftp_rename ($ftp_stream, $oldname, $newname) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Deletes a file on the FTP server
  * @link http://php.net/manual/en/function.ftp-delete.php
  * @param resource $ftp_stream <p>
@@ -415,7 +436,8 @@ function ftp_rename ($ftp_stream, $oldname, $newname) {}
 function ftp_delete ($ftp_stream, $path) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Sends a SITE command to the server
  * @link http://php.net/manual/en/function.ftp-site.php
  * @param resource $ftp_stream <p>
@@ -430,7 +452,8 @@ function ftp_delete ($ftp_stream, $path) {}
 function ftp_site ($ftp_stream, $command) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Closes an FTP connection
  * @link http://php.net/manual/en/function.ftp-close.php
  * @param resource $ftp_stream <p>
@@ -441,7 +464,8 @@ function ftp_site ($ftp_stream, $command) {}
 function ftp_close ($ftp_stream) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Set miscellaneous runtime FTP options
  * @link http://php.net/manual/en/function.ftp-set-option.php
  * @param resource $ftp_stream <p>
@@ -482,7 +506,8 @@ function ftp_close ($ftp_stream) {}
 function ftp_set_option ($ftp_stream, $option, $value) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Retrieves various runtime behaviours of the current FTP stream
  * @link http://php.net/manual/en/function.ftp-get-option.php
  * @param resource $ftp_stream <p>
@@ -513,7 +538,8 @@ function ftp_set_option ($ftp_stream, $option, $value) {}
 function ftp_get_option ($ftp_stream, $option) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Retrieves a file from the FTP server and writes it to an open file (non-blocking)
  * @link http://php.net/manual/en/function.ftp-nb-fget.php
  * @param resource $ftp_stream <p>
@@ -536,7 +562,8 @@ function ftp_get_option ($ftp_stream, $option) {}
 function ftp_nb_fget ($ftp_stream, $handle, $remote_file, $mode, $resumepos = 0) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Retrieves a file from the FTP server and writes it to a local file (non-blocking)
  * @link http://php.net/manual/en/function.ftp-nb-get.php
  * @param resource $ftp_stream <p>
@@ -559,7 +586,8 @@ function ftp_nb_fget ($ftp_stream, $handle, $remote_file, $mode, $resumepos = 0)
 function ftp_nb_get ($ftp_stream, $local_file, $remote_file, $mode, $resumepos = 0) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Continues retrieving/sending a file (non-blocking)
  * @link http://php.net/manual/en/function.ftp-nb-continue.php
  * @param resource $ftp_stream <p>
@@ -571,7 +599,8 @@ function ftp_nb_get ($ftp_stream, $local_file, $remote_file, $mode, $resumepos =
 function ftp_nb_continue ($ftp_stream) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Stores a file on the FTP server (non-blocking)
  * @link http://php.net/manual/en/function.ftp-nb-put.php
  * @param resource $ftp_stream <p>
@@ -594,7 +623,8 @@ function ftp_nb_continue ($ftp_stream) {}
 function ftp_nb_put ($ftp_stream, $remote_file, $local_file, $mode, $startpos = 0) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Stores a file from an open file to the FTP server (non-blocking)
  * @link http://php.net/manual/en/function.ftp-nb-fput.php
  * @param resource $ftp_stream <p>
@@ -617,7 +647,8 @@ function ftp_nb_put ($ftp_stream, $remote_file, $local_file, $mode, $startpos = 
 function ftp_nb_fput ($ftp_stream, $remote_file, $handle, $mode, $startpos = 0) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Alias of <b>ftp_close</b>
  * @link http://php.net/manual/en/function.ftp-quit.php
  * @param $ftp

--- a/gd.php
+++ b/gd.php
@@ -3,7 +3,8 @@
 // Start of gd v.
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Retrieve information about the currently installed GD library
  * @link http://php.net/manual/en/function.gd-info.php
  * @return array an associative array.
@@ -84,7 +85,8 @@
 function gd_info () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Draws an arc
  * @link http://php.net/manual/en/function.imagearc.php
  * @param resource $image 
@@ -117,7 +119,8 @@ function gd_info () {}
 function imagearc ($image, $cx, $cy, $width, $height, $start, $end, $color) {}
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Draw an ellipse
  * @link http://php.net/manual/en/function.imageellipse.php
  * @param resource $image 
@@ -142,7 +145,8 @@ function imagearc ($image, $cx, $cy, $width, $height, $start, $end, $color) {}
 function imageellipse ($image, $cx, $cy, $width, $height, $color) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Draw a character horizontally
  * @link http://php.net/manual/en/function.imagechar.php
  * @param resource $image 
@@ -165,7 +169,8 @@ function imageellipse ($image, $cx, $cy, $width, $height, $color) {}
 function imagechar ($image, $font, $x, $y, $c, $color) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Draw a character vertically
  * @link http://php.net/manual/en/function.imagecharup.php
  * @param resource $image 
@@ -188,7 +193,8 @@ function imagechar ($image, $font, $x, $y, $c, $color) {}
 function imagecharup ($image, $font, $x, $y, $c, $color) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get the index of the color of a pixel
  * @link http://php.net/manual/en/function.imagecolorat.php
  * @param resource $image 
@@ -203,7 +209,8 @@ function imagecharup ($image, $font, $x, $y, $c, $color) {}
 function imagecolorat ($image, $x, $y) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Allocate a color for an image
  * @link http://php.net/manual/en/function.imagecolorallocate.php
  * @param resource $image 
@@ -215,7 +222,8 @@ function imagecolorat ($image, $x, $y) {}
 function imagecolorallocate ($image, $red, $green, $blue) {}
 
 /**
- * (PHP 4 &gt;= 4.0.1, PHP 5)<br/>
+ * @since 4.0.1
+ * @since 5.0
  * Copy the palette from one image to another
  * @link http://php.net/manual/en/function.imagepalettecopy.php
  * @param resource $destination <p>
@@ -229,7 +237,8 @@ function imagecolorallocate ($image, $red, $green, $blue) {}
 function imagepalettecopy ($destination, $source) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Create a new image from the image stream in the string
  * @link http://php.net/manual/en/function.imagecreatefromstring.php
  * @param string $image <p>
@@ -242,7 +251,8 @@ function imagepalettecopy ($destination, $source) {}
 function imagecreatefromstring ($image) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get the index of the closest color to the specified color
  * @link http://php.net/manual/en/function.imagecolorclosest.php
  * @param resource $image 
@@ -255,7 +265,8 @@ function imagecreatefromstring ($image) {}
 function imagecolorclosest ($image, $red, $green, $blue) {}
 
 /**
- * (PHP 4 &gt;= 4.0.1, PHP 5)<br/>
+ * @since 4.0.1
+ * @since 5.0
  * Get the index of the color which has the hue, white and blackness
  * @link http://php.net/manual/en/function.imagecolorclosesthwb.php
  * @param resource $image 
@@ -268,7 +279,8 @@ function imagecolorclosest ($image, $red, $green, $blue) {}
 function imagecolorclosesthwb ($image, $red, $green, $blue) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * De-allocate a color for an image
  * @link http://php.net/manual/en/function.imagecolordeallocate.php
  * @param resource $image 
@@ -280,7 +292,8 @@ function imagecolorclosesthwb ($image, $red, $green, $blue) {}
 function imagecolordeallocate ($image, $color) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get the index of the specified color or its closest possible alternative
  * @link http://php.net/manual/en/function.imagecolorresolve.php
  * @param resource $image 
@@ -292,7 +305,8 @@ function imagecolordeallocate ($image, $color) {}
 function imagecolorresolve ($image, $red, $green, $blue) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get the index of the specified color
  * @link http://php.net/manual/en/function.imagecolorexact.php
  * @param resource $image 
@@ -305,7 +319,8 @@ function imagecolorresolve ($image, $red, $green, $blue) {}
 function imagecolorexact ($image, $red, $green, $blue) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Set the color for the specified palette index
  * @link http://php.net/manual/en/function.imagecolorset.php
  * @param resource $image 
@@ -323,7 +338,8 @@ function imagecolorexact ($image, $red, $green, $blue) {}
 function imagecolorset ($image, $index, $red, $green, $blue, $alpha = 0) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Define a color as transparent
  * @link http://php.net/manual/en/function.imagecolortransparent.php
  * @param resource $image 
@@ -339,7 +355,8 @@ function imagecolorset ($image, $index, $red, $green, $blue, $alpha = 0) {}
 function imagecolortransparent ($image, $color = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Find out the number of colors in an image's palette
  * @link http://php.net/manual/en/function.imagecolorstotal.php
  * @param resource $image <p>
@@ -352,7 +369,8 @@ function imagecolortransparent ($image, $color = null) {}
 function imagecolorstotal ($image) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get the colors for an index
  * @link http://php.net/manual/en/function.imagecolorsforindex.php
  * @param resource $image 
@@ -365,7 +383,8 @@ function imagecolorstotal ($image) {}
 function imagecolorsforindex ($image, $index) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Copy part of an image
  * @link http://php.net/manual/en/function.imagecopy.php
  * @param resource $dst_im <p>
@@ -397,7 +416,8 @@ function imagecolorsforindex ($image, $index) {}
 function imagecopy ($dst_im, $src_im, $dst_x, $dst_y, $src_x, $src_y, $src_w, $src_h) {}
 
 /**
- * (PHP 4 &gt;= 4.0.1, PHP 5)<br/>
+ * @since 4.0.1
+ * @since 5.0
  * Copy and merge part of an image
  * @link http://php.net/manual/en/function.imagecopymerge.php
  * @param resource $dst_im <p>
@@ -436,7 +456,8 @@ function imagecopy ($dst_im, $src_im, $dst_x, $dst_y, $src_x, $src_y, $src_w, $s
 function imagecopymerge ($dst_im, $src_im, $dst_x, $dst_y, $src_x, $src_y, $src_w, $src_h, $pct) {}
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Copy and merge part of an image with gray scale
  * @link http://php.net/manual/en/function.imagecopymergegray.php
  * @param resource $dst_im <p>
@@ -475,7 +496,8 @@ function imagecopymerge ($dst_im, $src_im, $dst_x, $dst_y, $src_x, $src_y, $src_
 function imagecopymergegray ($dst_im, $src_im, $dst_x, $dst_y, $src_x, $src_y, $src_w, $src_h, $pct) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Copy and resize part of an image
  * @link http://php.net/manual/en/function.imagecopyresized.php
  * @param resource $dst_image 
@@ -509,7 +531,8 @@ function imagecopymergegray ($dst_im, $src_im, $dst_x, $dst_y, $src_x, $src_y, $
 function imagecopyresized ($dst_image, $src_image, $dst_x, $dst_y, $src_x, $src_y, $dst_w, $dst_h, $src_w, $src_h) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Create a new palette based image
  * @link http://php.net/manual/en/function.imagecreate.php
  * @param int $width <p>
@@ -523,7 +546,8 @@ function imagecopyresized ($dst_image, $src_image, $dst_x, $dst_y, $src_x, $src_
 function imagecreate ($width, $height) {}
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Create a new true color image
  * @link http://php.net/manual/en/function.imagecreatetruecolor.php
  * @param int $width <p>
@@ -537,7 +561,8 @@ function imagecreate ($width, $height) {}
 function imagecreatetruecolor ($width, $height) {}
 
 /**
- * (PHP 4 &gt;= 4.3.2, PHP 5)<br/>
+ * @since 4.3.2
+ * @since 5.0
  * Finds whether an image is a truecolor image
  * @link http://php.net/manual/en/function.imageistruecolor.php
  * @param resource $image 
@@ -547,7 +572,8 @@ function imagecreatetruecolor ($width, $height) {}
 function imageistruecolor ($image) {}
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Convert a true color image to a palette image
  * @link http://php.net/manual/en/function.imagetruecolortopalette.php
  * @param resource $image 
@@ -564,7 +590,8 @@ function imageistruecolor ($image) {}
 function imagetruecolortopalette ($image, $dither, $ncolors) {}
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Set the thickness for line drawing
  * @link http://php.net/manual/en/function.imagesetthickness.php
  * @param resource $image 
@@ -576,7 +603,8 @@ function imagetruecolortopalette ($image, $dither, $ncolors) {}
 function imagesetthickness ($image, $thickness) {}
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Draw a partial arc and fill it
  * @link http://php.net/manual/en/function.imagefilledarc.php
  * @param resource $image 
@@ -612,7 +640,8 @@ function imagesetthickness ($image, $thickness) {}
 function imagefilledarc ($image, $cx, $cy, $width, $height, $start, $end, $color, $style) {}
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Draw a filled ellipse
  * @link http://php.net/manual/en/function.imagefilledellipse.php
  * @param resource $image 
@@ -637,7 +666,8 @@ function imagefilledarc ($image, $cx, $cy, $width, $height, $start, $end, $color
 function imagefilledellipse ($image, $cx, $cy, $width, $height, $color) {}
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Set the blending mode for an image
  * @link http://php.net/manual/en/function.imagealphablending.php
  * @param resource $image 
@@ -650,7 +680,8 @@ function imagefilledellipse ($image, $cx, $cy, $width, $height, $color) {}
 function imagealphablending ($image, $blendmode) {}
 
 /**
- * (PHP 4 &gt;= 4.3.2, PHP 5)<br/>
+ * @since 4.3.2
+ * @since 5.0
  * Set the flag to save full alpha channel information (as opposed to single-color transparency) when saving PNG images
  * @link http://php.net/manual/en/function.imagesavealpha.php
  * @param resource $image 
@@ -662,7 +693,8 @@ function imagealphablending ($image, $blendmode) {}
 function imagesavealpha ($image, $saveflag) {}
 
 /**
- * (PHP 4 &gt;= 4.3.2, PHP 5)<br/>
+ * @since 4.3.2
+ * @since 5.0
  * Allocate a color for an image
  * @link http://php.net/manual/en/function.imagecolorallocatealpha.php
  * @param resource $image 
@@ -685,7 +717,8 @@ function imagesavealpha ($image, $saveflag) {}
 function imagecolorallocatealpha ($image, $red, $green, $blue, $alpha) {}
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Get the index of the specified color + alpha or its closest possible alternative
  * @link http://php.net/manual/en/function.imagecolorresolvealpha.php
  * @param resource $image 
@@ -708,7 +741,8 @@ function imagecolorallocatealpha ($image, $red, $green, $blue, $alpha) {}
 function imagecolorresolvealpha ($image, $red, $green, $blue, $alpha) {}
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Get the index of the closest color to the specified color + alpha
  * @link http://php.net/manual/en/function.imagecolorclosestalpha.php
  * @param resource $image 
@@ -731,7 +765,8 @@ function imagecolorresolvealpha ($image, $red, $green, $blue, $alpha) {}
 function imagecolorclosestalpha ($image, $red, $green, $blue, $alpha) {}
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Get the index of the specified color + alpha
  * @link http://php.net/manual/en/function.imagecolorexactalpha.php
  * @param resource $image 
@@ -755,7 +790,8 @@ function imagecolorclosestalpha ($image, $red, $green, $blue, $alpha) {}
 function imagecolorexactalpha ($image, $red, $green, $blue, $alpha) {}
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Copy and resize part of an image with resampling
  * @link http://php.net/manual/en/function.imagecopyresampled.php
  * @param resource $dst_image 
@@ -789,7 +825,8 @@ function imagecolorexactalpha ($image, $red, $green, $blue, $alpha) {}
 function imagecopyresampled ($dst_image, $src_image, $dst_x, $dst_y, $src_x, $src_y, $dst_w, $dst_h, $src_w, $src_h) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Rotate an image with a given angle
  * @link http://php.net/manual/en/function.imagerotate.php
  * @param resource $image 
@@ -807,7 +844,8 @@ function imagecopyresampled ($dst_image, $src_image, $dst_x, $dst_y, $src_x, $sr
 function imagerotate ($image, $angle, $bgd_color, $ignore_transparent = null) {}
 
 /**
- * (PHP 4 &gt;= 4.3.2, PHP 5)<br/>
+ * @since 4.3.2
+ * @since 5.0
  * Should antialias functions be used or not
  * @link http://php.net/manual/en/function.imageantialias.php
  * @param resource $image 
@@ -819,7 +857,8 @@ function imagerotate ($image, $angle, $bgd_color, $ignore_transparent = null) {}
 function imageantialias ($image, $enabled) {}
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Set the tile image for filling
  * @link http://php.net/manual/en/function.imagesettile.php
  * @param resource $image 
@@ -831,7 +870,8 @@ function imageantialias ($image, $enabled) {}
 function imagesettile ($image, $tile) {}
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Set the brush image for line drawing
  * @link http://php.net/manual/en/function.imagesetbrush.php
  * @param resource $image 
@@ -843,7 +883,8 @@ function imagesettile ($image, $tile) {}
 function imagesetbrush ($image, $brush) {}
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Set the style for line drawing
  * @link http://php.net/manual/en/function.imagesetstyle.php
  * @param resource $image 
@@ -857,7 +898,8 @@ function imagesetbrush ($image, $brush) {}
 function imagesetstyle ($image, $stylearray ) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Create a new image from file or URL
  * @link http://php.net/manual/en/function.imagecreatefrompng.php
  * @param string $filename <p>
@@ -868,7 +910,8 @@ function imagesetstyle ($image, $stylearray ) {}
 function imagecreatefrompng ($filename) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Create a new image from file or URL
  * @link http://php.net/manual/en/function.imagecreatefromgif.php
  * @param string $filename <p>
@@ -879,7 +922,8 @@ function imagecreatefrompng ($filename) {}
 function imagecreatefromgif ($filename) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Create a new image from file or URL
  * @link http://php.net/manual/en/function.imagecreatefromjpeg.php
  * @param string $filename <p>
@@ -890,7 +934,8 @@ function imagecreatefromgif ($filename) {}
 function imagecreatefromjpeg ($filename) {}
 
 /**
- * (PHP 4 &gt;= 4.0.1, PHP 5)<br/>
+ * @since 4.0.1
+ * @since 5.0
  * Create a new image from file or URL
  * @link http://php.net/manual/en/function.imagecreatefromwbmp.php
  * @param string $filename <p>
@@ -901,7 +946,8 @@ function imagecreatefromjpeg ($filename) {}
 function imagecreatefromwbmp ($filename) {}
 
 /**
- * (PHP 4 &gt;= 4.0.1, PHP 5)<br/>
+ * @since 4.0.1
+ * @since 5.0
  * Create a new image from file or URL
  * @link http://php.net/manual/en/function.imagecreatefromxbm.php
  * @param string $filename <p>
@@ -912,7 +958,8 @@ function imagecreatefromwbmp ($filename) {}
 function imagecreatefromxbm ($filename) {}
 
 /**
- * (PHP 4 &gt;= 4.0.1, PHP 5)<br/>
+ * @since 4.0.1
+ * @since 5.0
  * Create a new image from file or URL
  * @link http://php.net/manual/en/function.imagecreatefromxpm.php
  * @param string $filename <p>
@@ -923,7 +970,8 @@ function imagecreatefromxbm ($filename) {}
 function imagecreatefromxpm ($filename) {}
 
 /**
- * (PHP 4 &gt;= 4.0.7, PHP 5)<br/>
+ * @since 4.0.7
+ * @since 5.0
  * Create a new image from GD file or URL
  * @link http://php.net/manual/en/function.imagecreatefromgd.php
  * @param string $filename <p>
@@ -934,7 +982,8 @@ function imagecreatefromxpm ($filename) {}
 function imagecreatefromgd ($filename) {}
 
 /**
- * (PHP 4 &gt;= 4.0.7, PHP 5)<br/>
+ * @since 4.0.7
+ * @since 5.0
  * Create a new image from GD2 file or URL
  * @link http://php.net/manual/en/function.imagecreatefromgd2.php
  * @param string $filename <p>
@@ -945,7 +994,8 @@ function imagecreatefromgd ($filename) {}
 function imagecreatefromgd2 ($filename) {}
 
 /**
- * (PHP 4 &gt;= 4.0.7, PHP 5)<br/>
+ * @since 4.0.7
+ * @since 5.0
  * Create a new image from a given part of GD2 file or URL
  * @link http://php.net/manual/en/function.imagecreatefromgd2part.php
  * @param string $filename <p>
@@ -968,7 +1018,8 @@ function imagecreatefromgd2 ($filename) {}
 function imagecreatefromgd2part ($filename, $srcX, $srcY, $width, $height) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Output a PNG image to either the browser or a file
  * @link http://php.net/manual/en/function.imagepng.php
  * @param resource $image 
@@ -995,7 +1046,8 @@ function imagecreatefromgd2part ($filename, $srcX, $srcY, $width, $height) {}
 function imagepng ($image, $filename = null, $quality = null, $filters = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Output image to browser or file
  * @link http://php.net/manual/en/function.imagegif.php
  * @param resource $image 
@@ -1008,7 +1060,8 @@ function imagepng ($image, $filename = null, $quality = null, $filters = null) {
 function imagegif ($image, $filename = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Output image to browser or file
  * @link http://php.net/manual/en/function.imagejpeg.php
  * @param resource $image 
@@ -1030,7 +1083,8 @@ function imagegif ($image, $filename = null) {}
 function imagejpeg ($image, $filename = null, $quality = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.1, PHP 5)<br/>
+ * @since 4.0.1
+ * @since 5.0
  * Output image to browser or file
  * @link http://php.net/manual/en/function.imagewbmp.php
  * @param resource $image 
@@ -1048,7 +1102,8 @@ function imagejpeg ($image, $filename = null, $quality = null) {}
 function imagewbmp ($image, $filename = null, $foreground = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.7, PHP 5)<br/>
+ * @since 4.0.7
+ * @since 5.0
  * Output GD image to browser or file
  * @link http://php.net/manual/en/function.imagegd.php
  * @param resource $image 
@@ -1061,7 +1116,8 @@ function imagewbmp ($image, $filename = null, $foreground = null) {}
 function imagegd ($image, $filename = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.7, PHP 5)<br/>
+ * @since 4.0.7
+ * @since 5.0
  * Output GD2 image to browser or file
  * @link http://php.net/manual/en/function.imagegd2.php
  * @param resource $image 
@@ -1082,7 +1138,8 @@ function imagegd ($image, $filename = null) {}
 function imagegd2 ($image, $filename = null, $chunk_size = null, $type = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Destroy an image
  * @link http://php.net/manual/en/function.imagedestroy.php
  * @param resource $image 
@@ -1091,7 +1148,8 @@ function imagegd2 ($image, $filename = null, $chunk_size = null, $type = null) {
 function imagedestroy ($image) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Apply a gamma correction to a GD image
  * @link http://php.net/manual/en/function.imagegammacorrect.php
  * @param resource $image 
@@ -1106,7 +1164,8 @@ function imagedestroy ($image) {}
 function imagegammacorrect ($image, $inputgamma, $outputgamma) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Flood fill
  * @link http://php.net/manual/en/function.imagefill.php
  * @param resource $image 
@@ -1125,7 +1184,8 @@ function imagegammacorrect ($image, $inputgamma, $outputgamma) {}
 function imagefill ($image, $x, $y, $color) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Draw a filled polygon
  * @link http://php.net/manual/en/function.imagefilledpolygon.php
  * @param resource $image 
@@ -1145,7 +1205,8 @@ function imagefill ($image, $x, $y, $color) {}
 function imagefilledpolygon ($image, array $points, $num_points, $color) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Draw a filled rectangle
  * @link http://php.net/manual/en/function.imagefilledrectangle.php
  * @param resource $image 
@@ -1170,7 +1231,8 @@ function imagefilledpolygon ($image, array $points, $num_points, $color) {}
 function imagefilledrectangle ($image, $x1, $y1, $x2, $y2, $color) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Flood fill to specific color
  * @link http://php.net/manual/en/function.imagefilltoborder.php
  * @param resource $image 
@@ -1193,7 +1255,8 @@ function imagefilledrectangle ($image, $x1, $y1, $x2, $y2, $color) {}
 function imagefilltoborder ($image, $x, $y, $border, $color) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get font width
  * @link http://php.net/manual/en/function.imagefontwidth.php
  * @param int $font 
@@ -1202,7 +1265,8 @@ function imagefilltoborder ($image, $x, $y, $border, $color) {}
 function imagefontwidth ($font) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get font height
  * @link http://php.net/manual/en/function.imagefontheight.php
  * @param int $font 
@@ -1211,7 +1275,8 @@ function imagefontwidth ($font) {}
 function imagefontheight ($font) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Enable or disable interlace
  * @link http://php.net/manual/en/function.imageinterlace.php
  * @param resource $image 
@@ -1224,7 +1289,8 @@ function imagefontheight ($font) {}
 function imageinterlace ($image, $interlace = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Draw a line
  * @link http://php.net/manual/en/function.imageline.php
  * @param resource $image 
@@ -1249,7 +1315,8 @@ function imageinterlace ($image, $interlace = null) {}
 function imageline ($image, $x1, $y1, $x2, $y2, $color) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Load a new font
  * @link http://php.net/manual/en/function.imageloadfont.php
  * @param string $file <p>
@@ -1303,7 +1370,8 @@ function imageline ($image, $x1, $y1, $x2, $y2, $color) {}
 function imageloadfont ($file) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Draws a polygon
  * @link http://php.net/manual/en/function.imagepolygon.php
  * @param resource $image 
@@ -1338,7 +1406,8 @@ function imageloadfont ($file) {}
 function imagepolygon ($image, array $points, $num_points, $color) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Draw a rectangle
  * @link http://php.net/manual/en/function.imagerectangle.php
  * @param resource $image 
@@ -1364,7 +1433,8 @@ function imagepolygon ($image, array $points, $num_points, $color) {}
 function imagerectangle ($image, $x1, $y1, $x2, $y2, $color) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Set a single pixel
  * @link http://php.net/manual/en/function.imagesetpixel.php
  * @param resource $image 
@@ -1383,7 +1453,8 @@ function imagerectangle ($image, $x1, $y1, $x2, $y2, $color) {}
 function imagesetpixel ($image, $x, $y, $color) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Draw a string horizontally
  * @link http://php.net/manual/en/function.imagestring.php
  * @param resource $image 
@@ -1406,7 +1477,8 @@ function imagesetpixel ($image, $x, $y, $color) {}
 function imagestring ($image, $font, $x, $y, $string, $color) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Draw a string vertically
  * @link http://php.net/manual/en/function.imagestringup.php
  * @param resource $image 
@@ -1429,7 +1501,8 @@ function imagestring ($image, $font, $x, $y, $string, $color) {}
 function imagestringup ($image, $font, $x, $y, $string, $color) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get image width
  * @link http://php.net/manual/en/function.imagesx.php
  * @param resource $image 
@@ -1439,7 +1512,8 @@ function imagestringup ($image, $font, $x, $y, $string, $color) {}
 function imagesx ($image) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get image height
  * @link http://php.net/manual/en/function.imagesy.php
  * @param resource $image 
@@ -1449,7 +1523,8 @@ function imagesx ($image) {}
 function imagesy ($image) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Draw a dashed line
  * @link http://php.net/manual/en/function.imagedashedline.php
  * @param resource $image 
@@ -1474,7 +1549,8 @@ function imagesy ($image) {}
 function imagedashedline ($image, $x1, $y1, $x2, $y2, $color) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Give the bounding box of a text using TrueType fonts
  * @link http://php.net/manual/en/function.imagettfbbox.php
  * @param float $size <p>
@@ -1541,7 +1617,8 @@ function imagedashedline ($image, $x1, $y1, $x2, $y2, $color) {}
 function imagettfbbox ($size, $angle, $fontfile, $text) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Write text to the image using TrueType fonts
  * @link http://php.net/manual/en/function.imagettftext.php
  * @param resource $image 
@@ -1622,7 +1699,8 @@ function imagettfbbox ($size, $angle, $fontfile, $text) {}
 function imagettftext ($image, $size, $angle, $x, $y, $color, $fontfile, $text) {}
 
 /**
- * (PHP 4 &gt;= 4.0.7, PHP 5)<br/>
+ * @since 4.0.7
+ * @since 5.0
  * Give the bounding box of a text using fonts via freetype2
  * @link http://php.net/manual/en/function.imageftbbox.php
  * @param float $size <p>
@@ -1701,7 +1779,8 @@ function imagettftext ($image, $size, $angle, $x, $y, $color, $fontfile, $text) 
 function imageftbbox ($size, $angle, $fontfile, $text, $extrainfo = null ) {}
 
 /**
- * (PHP 4 &gt;= 4.0.7, PHP 5)<br/>
+ * @since 4.0.7
+ * @since 5.0
  * Write text to the image using fonts using FreeType 2
  * @link http://php.net/manual/en/function.imagefttext.php
  * @param resource $image 
@@ -1807,7 +1886,8 @@ function imageftbbox ($size, $angle, $fontfile, $text, $extrainfo = null ) {}
 function imagefttext ($image, $size, $angle, $x, $y, $color, $fontfile, $text, $extrainfo = null ) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Load a PostScript Type 1 font from file
  * @link http://php.net/manual/en/function.imagepsloadfont.php
  * @param string $filename <p>
@@ -1819,7 +1899,8 @@ function imagefttext ($image, $size, $angle, $x, $y, $color, $fontfile, $text, $
 function imagepsloadfont ($filename) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Free memory used by a PostScript Type 1 font
  * @link http://php.net/manual/en/function.imagepsfreefont.php
  * @param resource $font_index <p>
@@ -1830,7 +1911,8 @@ function imagepsloadfont ($filename) {}
 function imagepsfreefont ($font_index) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Change the character encoding vector of a font
  * @link http://php.net/manual/en/function.imagepsencodefont.php
  * @param resource $font_index <p>
@@ -1847,7 +1929,8 @@ function imagepsfreefont ($font_index) {}
 function imagepsencodefont ($font_index, $encodingfile) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Extend or condense a font
  * @link http://php.net/manual/en/function.imagepsextendfont.php
  * @param resource $font_index <p>
@@ -1861,7 +1944,8 @@ function imagepsencodefont ($font_index, $encodingfile) {}
 function imagepsextendfont ($font_index, $extend) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Slant a font
  * @link http://php.net/manual/en/function.imagepsslantfont.php
  * @param resource $font_index <p>
@@ -1875,7 +1959,8 @@ function imagepsextendfont ($font_index, $extend) {}
 function imagepsslantfont ($font_index, $slant) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Draws a text over an image using PostScript Type1 fonts
  * @link http://php.net/manual/en/function.imagepstext.php
  * @param resource $image 
@@ -1947,7 +2032,8 @@ function imagepsslantfont ($font_index, $slant) {}
 function imagepstext ($image, $text, $font_index, $size, $foreground, $background, $x, $y, $space = null, $tightness = null, $angle = null, $antialias_steps = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Give the bounding box of a text rectangle using PostScript Type1 fonts
  * @link http://php.net/manual/en/function.imagepsbbox.php
  * @param string $text <p>
@@ -1978,7 +2064,8 @@ function imagepstext ($image, $text, $font_index, $size, $foreground, $backgroun
 function imagepsbbox ($text, $font, $size) {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Return the image types supported by this PHP build
  * @link http://php.net/manual/en/function.imagetypes.php
  * @return int a bit-field corresponding to the image formats supported by the
@@ -1990,7 +2077,8 @@ function imagepsbbox ($text, $font, $size) {}
 function imagetypes () {}
 
 /**
- * (PHP 4 &gt;= 4.0.5, PHP 5)<br/>
+ * @since 4.0.5
+ * @since 5.0
  * Convert JPEG image file to WBMP image file
  * @link http://php.net/manual/en/function.jpeg2wbmp.php
  * @param string $jpegname <p>
@@ -2013,7 +2101,8 @@ function imagetypes () {}
 function jpeg2wbmp ($jpegname, $wbmpname, $dest_height, $dest_width, $threshold) {}
 
 /**
- * (PHP 4 &gt;= 4.0.5, PHP 5)<br/>
+ * @since 4.0.5
+ * @since 5.0
  * Convert PNG image file to WBMP image file
  * @link http://php.net/manual/en/function.png2wbmp.php
  * @param string $pngname <p>
@@ -2036,7 +2125,8 @@ function jpeg2wbmp ($jpegname, $wbmpname, $dest_height, $dest_width, $threshold)
 function png2wbmp ($pngname, $wbmpname, $dest_height, $dest_width, $threshold) {}
 
 /**
- * (PHP 4 &gt;= 4.0.5, PHP 5)<br/>
+ * @since 4.0.5
+ * @since 5.0
  * Output image to browser or file
  * @link http://php.net/manual/en/function.image2wbmp.php
  * @param resource $image 
@@ -2052,7 +2142,8 @@ function png2wbmp ($pngname, $wbmpname, $dest_height, $dest_width, $threshold) {
 function image2wbmp ($image, $filename = null, $threshold = null) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Set the alpha blending flag to use the bundled libgd layering effects
  * @link http://php.net/manual/en/function.imagelayereffect.php
  * @param resource $image 
@@ -2119,7 +2210,7 @@ function imagexbm ($image, $filename, $foreground = null) {}
 function imagefilter ($image, $filtertype, $arg1 = null, $arg2 = null, $arg3 = null, $arg4 = null) {}
 
 /**
- * (PHP 5 &gt;= 5.1.0)<br/>
+ * @since 5.1.0
  * Apply a 3x3 convolution matrix, using coefficient and offset
  * @link http://php.net/manual/en/function.imageconvolution.php
  * @param resource $image 
@@ -2443,212 +2534,212 @@ define ('PNG_FILTER_PAETH', 128);
 define ('PNG_ALL_FILTERS', 248);
 
 /**
- * (PHP 5 &gt;= 5.5.0)<br/>
+ * @since 5.5.0
  */
 define('IMG_AFFINE_TRANSLATE',0);
 
 /**
- * (PHP 5 &gt;= 5.5.0)<br/>
+ * @since 5.5.0
  */
 define('IMG_AFFINE_SCALE',1);
 
 /**
- * (PHP 5 &gt;= 5.5.0)<br/>
+ * @since 5.5.0
  */
 define('IMG_AFFINE_ROTATE',2);
 
 /**
- * (PHP 5 &gt;= 5.5.0)<br/>
+ * @since 5.5.0
  */
 define('IMG_AFFINE_SHEAR_HORIZONTAL',3);
 
 /**
- * (PHP 5 &gt;= 5.5.0)<br/>
+ * @since 5.5.0
  */
 define('IMG_AFFINE_SHEAR_VERTICAL',4);
 
 /**
- * (PHP 5 &gt;= 5.5.0)<br/>
+ * @since 5.5.0
  */
 define('IMG_CROP_DEFAULT',0);
 
 /**
- * (PHP 5 &gt;= 5.5.0)<br/>
+ * @since 5.5.0
  */
 define('IMG_CROP_TRANSPARENT',1);
 
 /**
- * (PHP 5 &gt;= 5.5.0)<br/>
+ * @since 5.5.0
  */
 define('IMG_CROP_BLACK',2);
 
 /**
- * (PHP 5 &gt;= 5.5.0)<br/>
+ * @since 5.5.0
  */
 define('IMG_CROP_WHITE',3);
 
 /**
- * (PHP 5 &gt;= 5.5.0)<br/>
+ * @since 5.5.0
  */
 define('IMG_CROP_SIDES',4);
 
 /**
- * (PHP 5 &gt;= 5.5.0)<br/>
+ * @since 5.5.0
  */
 define('IMG_FLIP_BOTH',3);
 
 /**
- * (PHP 5 &gt;= 5.5.0)<br/>
+ * @since 5.5.0
  */
 define('IMG_FLIP_HORIZONTAL',1);
 
 /**
- * (PHP 5 &gt;= 5.5.0)<br/>
+ * @since 5.5.0
  */
 define('IMG_FLIP_VERTICAL',2);
 
 /**
- * (PHP 5 &gt;= 5.5.0)<br/>
+ * @since 5.5.0
  * Used together with imagesetinterpolation().
  * @link http://php.net/manual/en/image.constants.php
  */
 define('IMG_BELL', 1);
 
 /**
- * (PHP 5 &gt;= 5.5.0)<br/>
+ * @since 5.5.0
  * Used together with imagesetinterpolation().
  * @link http://php.net/manual/en/image.constants.php
  */
 define('IMG_BESSEL', 2);
 
 /**
- * (PHP 5 &gt;= 5.5.0)<br/>
+ * @since 5.5.0
  * Used together with imagesetinterpolation().
  * @link http://php.net/manual/en/image.constants.php
  */
 define('IMG_BICUBIC', 4);
 
 /**
- * (PHP 5 &gt;= 5.5.0)<br/>
+ * @since 5.5.0
  * Used together with imagesetinterpolation().
  * @link http://php.net/manual/en/image.constants.php
  */
 define('IMG_BICUBIC_FIXED', 5);
 
 /**
- * (PHP 5 &gt;= 5.5.0)<br/>
+ * @since 5.5.0
  * Used together with imagesetinterpolation().
  * @link http://php.net/manual/en/image.constants.php
  */
 define('IMG_BILINEAR_FIXED', 3);
 
 /**
- * (PHP 5 &gt;= 5.5.0)<br/>
+ * @since 5.5.0
  * Used together with imagesetinterpolation().
  * @link http://php.net/manual/en/image.constants.php
  */
 define('IMG_BLACKMAN', 6);
 
 /**
- * (PHP 5 &gt;= 5.5.0)<br/>
+ * @since 5.5.0
  * Used together with imagesetinterpolation().
  * @link http://php.net/manual/en/image.constants.php
  */
 define('IMG_BOX', 7);
 
 /**
- * (PHP 5 &gt;= 5.5.0)<br/>
+ * @since 5.5.0
  * Used together with imagesetinterpolation().
  * @link http://php.net/manual/en/image.constants.php
  */
 define('IMG_BSPLINE', 8);
 
 /**
- * (PHP 5 &gt;= 5.5.0)<br/>
+ * @since 5.5.0
  * Used together with imagesetinterpolation().
  * @link http://php.net/manual/en/image.constants.php
  */
 define('IMG_CATMULLROM', 9);
 
 /**
- * (PHP 5 &gt;= 5.5.0)<br/>
+ * @since 5.5.0
  * Used together with imagesetinterpolation().
  * @link http://php.net/manual/en/image.constants.php
  */
 define('IMG_GAUSSIAN', 10);
 
 /**
- * (PHP 5 &gt;= 5.5.0)<br/>
+ * @since 5.5.0
  * Used together with imagesetinterpolation().
  * @link http://php.net/manual/en/image.constants.php
  */
 define('IMG_GENERALIZED_CUBIC', 11);
 
 /**
- * (PHP 5 &gt;= 5.5.0)<br/>
+ * @since 5.5.0
  * Used together with imagesetinterpolation().
  * @link http://php.net/manual/en/image.constants.php
  */
 define('IMG_HERMITE', 12);
 
 /**
- * (PHP 5 &gt;= 5.5.0)<br/>
+ * @since 5.5.0
  * Used together with imagesetinterpolation().
  * @link http://php.net/manual/en/image.constants.php
  */
 define('IMG_HAMMING', 13);
 
 /**
- * (PHP 5 &gt;= 5.5.0)<br/>
+ * @since 5.5.0
  * Used together with imagesetinterpolation().
  * @link http://php.net/manual/en/image.constants.php
  */
 define('IMG_HANNING', 14);
 
 /**
- * (PHP 5 &gt;= 5.5.0)<br/>
+ * @since 5.5.0
  * Used together with imagesetinterpolation().
  * @link http://php.net/manual/en/image.constants.php
  */
 define('IMG_MITCHELL', 15);
 
 /**
- * (PHP 5 &gt;= 5.5.0)<br/>
+ * @since 5.5.0
  * Used together with imagesetinterpolation().
  * @link http://php.net/manual/en/image.constants.php
  */
 define('IMG_POWER', 17);
 
 /**
- * (PHP 5 &gt;= 5.5.0)<br/>
+ * @since 5.5.0
  * Used together with imagesetinterpolation().
  * @link http://php.net/manual/en/image.constants.php
  */
 define('IMG_QUADRATIC', 18);
 
 /**
- * (PHP 5 &gt;= 5.5.0)<br/>
+ * @since 5.5.0
  * Used together with imagesetinterpolation().
  * @link http://php.net/manual/en/image.constants.php
  */
 define('IMG_SINC', 19);
 
 /**
- * (PHP 5 &gt;= 5.5.0)<br/>
+ * @since 5.5.0
  * Used together with imagesetinterpolation().
  * @link http://php.net/manual/en/image.constants.php
  */
 define('IMG_NEAREST_NEIGHBOUR', 16);
 
 /**
- * (PHP 5 &gt;= 5.5.0)<br/>
+ * @since 5.5.0
  * Used together with imagesetinterpolation().
  * @link http://php.net/manual/en/image.constants.php
  */
 define('IMG_WEIGHTED4', 21);
 
 /**
- * (PHP 5 &gt;= 5.5.0)<br/>
+ * @since 5.5.0
  * Used together with imagesetinterpolation().
  * @link http://php.net/manual/en/image.constants.php
  */

--- a/gettext.php
+++ b/gettext.php
@@ -3,7 +3,8 @@
 // Start of gettext v.
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Sets the default domain
  * @link http://php.net/manual/en/function.textdomain.php
  * @param string $text_domain <p>
@@ -16,7 +17,8 @@
 function textdomain ($text_domain) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Lookup a message in the current domain
  * @link http://php.net/manual/en/function.gettext.php
  * @param string $message <p>
@@ -28,7 +30,8 @@ function textdomain ($text_domain) {}
 function gettext ($message) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Lookup a message in the current domain
  * @link http://php.net/manual/en/function.gettext.php
  * @param string $message <p>
@@ -40,7 +43,8 @@ function gettext ($message) {}
 function _ ($message) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Override the current domain
  * @link http://php.net/manual/en/function.dgettext.php
  * @param string $domain <p>
@@ -54,7 +58,8 @@ function _ ($message) {}
 function dgettext ($domain, $message) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Overrides the domain for a single lookup
  * @link http://php.net/manual/en/function.dcgettext.php
  * @param string $domain <p>
@@ -71,7 +76,8 @@ function dgettext ($domain, $message) {}
 function dcgettext ($domain, $message, $category) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Sets the path for a domain
  * @link http://php.net/manual/en/function.bindtextdomain.php
  * @param string $domain <p>
@@ -85,7 +91,8 @@ function dcgettext ($domain, $message, $category) {}
 function bindtextdomain ($domain, $directory) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Plural version of gettext
  * @link http://php.net/manual/en/function.ngettext.php
  * @param string $msgid1
@@ -98,7 +105,8 @@ function bindtextdomain ($domain, $directory) {}
 function ngettext ($msgid1, $msgid2, $n) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Plural version of dgettext
  * @link http://php.net/manual/en/function.dngettext.php
  * @param string $domain <p>
@@ -112,7 +120,8 @@ function ngettext ($msgid1, $msgid2, $n) {}
 function dngettext ($domain, $msgid1, $msgid2, $n) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Plural version of dcgettext
  * @link http://php.net/manual/en/function.dcngettext.php
  * @param string $domain <p>
@@ -127,7 +136,8 @@ function dngettext ($domain, $msgid1, $msgid2, $n) {}
 function dcngettext ($domain, $msgid1, $msgid2, $n, $category) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Specify the character encoding in which the messages from the DOMAIN message catalog will be returned
  * @link http://php.net/manual/en/function.bind-textdomain-codeset.php
  * @param string $domain <p>

--- a/gmp.php
+++ b/gmp.php
@@ -3,7 +3,8 @@
 // Start of gmp v.
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Create GMP number
  * @link http://php.net/manual/en/function.gmp-init.php
  * @param mixed $number <p>
@@ -25,7 +26,8 @@
 function gmp_init ($number, $base = 0) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Convert GMP number to integer
  * @link http://php.net/manual/en/function.gmp-intval.php
  * @param resource $gmpnumber <p>
@@ -36,7 +38,8 @@ function gmp_init ($number, $base = 0) {}
 function gmp_intval ($gmpnumber) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Convert GMP number to string
  * @link http://php.net/manual/en/function.gmp-strval.php
  * @param resource|string $gmpnumber <p>
@@ -53,7 +56,8 @@ function gmp_intval ($gmpnumber) {}
 function gmp_strval ($gmpnumber, $base = 10) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Add numbers
  * @link http://php.net/manual/en/function.gmp-add.php
  * @param resource|string $a <p>
@@ -71,7 +75,8 @@ function gmp_strval ($gmpnumber, $base = 10) {}
 function gmp_add ($a, $b) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Subtract numbers
  * @link http://php.net/manual/en/function.gmp-sub.php
  * @param resource|string $a <p>
@@ -89,7 +94,8 @@ function gmp_add ($a, $b) {}
 function gmp_sub ($a, $b) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Multiply numbers
  * @link http://php.net/manual/en/function.gmp-mul.php
  * @param resource|string $a <p>
@@ -107,7 +113,8 @@ function gmp_sub ($a, $b) {}
 function gmp_mul ($a, $b) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Divide numbers and get quotient and remainder
  * @link http://php.net/manual/en/function.gmp-div-qr.php
  * @param resource|string $n <p>
@@ -132,7 +139,8 @@ function gmp_mul ($a, $b) {}
 function gmp_div_qr ($n, $d, $round = GMP_ROUND_ZERO) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Divide numbers
  * @link http://php.net/manual/en/function.gmp-div-q.php
  * @param resource|string $a <p>
@@ -156,7 +164,8 @@ function gmp_div_qr ($n, $d, $round = GMP_ROUND_ZERO) {}
 function gmp_div_q ($a, $b, $round = GMP_ROUND_ZERO) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Remainder of the division of numbers
  * @link http://php.net/manual/en/function.gmp-div-r.php
  * @param resource|string $n <p>
@@ -178,7 +187,8 @@ function gmp_div_q ($a, $b, $round = GMP_ROUND_ZERO) {}
 function gmp_div_r ($n, $d, $round = GMP_ROUND_ZERO) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Divide numbers
  * @link http://php.net/manual/en/function.gmp-div-q.php
  * @param resource|string|GMP $a <p>
@@ -202,7 +212,8 @@ function gmp_div_r ($n, $d, $round = GMP_ROUND_ZERO) {}
 function gmp_div ($a, $b, $round = GMP_ROUND_ZERO) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Modulo operation
  * @link http://php.net/manual/en/function.gmp-mod.php
  * @param resource|string $n It can be either a GMP number resource, or a
@@ -217,7 +228,8 @@ function gmp_div ($a, $b, $round = GMP_ROUND_ZERO) {}
 function gmp_mod ($n, $d) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Exact division of numbers
  * @link http://php.net/manual/en/function.gmp-divexact.php
  * @param resource|string|GMP $n <p>
@@ -235,7 +247,8 @@ function gmp_mod ($n, $d) {}
 function gmp_divexact ($n, $d) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Negate number
  * @link http://php.net/manual/en/function.gmp-neg.php
  * @param resource|string $a It can be either a GMP number resource, or a
@@ -245,7 +258,8 @@ function gmp_divexact ($n, $d) {}
 function gmp_neg ($a) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Absolute value
  * @link http://php.net/manual/en/function.gmp-abs.php
  * @param resource|string $a It can be either a GMP number resource, or a
@@ -255,7 +269,8 @@ function gmp_neg ($a) {}
 function gmp_abs ($a) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Factorial
  * @link http://php.net/manual/en/function.gmp-fact.php
  * @param resource|string $a <p>
@@ -268,7 +283,8 @@ function gmp_abs ($a) {}
 function gmp_fact ($a) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Calculate square root
  * @link http://php.net/manual/en/function.gmp-sqrt.php
  * @param resource|string $a It can be either a GMP number resource, or a
@@ -278,7 +294,8 @@ function gmp_fact ($a) {}
 function gmp_sqrt ($a) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Square root with remainder
  * @link http://php.net/manual/en/function.gmp-sqrtrem.php
  * @param resource|string $a <p>
@@ -294,7 +311,8 @@ function gmp_sqrt ($a) {}
 function gmp_sqrtrem ($a) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Raise number into power
  * @link http://php.net/manual/en/function.gmp-pow.php
  * @param resource|string $base <p>
@@ -311,7 +329,8 @@ function gmp_sqrtrem ($a) {}
 function gmp_pow ($base, $exp) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Raise number into power with modulo
  * @link http://php.net/manual/en/function.gmp-powm.php
  * @param resource|string $base <p>
@@ -334,7 +353,8 @@ function gmp_pow ($base, $exp) {}
 function gmp_powm ($base, $exp, $mod) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Perfect square check
  * @link http://php.net/manual/en/function.gmp-perfect-square.php
  * @param resource|string $a <p>
@@ -348,7 +368,8 @@ function gmp_powm ($base, $exp, $mod) {}
 function gmp_perfect_square ($a) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Check if number is "probably prime"
  * @link http://php.net/manual/en/function.gmp-prob-prime.php
  * @param resource|string $a <p>
@@ -372,7 +393,8 @@ function gmp_perfect_square ($a) {}
 function gmp_prob_prime ($a, $reps = 10) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Calculate GCD
  * @link http://php.net/manual/en/function.gmp-gcd.php
  * @param resource|string $a It can be either a GMP number resource, or a
@@ -385,7 +407,8 @@ function gmp_prob_prime ($a, $reps = 10) {}
 function gmp_gcd ($a, $b) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Calculate GCD and multipliers
  * @link http://php.net/manual/en/function.gmp-gcdext.php
  * @param resource|string $a It can be either a GMP number resource, or a
@@ -397,7 +420,8 @@ function gmp_gcd ($a, $b) {}
 function gmp_gcdext ($a, $b) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Inverse by modulo
  * @link http://php.net/manual/en/function.gmp-invert.php
  * @param resource|string $a It can be either a GMP number resource, or a
@@ -409,7 +433,8 @@ function gmp_gcdext ($a, $b) {}
 function gmp_invert ($a, $b) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Jacobi symbol
  * @link http://php.net/manual/en/function.gmp-jacobi.php
  * @param resource|string $a It can be either a GMP number resource, or a
@@ -424,7 +449,8 @@ function gmp_invert ($a, $b) {}
 function gmp_jacobi ($a, $p) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Legendre symbol
  * @link http://php.net/manual/en/function.gmp-legendre.php
  * @param resource|string $a It can be either a GMP number resource, or a
@@ -439,7 +465,8 @@ function gmp_jacobi ($a, $p) {}
 function gmp_legendre ($a, $p) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Compare numbers
  * @link http://php.net/manual/en/function.gmp-cmp.php
  * @param resource|string $a It can be either a GMP number resource, or a
@@ -453,7 +480,8 @@ function gmp_legendre ($a, $p) {}
 function gmp_cmp ($a, $b) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Sign of number
  * @link http://php.net/manual/en/function.gmp-sign.php
  * @param resource|string $a It can be either a GMP number resource, or a
@@ -465,7 +493,8 @@ function gmp_cmp ($a, $b) {}
 function gmp_sign ($a) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Random number
  * @link http://php.net/manual/en/function.gmp-random.php
  * @param int $limiter [optional] <p>
@@ -478,7 +507,8 @@ function gmp_sign ($a) {}
 function gmp_random ($limiter = 20) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Bitwise AND
  * @link http://php.net/manual/en/function.gmp-and.php
  * @param resource|string $a It can be either a GMP number resource, or a
@@ -490,7 +520,8 @@ function gmp_random ($limiter = 20) {}
 function gmp_and ($a, $b) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Bitwise OR
  * @link http://php.net/manual/en/function.gmp-or.php
  * @param resource|string $a It can be either a GMP number resource, or a
@@ -502,7 +533,8 @@ function gmp_and ($a, $b) {}
 function gmp_or ($a, $b) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Calculates one's complement
  * @link http://php.net/manual/en/function.gmp-com.php
  * @param resource|string $a It can be either a GMP number resource, or a
@@ -512,7 +544,8 @@ function gmp_or ($a, $b) {}
 function gmp_com ($a) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Bitwise XOR
  * @link http://php.net/manual/en/function.gmp-xor.php
  * @param resource|string $a It can be either a GMP number resource, or a
@@ -524,7 +557,8 @@ function gmp_com ($a) {}
 function gmp_xor ($a, $b) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Set bit
  * @link http://php.net/manual/en/function.gmp-setbit.php
  * @param resource|string $a <p>
@@ -544,7 +578,8 @@ function gmp_xor ($a, $b) {}
 function gmp_setbit (&$a, $index, $set_clear = true) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Clear bit
  * @link http://php.net/manual/en/function.gmp-clrbit.php
  * @param resource|string|GMP $a It can be either a GMP number resource, or a
@@ -556,7 +591,8 @@ function gmp_setbit (&$a, $index, $set_clear = true) {}
 function gmp_clrbit (&$a, $index) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Scan for 0
  * @link http://php.net/manual/en/function.gmp-scan0.php
  * @param resource|string $a <p>
@@ -573,7 +609,8 @@ function gmp_clrbit (&$a, $index) {}
 function gmp_scan0 ($a, $start) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Scan for 1
  * @link http://php.net/manual/en/function.gmp-scan1.php
  * @param resource|string $a <p>
@@ -590,7 +627,7 @@ function gmp_scan0 ($a, $start) {}
 function gmp_scan1 ($a, $start) {}
 
 /**
- * (PHP 5 &gt;= 5.3.0)<br/>
+ * @since 5.3.0
  * Tests if a bit is set
  * @link http://php.net/manual/en/function.gmp-testbit.php
  * @param resource|string|GMP $a It can be either a GMP number resource, or a
@@ -603,7 +640,8 @@ function gmp_scan1 ($a, $start) {}
 function gmp_testbit ($a, $index) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Population count
  * @link http://php.net/manual/en/function.gmp-popcount.php
  * @param resource|string $a It can be either a GMP number resource, or a
@@ -613,7 +651,8 @@ function gmp_testbit ($a, $index) {}
 function gmp_popcount ($a) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Hamming distance
  * @link http://php.net/manual/en/function.gmp-hamdist.php
  * @param resource|string|GMP $a It can be either a GMP number resource, or a
@@ -631,7 +670,7 @@ function gmp_popcount ($a) {}
 function gmp_hamdist ($a, $b) {}
 
 /**
- * (PHP 5 &gt;= 5.2.0)<br/>
+ * @since 5.2.0
  * Find next prime number
  * @link http://php.net/manual/en/function.gmp-nextprime.php
  * @param resource|string $a It can be either a GMP number resource, or a
@@ -654,7 +693,7 @@ define ('GMP_VERSION', "");
 class GMP implements Serializable {
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * String representation of object
      * @link http://php.net/manual/en/serializable.serialize.php
      * @return string the string representation of the object or null
@@ -662,7 +701,7 @@ class GMP implements Serializable {
     public function serialize() {}
 
     /**
-     * (PHP 5 &gt;= 5.1.0)<br/>
+     * @since 5.1.0
      * Constructs the object
      * @link http://php.net/manual/en/serializable.unserialize.php
      * @param string $serialized <p>

--- a/hash.php
+++ b/hash.php
@@ -23,7 +23,7 @@
 function hash ($algo, $data, $raw_output = false) {}
 
 /**
- * (PHP 5 &gt;= 5.6.0)<br/>
+ * @since 5.6.0
  * Timing attack safe string comparison
  * @link http://php.net/manual/en/function.hash-equals.php
  * @param string $known_string <p>The string of known length to compare against</p>
@@ -188,7 +188,7 @@ function hash_update_file ($hcontext, $filename, $scontext = null) {}
 function hash_final ($context, $raw_output = false) {}
 
 /**
- * (PHP 5 &gt;= 5.3.0)<br/>
+ * @since 5.3.0
  * Copy hashing context
  * @link http://php.net/manual/en/function.hash-copy.php
  * @param resource $context <p>
@@ -208,7 +208,7 @@ function hash_copy ($context) {}
 function hash_algos () {}
 
 /**
- * (PHP 5 &gt;= 5.5.0)<br/>
+ * @since 5.5.0
  * Generate a PBKDF2 key derivation of a supplied password
  * @link http://php.net/manual/en/function.hash-pbkdf2.php
  * @param $algo
@@ -224,7 +224,8 @@ function hash_algos () {}
 function hash_pbkdf2 ($algo, $password, $salt, $iterations, $length, $raw_output) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Generates a key
  * @link http://php.net/manual/en/function.mhash-keygen-s2k.php
  * @param int $hash <p>
@@ -249,7 +250,8 @@ function hash_pbkdf2 ($algo, $password, $salt, $iterations, $length, $raw_output
 function mhash_keygen_s2k ($hash, $password, $salt, $bytes) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Gets the block size of the specified hash
  * @link http://php.net/manual/en/function.mhash-get-block-size.php
  * @param int $hash <p>
@@ -261,7 +263,8 @@ function mhash_keygen_s2k ($hash, $password, $salt, $bytes) {}
 function mhash_get_block_size ($hash) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Gets the name of the specified hash
  * @link http://php.net/manual/en/function.mhash-get-hash-name.php
  * @param int $hash <p>
@@ -272,7 +275,8 @@ function mhash_get_block_size ($hash) {}
 function mhash_get_hash_name ($hash) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Gets the highest available hash ID
  * @link http://php.net/manual/en/function.mhash-count.php
  * @return int the highest available hash ID. Hashes are numbered from 0 to this
@@ -281,7 +285,8 @@ function mhash_get_hash_name ($hash) {}
 function mhash_count () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Computes hash
  * @link http://php.net/manual/en/function.mhash.php
  * @param int $hash <p>

--- a/iconv.php
+++ b/iconv.php
@@ -3,7 +3,8 @@
 // Start of iconv v.
 
 /**
- * (PHP 4 &gt;= 4.0.5, PHP 5)<br/>
+ * @since 4.0.5
+ * @since 5.0
  * Convert string to requested character encoding
  * @link http://php.net/manual/en/function.iconv.php
  * @param string $in_charset <p>
@@ -30,7 +31,8 @@
 function iconv ($in_charset, $out_charset, $str) {}
 
 /**
- * (PHP 4 &gt;= 4.0.5, PHP 5)<br/>
+ * @since 4.0.5
+ * @since 5.0
  * Convert character encoding as output buffer handler
  * @link http://php.net/manual/en/function.ob-iconv-handler.php
  * @param string $contents 
@@ -41,7 +43,8 @@ function iconv ($in_charset, $out_charset, $str) {}
 function ob_iconv_handler ($contents, $status) {}
 
 /**
- * (PHP 4 &gt;= 4.0.5, PHP 5)<br/>
+ * @since 4.0.5
+ * @since 5.0
  * Retrieve internal configuration variables of iconv extension
  * @link http://php.net/manual/en/function.iconv-get-encoding.php
  * @param string $type [optional] <p>
@@ -62,7 +65,8 @@ function ob_iconv_handler ($contents, $status) {}
 function iconv_get_encoding ($type = "all") {}
 
 /**
- * (PHP 4 &gt;= 4.0.5, PHP 5)<br/>
+ * @since 4.0.5
+ * @since 5.0
  * Set current setting for character encoding conversion
  * @link http://php.net/manual/en/function.iconv-set-encoding.php
  * @param string $type <p>
@@ -79,7 +83,7 @@ function iconv_get_encoding ($type = "all") {}
 function iconv_set_encoding ($type, $charset) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Returns the character count of string
  * @link http://php.net/manual/en/function.iconv-strlen.php
  * @param string $str <p>
@@ -95,7 +99,7 @@ function iconv_set_encoding ($type, $charset) {}
 function iconv_strlen ($str, $charset = 'ini_get("iconv.internal_encoding")') {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Cut out part of a string
  * @link http://php.net/manual/en/function.iconv-substr.php
  * @param string $str <p>
@@ -150,7 +154,7 @@ function iconv_strlen ($str, $charset = 'ini_get("iconv.internal_encoding")') {}
 function iconv_substr ($str, $offset, $length = 'iconv_strlen($str, $charset)', $charset = 'ini_get("iconv.internal_encoding")') {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Finds position of first occurrence of a needle within a haystack
  * @link http://php.net/manual/en/function.iconv-strpos.php
  * @param string $haystack <p>
@@ -178,7 +182,7 @@ function iconv_substr ($str, $offset, $length = 'iconv_strlen($str, $charset)', 
 function iconv_strpos ($haystack, $needle, $offset = 0, $charset = 'ini_get("iconv.internal_encoding")') {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Finds the last occurrence of a needle within a haystack
  * @link http://php.net/manual/en/function.iconv-strrpos.php
  * @param string $haystack <p>
@@ -202,7 +206,7 @@ function iconv_strpos ($haystack, $needle, $offset = 0, $charset = 'ini_get("ico
 function iconv_strrpos ($haystack, $needle, $charset = 'ini_get("iconv.internal_encoding")') {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Composes a MIME header field
  * @link http://php.net/manual/en/function.iconv-mime-encode.php
  * @param string $field_name <p>
@@ -303,7 +307,7 @@ function iconv_strrpos ($haystack, $needle, $charset = 'ini_get("iconv.internal_
 function iconv_mime_encode ($field_name, $field_value, array $preferences = null) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Decodes a MIME header field
  * @link http://php.net/manual/en/function.iconv-mime-decode.php
  * @param string $encoded_header <p>
@@ -355,7 +359,7 @@ function iconv_mime_encode ($field_name, $field_value, array $preferences = null
 function iconv_mime_decode ($encoded_header, $mode = 0, $charset = 'ini_get("iconv.internal_encoding")') {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Decodes multiple MIME header fields at once
  * @link http://php.net/manual/en/function.iconv-mime-decode-headers.php
  * @param string $encoded_headers <p>

--- a/imap.php
+++ b/imap.php
@@ -3,7 +3,8 @@
 // Start of imap v.
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Open an IMAP stream to a mailbox
  * @link http://php.net/manual/en/function.imap-open.php
  * @param string $mailbox <p>
@@ -50,7 +51,8 @@
 function imap_open ($mailbox, $username, $password, $options = 0, $n_retries = 0, array $params = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Reopen IMAP stream to new mailbox
  * @link http://php.net/manual/en/function.imap-reopen.php
  * @param resource $imap_stream 
@@ -70,7 +72,8 @@ function imap_open ($mailbox, $username, $password, $options = 0, $n_retries = 0
 function imap_reopen ($imap_stream, $mailbox, $options = 0, $n_retries = 0) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Close an IMAP stream
  * @link http://php.net/manual/en/function.imap-close.php
  * @param resource $imap_stream 
@@ -85,7 +88,8 @@ function imap_reopen ($imap_stream, $mailbox, $options = 0, $n_retries = 0) {}
 function imap_close ($imap_stream, $flag = 0) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Gets the number of messages in the current mailbox
  * @link http://php.net/manual/en/function.imap-num-msg.php
  * @param resource $imap_stream 
@@ -94,7 +98,8 @@ function imap_close ($imap_stream, $flag = 0) {}
 function imap_num_msg ($imap_stream) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Gets the number of recent messages in current mailbox
  * @link http://php.net/manual/en/function.imap-num-recent.php
  * @param resource $imap_stream 
@@ -104,7 +109,8 @@ function imap_num_msg ($imap_stream) {}
 function imap_num_recent ($imap_stream) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Returns headers for all messages in a mailbox
  * @link http://php.net/manual/en/function.imap-headers.php
  * @param resource $imap_stream 
@@ -114,7 +120,8 @@ function imap_num_recent ($imap_stream) {}
 function imap_headers ($imap_stream) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Read the header of the message
  * @link http://php.net/manual/en/function.imap-headerinfo.php
  * @param resource $stream_id An IMAP stream returned by imap_open().
@@ -165,7 +172,8 @@ function imap_headers ($imap_stream) {}
 function imap_headerinfo ($stream_id, $msg_no, $from_length = 0, $subject_length = 0, $default_host = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Parse mail headers from a string
  * @link http://php.net/manual/en/function.imap-rfc822-parse-headers.php
  * @param string $headers <p>
@@ -181,7 +189,8 @@ function imap_headerinfo ($stream_id, $msg_no, $from_length = 0, $subject_length
 function imap_rfc822_parse_headers ($headers, $defaulthost = UNKNOWN) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Returns a properly formatted email address given the mailbox, host, and personal info
  * @link http://php.net/manual/en/function.imap-rfc822-write-address.php
  * @param string $mailbox <p>
@@ -199,7 +208,8 @@ function imap_rfc822_parse_headers ($headers, $defaulthost = UNKNOWN) {}
 function imap_rfc822_write_address ($mailbox, $host, $personal) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Parses an address string
  * @link http://php.net/manual/en/function.imap-rfc822-parse-adrlist.php
  * @param string $address <p>
@@ -219,7 +229,8 @@ function imap_rfc822_write_address ($mailbox, $host, $personal) {}
 function imap_rfc822_parse_adrlist ($address, $default_host) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Read the message body
  * @link http://php.net/manual/en/function.imap-body.php
  * @param resource $imap_stream 
@@ -235,7 +246,8 @@ function imap_rfc822_parse_adrlist ($address, $default_host) {}
 function imap_body ($imap_stream, $msg_number, $options = 0) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Read the structure of a specified body section of a specific message
  * @link http://php.net/manual/en/function.imap-bodystruct.php
  * @param resource $imap_stream 
@@ -252,7 +264,8 @@ function imap_body ($imap_stream, $msg_number, $options = 0) {}
 function imap_bodystruct ($imap_stream, $msg_number, $section) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Fetch a particular section of the body of the message
  * @link http://php.net/manual/en/function.imap-fetchbody.php
  * @param resource $imap_stream 
@@ -272,7 +285,7 @@ function imap_bodystruct ($imap_stream, $msg_number, $section) {}
 function imap_fetchbody ($imap_stream, $msg_number, $section, $options = 0) {}
 
 /**
- * (PHP 5 &gt;= 5.3.6)<br/>
+ * @since 5.3.6
  * Fetch MIME headers for a particular section of the message
  * @link http://php.net/manual/en/function.imap-fetchmime.php
  * @param resource $imap_stream
@@ -292,7 +305,7 @@ function imap_fetchbody ($imap_stream, $msg_number, $section, $options = 0) {}
 function imap_fetchmime ($imap_stream, $msg_number, $section, $options = 0) {}
 
 /**
- * (PHP 5 &gt;= 5.1.3)<br/>
+ * @since 5.1.3
  * Save a specific body section to a file
  * @link http://php.net/manual/en/function.imap-savebody.php
  * @param resource $imap_stream 
@@ -315,7 +328,8 @@ function imap_fetchmime ($imap_stream, $msg_number, $section, $options = 0) {}
 function imap_savebody ($imap_stream, $file, $msg_number, $part_number = "", $options = 0) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Returns header for a message
  * @link http://php.net/manual/en/function.imap-fetchheader.php
  * @param resource $imap_stream 
@@ -331,7 +345,8 @@ function imap_savebody ($imap_stream, $file, $msg_number, $part_number = "", $op
 function imap_fetchheader ($imap_stream, $msg_number, $options = 0) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Read the structure of a particular message
  * @link http://php.net/manual/en/function.imap-fetchstructure.php
  * @param resource $imap_stream 
@@ -456,7 +471,7 @@ function imap_fetchheader ($imap_stream, $msg_number, $options = 0) {}
 function imap_fetchstructure ($imap_stream, $msg_number, $options = 0) {}
 
 /**
- * (PHP 5 &gt;= 5.3.0)<br/>
+ * @since 5.3.0
  * Clears IMAP cache
  * @link http://php.net/manual/en/function.imap-gc.php
  * @param resource $imap_stream 
@@ -472,7 +487,8 @@ function imap_fetchstructure ($imap_stream, $msg_number, $options = 0) {}
 function imap_gc ($imap_stream, $caches) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Delete all messages marked for deletion
  * @link http://php.net/manual/en/function.imap-expunge.php
  * @param resource $imap_stream 
@@ -481,7 +497,8 @@ function imap_gc ($imap_stream, $caches) {}
 function imap_expunge ($imap_stream) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Mark a message for deletion from current mailbox
  * @link http://php.net/manual/en/function.imap-delete.php
  * @param resource $imap_stream 
@@ -498,7 +515,8 @@ function imap_expunge ($imap_stream) {}
 function imap_delete ($imap_stream, $msg_number, $options = 0) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Unmark the message which is marked deleted
  * @link http://php.net/manual/en/function.imap-undelete.php
  * @param resource $imap_stream 
@@ -511,7 +529,8 @@ function imap_delete ($imap_stream, $msg_number, $options = 0) {}
 function imap_undelete ($imap_stream, $msg_number, $flags = 0) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Check current mailbox
  * @link http://php.net/manual/en/function.imap-check.php
  * @param resource $imap_stream 
@@ -529,7 +548,8 @@ function imap_undelete ($imap_stream, $msg_number, $flags = 0) {}
 function imap_check ($imap_stream) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Returns the list of mailboxes that matches the given text
  * @link http://php.net/manual/en/function.imap-listscan.php
  * @param resource $imap_stream 
@@ -558,7 +578,8 @@ function imap_check ($imap_stream) {}
 function imap_listscan ($imap_stream, $ref, $pattern, $content) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Copy specified messages to a mailbox
  * @link http://php.net/manual/en/function.imap-mail-copy.php
  * @param resource $imap_stream 
@@ -578,7 +599,8 @@ function imap_listscan ($imap_stream, $ref, $pattern, $content) {}
 function imap_mail_copy ($imap_stream, $msglist, $mailbox, $options = 0) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Move specified messages to a mailbox
  * @link http://php.net/manual/en/function.imap-mail-move.php
  * @param resource $imap_stream 
@@ -598,7 +620,8 @@ function imap_mail_copy ($imap_stream, $msglist, $mailbox, $options = 0) {}
 function imap_mail_move ($imap_stream, $msglist, $mailbox, $options = 0) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Create a MIME message based on given envelope and body sections
  * @link http://php.net/manual/en/function.imap-mail-compose.php
  * @param array $envelope <p>
@@ -621,7 +644,8 @@ function imap_mail_move ($imap_stream, $msglist, $mailbox, $options = 0) {}
 function imap_mail_compose (array $envelope, array $body) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Create a new mailbox
  * @link http://php.net/manual/en/function.imap-createmailbox.php
  * @param resource $imap_stream 
@@ -635,7 +659,8 @@ function imap_mail_compose (array $envelope, array $body) {}
 function imap_createmailbox ($imap_stream, $mailbox) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Rename an old mailbox to new mailbox
  * @link http://php.net/manual/en/function.imap-renamemailbox.php
  * @param resource $imap_stream 
@@ -652,7 +677,8 @@ function imap_createmailbox ($imap_stream, $mailbox) {}
 function imap_renamemailbox ($imap_stream, $old_mbox, $new_mbox) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Delete a mailbox
  * @link http://php.net/manual/en/function.imap-deletemailbox.php
  * @param resource $imap_stream 
@@ -665,7 +691,8 @@ function imap_renamemailbox ($imap_stream, $old_mbox, $new_mbox) {}
 function imap_deletemailbox ($imap_stream, $mailbox) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Subscribe to a mailbox
  * @link http://php.net/manual/en/function.imap-subscribe.php
  * @param resource $imap_stream 
@@ -678,7 +705,8 @@ function imap_deletemailbox ($imap_stream, $mailbox) {}
 function imap_subscribe ($imap_stream, $mailbox) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Unsubscribe from a mailbox
  * @link http://php.net/manual/en/function.imap-unsubscribe.php
  * @param resource $imap_stream 
@@ -691,7 +719,8 @@ function imap_subscribe ($imap_stream, $mailbox) {}
 function imap_unsubscribe ($imap_stream, $mailbox) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Append a string message to a specified mailbox
  * @link http://php.net/manual/en/function.imap-append.php
  * @param resource $imap_stream 
@@ -719,7 +748,8 @@ function imap_unsubscribe ($imap_stream, $mailbox) {}
 function imap_append ($imap_stream, $mailbox, $message, $options = null, $internal_date = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Check if the IMAP stream is still active
  * @link http://php.net/manual/en/function.imap-ping.php
  * @param resource $imap_stream 
@@ -728,7 +758,8 @@ function imap_append ($imap_stream, $mailbox, $message, $options = null, $intern
 function imap_ping ($imap_stream) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Decode BASE64 encoded text
  * @link http://php.net/manual/en/function.imap-base64.php
  * @param string $text <p>
@@ -739,7 +770,8 @@ function imap_ping ($imap_stream) {}
 function imap_base64 ($text) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Convert a quoted-printable string to an 8 bit string
  * @link http://php.net/manual/en/function.imap-qprint.php
  * @param string $string <p>
@@ -750,7 +782,8 @@ function imap_base64 ($text) {}
 function imap_qprint ($string) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Convert an 8bit string to a quoted-printable string
  * @link http://php.net/manual/en/function.imap-8bit.php
  * @param string $string <p>
@@ -761,7 +794,8 @@ function imap_qprint ($string) {}
 function imap_8bit ($string) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Convert an 8bit string to a base64 string
  * @link http://php.net/manual/en/function.imap-binary.php
  * @param string $string <p>
@@ -772,7 +806,8 @@ function imap_8bit ($string) {}
 function imap_binary ($string) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Converts MIME-encoded text to UTF-8
  * @link http://php.net/manual/en/function.imap-utf8.php
  * @param string $mime_encoded_text <p>
@@ -784,7 +819,8 @@ function imap_binary ($string) {}
 function imap_utf8 ($mime_encoded_text) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Returns status information on a mailbox
  * @link http://php.net/manual/en/function.imap-status.php
  * @param resource $imap_stream 
@@ -814,7 +850,8 @@ function imap_status ($imap_stream, $mailbox, $options) {}
 function imap_status_current ($stream_id, $options) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get information about the current mailbox
  * @link http://php.net/manual/en/function.imap-mailboxmsginfo.php
  * @param resource $imap_stream 
@@ -861,7 +898,8 @@ function imap_status_current ($stream_id, $options) {}
 function imap_mailboxmsginfo ($imap_stream) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Sets flags on messages
  * @link http://php.net/manual/en/function.imap-setflag-full.php
  * @param resource $imap_stream 
@@ -885,7 +923,8 @@ function imap_mailboxmsginfo ($imap_stream) {}
 function imap_setflag_full ($imap_stream, $sequence, $flag, $options = NIL) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Clears flags on messages
  * @link http://php.net/manual/en/function.imap-clearflag-full.php
  * @param resource $imap_stream 
@@ -908,7 +947,8 @@ function imap_setflag_full ($imap_stream, $sequence, $flag, $options = NIL) {}
 function imap_clearflag_full ($imap_stream, $sequence, $flag, $options = 0) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Gets and sort messages
  * @link http://php.net/manual/en/function.imap-sort.php
  * @param resource $imap_stream 
@@ -930,7 +970,8 @@ function imap_clearflag_full ($imap_stream, $sequence, $flag, $options = 0) {}
 function imap_sort ($imap_stream, $criteria, $reverse, $options = 0, $search_criteria = null, $charset = 'NIL') {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * This function returns the UID for the given message sequence number
  * @link http://php.net/manual/en/function.imap-uid.php
  * @param resource $imap_stream 
@@ -942,7 +983,8 @@ function imap_sort ($imap_stream, $criteria, $reverse, $options = 0, $search_cri
 function imap_uid ($imap_stream, $msg_number) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Gets the message sequence number for the given UID
  * @link http://php.net/manual/en/function.imap-msgno.php
  * @param resource $imap_stream 
@@ -955,7 +997,8 @@ function imap_uid ($imap_stream, $msg_number) {}
 function imap_msgno ($imap_stream, $uid) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Read the list of mailboxes
  * @link http://php.net/manual/en/function.imap-list.php
  * @param resource $imap_stream 
@@ -980,7 +1023,8 @@ function imap_msgno ($imap_stream, $uid) {}
 function imap_list ($imap_stream, $ref, $pattern) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * List all the subscribed mailboxes
  * @link http://php.net/manual/en/function.imap-lsub.php
  * @param resource $imap_stream 
@@ -1005,7 +1049,8 @@ function imap_list ($imap_stream, $ref, $pattern) {}
 function imap_lsub ($imap_stream, $ref, $pattern) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Read an overview of the information in the headers of the given message
  * @link http://php.net/manual/en/function.imap-fetch-overview.php
  * @param resource $imap_stream 
@@ -1042,7 +1087,8 @@ function imap_lsub ($imap_stream, $ref, $pattern) {}
 function imap_fetch_overview ($imap_stream, $sequence, $options = 0) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Returns all IMAP alert messages that have occurred
  * @link http://php.net/manual/en/function.imap-alerts.php
  * @return array an array of all of the IMAP alert messages generated or <b>FALSE</b> if
@@ -1051,7 +1097,8 @@ function imap_fetch_overview ($imap_stream, $sequence, $options = 0) {}
 function imap_alerts () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Returns all of the IMAP errors that have occurred
  * @link http://php.net/manual/en/function.imap-errors.php
  * @return array This function returns an array of all of the IMAP error messages
@@ -1062,7 +1109,8 @@ function imap_alerts () {}
 function imap_errors () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Gets the last IMAP error that occurred during this page request
  * @link http://php.net/manual/en/function.imap-last-error.php
  * @return string the full text of the last IMAP error message that occurred on the
@@ -1071,7 +1119,8 @@ function imap_errors () {}
 function imap_last_error () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * This function returns an array of messages matching the given search criteria
  * @link http://php.net/manual/en/function.imap-search.php
  * @param resource $imap_stream 
@@ -1096,7 +1145,8 @@ function imap_last_error () {}
 function imap_search ($imap_stream, $criteria, $options = SE_FREE, $charset = NIL) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Decodes a modified UTF-7 encoded string
  * @link http://php.net/manual/en/function.imap-utf7-decode.php
  * @param string $text <p>
@@ -1112,7 +1162,8 @@ function imap_search ($imap_stream, $criteria, $options = SE_FREE, $charset = NI
 function imap_utf7_decode ($text) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Converts ISO-8859-1 string to modified UTF-7 text
  * @link http://php.net/manual/en/function.imap-utf7-encode.php
  * @param string $data <p>
@@ -1125,7 +1176,8 @@ function imap_utf7_decode ($text) {}
 function imap_utf7_encode ($data) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Decode MIME header elements
  * @link http://php.net/manual/en/function.imap-mime-header-decode.php
  * @param string $text <p>
@@ -1143,7 +1195,8 @@ function imap_utf7_encode ($data) {}
 function imap_mime_header_decode ($text) {}
 
 /**
- * (PHP 4 &gt;= 4.0.7, PHP 5)<br/>
+ * @since 4.0.7
+ * @since 5.0
  * Returns a tree of threaded message
  * @link http://php.net/manual/en/function.imap-thread.php
  * @param resource $imap_stream 
@@ -1168,7 +1221,8 @@ function imap_mime_header_decode ($text) {}
 function imap_thread ($imap_stream, $options = SE_FREE) {}
 
 /**
- * (PHP 4 &gt;= 4.3.3, PHP 5)<br/>
+ * @since 4.3.3
+ * @since 5.0
  * Set or fetch imap timeout
  * @link http://php.net/manual/en/function.imap-timeout.php
  * @param int $timeout_type <p>
@@ -1192,7 +1246,8 @@ function imap_thread ($imap_stream, $options = SE_FREE) {}
 function imap_timeout ($timeout_type, $timeout = -1) {}
 
 /**
- * (PHP 4 &gt;= 4.0.5, PHP 5)<br/>
+ * @since 4.0.5
+ * @since 5.0
  * Retrieve the quota level settings, and usage statics per mailbox
  * @link http://php.net/manual/en/function.imap-get-quota.php
  * @param resource $imap_stream 
@@ -1221,7 +1276,8 @@ function imap_timeout ($timeout_type, $timeout = -1) {}
 function imap_get_quota ($imap_stream, $quota_root) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Retrieve the quota settings per user
  * @link http://php.net/manual/en/function.imap-get-quotaroot.php
  * @param resource $imap_stream 
@@ -1241,7 +1297,8 @@ function imap_get_quota ($imap_stream, $quota_root) {}
 function imap_get_quotaroot ($imap_stream, $quota_root) {}
 
 /**
- * (PHP 4 &gt;= 4.0.5, PHP 5)<br/>
+ * @since 4.0.5
+ * @since 5.0
  * Sets a quota for a given mailbox
  * @link http://php.net/manual/en/function.imap-set-quota.php
  * @param resource $imap_stream 
@@ -1257,7 +1314,8 @@ function imap_get_quotaroot ($imap_stream, $quota_root) {}
 function imap_set_quota ($imap_stream, $quota_root, $quota_limit) {}
 
 /**
- * (PHP 4 &gt;= 4.0.7, PHP 5)<br/>
+ * @since 4.0.7
+ * @since 5.0
  * Sets the ACL for a given mailbox
  * @link http://php.net/manual/en/function.imap-setacl.php
  * @param resource $imap_stream 
@@ -1277,7 +1335,7 @@ function imap_set_quota ($imap_stream, $quota_root, $quota_limit) {}
 function imap_setacl ($imap_stream, $mailbox, $id, $rights) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Gets the ACL for a given mailbox
  * @link http://php.net/manual/en/function.imap-getacl.php
  * @param resource $imap_stream 
@@ -1313,7 +1371,8 @@ function imap_setannotation ($stream_id, $mailbox, $entry, $attr, $value) {}
 function imap_getannotation ($stream_id, $mailbox, $entry, $attr) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Send an email message
  * @link http://php.net/manual/en/function.imap-mail.php
  * @param string $to <p>
@@ -1342,7 +1401,8 @@ function imap_getannotation ($stream_id, $mailbox, $entry, $attr) {}
 function imap_mail ($to, $subject, $message, $additional_headers = null, $cc = null, $bcc = null, $rpath = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Alias of <b>imap_headerinfo</b>
  * @link http://php.net/manual/en/function.imap-header.php
  * @param resource $stream_id An IMAP stream returned by imap_open().
@@ -1393,7 +1453,8 @@ function imap_mail ($to, $subject, $message, $additional_headers = null, $cc = n
 function imap_header ($stream_id, $msg_no, $from_length = 0, $subject_length = 0, $default_host = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Alias of <b>imap_list</b>
  * @link http://php.net/manual/en/function.imap-listmailbox.php
  * @param $stream_id
@@ -1403,7 +1464,8 @@ function imap_header ($stream_id, $msg_no, $from_length = 0, $subject_length = 0
 function imap_listmailbox ($stream_id, $ref, $pattern) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Read the list of mailboxes, returning detailed information on each one
  * @link http://php.net/manual/en/function.imap-getmailboxes.php
  * @param resource $imap_stream 
@@ -1453,7 +1515,8 @@ function imap_listmailbox ($stream_id, $ref, $pattern) {}
 function imap_getmailboxes ($imap_stream, $ref, $pattern) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Alias of <b>imap_listscan</b>
  * @link http://php.net/manual/en/function.imap-scanmailbox.php
  * @param $stream_id
@@ -1464,7 +1527,8 @@ function imap_getmailboxes ($imap_stream, $ref, $pattern) {}
 function imap_scanmailbox ($stream_id, $ref, $pattern, $content) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Alias of <b>imap_lsub</b>
  * @link http://php.net/manual/en/function.imap-listsubscribed.php
  * @param $stream_id
@@ -1474,7 +1538,8 @@ function imap_scanmailbox ($stream_id, $ref, $pattern, $content) {}
 function imap_listsubscribed ($stream_id, $ref, $pattern) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * List all the subscribed mailboxes
  * @link http://php.net/manual/en/function.imap-getsubscribed.php
  * @param resource $imap_stream 
@@ -1526,7 +1591,8 @@ function imap_getsubscribed ($imap_stream, $ref, $pattern) {}
 function imap_fetchtext ($stream, $msg_no, $options = 0) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Alias of <b>imap_listscan</b>
  * @link http://php.net/manual/en/function.imap-scan.php
  * @param $stream_id
@@ -1537,7 +1603,8 @@ function imap_fetchtext ($stream, $msg_no, $options = 0) {}
 function imap_scan ($stream_id, $ref, $pattern, $content) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Alias of <b>imap_createmailbox</b>
  * @link http://php.net/manual/en/function.imap-create.php
  * @param $stream_id
@@ -1546,7 +1613,8 @@ function imap_scan ($stream_id, $ref, $pattern, $content) {}
 function imap_create ($stream_id, $mailbox) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Alias of <b>imap_renamemailbox</b>
  * @link http://php.net/manual/en/function.imap-rename.php
  * @param $stream_id

--- a/interbase.php
+++ b/interbase.php
@@ -3,7 +3,8 @@
 // Start of interbase v.
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Open a connection to an InterBase database
  * @link http://php.net/manual/en/function.ibase-connect.php
  * @param string $database [optional] <p>
@@ -46,7 +47,8 @@
 function ibase_connect ($database = null, $username = null, $password = null, $charset = null, $buffers = null, $dialect = null, $role = null, $sync = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Open a persistent connection to an InterBase database
  * @link http://php.net/manual/en/function.ibase-pconnect.php
  * @param string $database [optional] <p>
@@ -89,7 +91,8 @@ function ibase_connect ($database = null, $username = null, $password = null, $c
 function ibase_pconnect ($database = null, $username = null, $password = null, $charset = null, $buffers = null, $dialect = null, $role = null, $sync = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Close a connection to an InterBase database
  * @link http://php.net/manual/en/function.ibase-close.php
  * @param resource $connection_id [optional] <p>
@@ -102,7 +105,7 @@ function ibase_pconnect ($database = null, $username = null, $password = null, $
 function ibase_close ($connection_id = null) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Drops a database
  * @link http://php.net/manual/en/function.ibase-drop-db.php
  * @param resource $connection [optional] <p>
@@ -114,7 +117,8 @@ function ibase_close ($connection_id = null) {}
 function ibase_drop_db ($connection = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Execute a query on an InterBase database
  * @link http://php.net/manual/en/function.ibase-query.php
  * @param resource $link_identifier [optional] <p>
@@ -140,7 +144,8 @@ function ibase_drop_db ($connection = null) {}
 function ibase_query ($link_identifier = null, $query, $bind_args = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Fetch a row from an InterBase database
  * @link http://php.net/manual/en/function.ibase-fetch-row.php
  * @param resource $result_identifier <p>
@@ -161,7 +166,8 @@ function ibase_query ($link_identifier = null, $query, $bind_args = null) {}
 function ibase_fetch_row ($result_identifier, $fetch_flag = null) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Fetch a result row from a query as an associative array
  * @link http://php.net/manual/en/function.ibase-fetch-assoc.php
  * @param resource $result <p>
@@ -182,7 +188,8 @@ function ibase_fetch_row ($result_identifier, $fetch_flag = null) {}
 function ibase_fetch_assoc ($result, $fetch_flag = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get an object from a InterBase database
  * @link http://php.net/manual/en/function.ibase-fetch-object.php
  * @param resource $result_id <p>
@@ -203,7 +210,8 @@ function ibase_fetch_assoc ($result, $fetch_flag = null) {}
 function ibase_fetch_object ($result_id, $fetch_flag = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Free a result set
  * @link http://php.net/manual/en/function.ibase-free-result.php
  * @param resource $result_identifier <p>
@@ -215,7 +223,7 @@ function ibase_fetch_object ($result_id, $fetch_flag = null) {}
 function ibase_free_result ($result_identifier) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Assigns a name to a result set
  * @link http://php.net/manual/en/function.ibase-name-result.php
  * @param resource $result <p>
@@ -229,7 +237,8 @@ function ibase_free_result ($result_identifier) {}
 function ibase_name_result ($result, $name) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Prepare a query for later binding of parameter placeholders and execution
  * @link http://php.net/manual/en/function.ibase-prepare.php
  * @param string $query <p>
@@ -240,7 +249,8 @@ function ibase_name_result ($result, $name) {}
 function ibase_prepare ($query) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Execute a previously prepared query
  * @link http://php.net/manual/en/function.ibase-execute.php
  * @param resource $query <p>
@@ -263,7 +273,8 @@ function ibase_prepare ($query) {}
 function ibase_execute ($query, $bind_arg = null, $_ = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Free memory allocated by a prepared query
  * @link http://php.net/manual/en/function.ibase-free-query.php
  * @param resource $query <p>
@@ -274,7 +285,7 @@ function ibase_execute ($query, $bind_arg = null, $_ = null) {}
 function ibase_free_query ($query) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Increments the named generator and returns its new value
  * @link http://php.net/manual/en/function.ibase-gen-id.php
  * @param string $generator 
@@ -285,7 +296,8 @@ function ibase_free_query ($query) {}
 function ibase_gen_id ($generator, $increment = null, $link_identifier = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get the number of fields in a result set
  * @link http://php.net/manual/en/function.ibase-num-fields.php
  * @param resource $result_id <p>
@@ -296,7 +308,7 @@ function ibase_gen_id ($generator, $increment = null, $link_identifier = null) {
 function ibase_num_fields ($result_id) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Return the number of parameters in a prepared query
  * @link http://php.net/manual/en/function.ibase-num-params.php
  * @param resource $query <p>
@@ -307,7 +319,7 @@ function ibase_num_fields ($result_id) {}
 function ibase_num_params ($query) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Return the number of rows that were affected by the previous query
  * @link http://php.net/manual/en/function.ibase-affected-rows.php
  * @param resource $link_identifier [optional] <p>
@@ -319,7 +331,8 @@ function ibase_num_params ($query) {}
 function ibase_affected_rows ($link_identifier = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get information about a field
  * @link http://php.net/manual/en/function.ibase-field-info.php
  * @param resource $result <p>
@@ -335,7 +348,7 @@ function ibase_affected_rows ($link_identifier = null) {}
 function ibase_field_info ($result, $field_number) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Return information about a parameter in a prepared query
  * @link http://php.net/manual/en/function.ibase-param-info.php
  * @param resource $query <p>
@@ -351,7 +364,8 @@ function ibase_field_info ($result, $field_number) {}
 function ibase_param_info ($query, $param_number) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Begin a transaction
  * @link http://php.net/manual/en/function.ibase-trans.php
  * @param int $trans_args [optional] <p>
@@ -375,7 +389,8 @@ function ibase_param_info ($query, $param_number) {}
 function ibase_trans ($trans_args = null, $link_identifier = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Commit a transaction
  * @link http://php.net/manual/en/function.ibase-commit.php
  * @param resource $link_or_trans_identifier [optional] <p>
@@ -390,7 +405,8 @@ function ibase_trans ($trans_args = null, $link_identifier = null) {}
 function ibase_commit ($link_or_trans_identifier = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Roll back a transaction
  * @link http://php.net/manual/en/function.ibase-rollback.php
  * @param resource $link_or_trans_identifier [optional] <p>
@@ -405,7 +421,7 @@ function ibase_commit ($link_or_trans_identifier = null) {}
 function ibase_rollback ($link_or_trans_identifier = null) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Commit a transaction without closing it
  * @link http://php.net/manual/en/function.ibase-commit-ret.php
  * @param resource $link_or_trans_identifier [optional] <p>
@@ -422,7 +438,7 @@ function ibase_rollback ($link_or_trans_identifier = null) {}
 function ibase_commit_ret ($link_or_trans_identifier = null) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Roll back a transaction without closing it
  * @link http://php.net/manual/en/function.ibase-rollback-ret.php
  * @param resource $link_or_trans_identifier [optional] <p>
@@ -439,7 +455,8 @@ function ibase_commit_ret ($link_or_trans_identifier = null) {}
 function ibase_rollback_ret ($link_or_trans_identifier = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Return blob length and other useful info
  * @link http://php.net/manual/en/function.ibase-blob-info.php
  * @param resource $link_identifier <p>
@@ -456,7 +473,8 @@ function ibase_rollback_ret ($link_or_trans_identifier = null) {}
 function ibase_blob_info ($link_identifier, $blob_id) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Create a new blob for adding data
  * @link http://php.net/manual/en/function.ibase-blob-create.php
  * @param resource $link_identifier [optional] <p>
@@ -469,7 +487,8 @@ function ibase_blob_info ($link_identifier, $blob_id) {}
 function ibase_blob_create ($link_identifier = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Add data into a newly created blob
  * @link http://php.net/manual/en/function.ibase-blob-add.php
  * @param resource $blob_handle <p>
@@ -483,7 +502,8 @@ function ibase_blob_create ($link_identifier = null) {}
 function ibase_blob_add ($blob_handle, $data) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Cancel creating blob
  * @link http://php.net/manual/en/function.ibase-blob-cancel.php
  * @param resource $blob_handle <p>
@@ -494,7 +514,8 @@ function ibase_blob_add ($blob_handle, $data) {}
 function ibase_blob_cancel ($blob_handle) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Close blob
  * @link http://php.net/manual/en/function.ibase-blob-close.php
  * @param resource $blob_handle <p>
@@ -509,7 +530,8 @@ function ibase_blob_cancel ($blob_handle) {}
 function ibase_blob_close ($blob_handle) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Open blob for retrieving data parts
  * @link http://php.net/manual/en/function.ibase-blob-open.php
  * @param resource $link_identifier <p>
@@ -525,7 +547,8 @@ function ibase_blob_close ($blob_handle) {}
 function ibase_blob_open ($link_identifier, $blob_id) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get len bytes data from open blob
  * @link http://php.net/manual/en/function.ibase-blob-get.php
  * @param resource $blob_handle <p>
@@ -540,7 +563,8 @@ function ibase_blob_open ($link_identifier, $blob_id) {}
 function ibase_blob_get ($blob_handle, $len) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Output blob contents to browser
  * @link http://php.net/manual/en/function.ibase-blob-echo.php
  * @param string $blob_id <p>
@@ -550,7 +574,8 @@ function ibase_blob_get ($blob_handle, $len) {}
 function ibase_blob_echo ($blob_id) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Create blob, copy file in it, and close it
  * @link http://php.net/manual/en/function.ibase-blob-import.php
  * @param resource $link_identifier <p>
@@ -565,7 +590,8 @@ function ibase_blob_echo ($blob_id) {}
 function ibase_blob_import ($link_identifier, $file_handle) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Return error messages
  * @link http://php.net/manual/en/function.ibase-errmsg.php
  * @return string the error message as a string, or false if no error occurred.
@@ -573,7 +599,7 @@ function ibase_blob_import ($link_identifier, $file_handle) {}
 function ibase_errmsg () {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Return an error code
  * @link http://php.net/manual/en/function.ibase-errcode.php
  * @return int the error code as an integer, or false if no error occurred.
@@ -581,7 +607,8 @@ function ibase_errmsg () {}
 function ibase_errcode () {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Add a user to a security database (only for IB6 or later)
  * @link http://php.net/manual/en/function.ibase-add-user.php
  * @param resource $service_handle 
@@ -595,7 +622,8 @@ function ibase_errcode () {}
 function ibase_add_user ($service_handle, $user_name, $password, $first_name = null, $middle_name = null, $last_name = null) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Modify a user to a security database (only for IB6 or later)
  * @link http://php.net/manual/en/function.ibase-modify-user.php
  * @param resource $service_handle 
@@ -609,7 +637,8 @@ function ibase_add_user ($service_handle, $user_name, $password, $first_name = n
 function ibase_modify_user ($service_handle, $user_name, $password, $first_name = null, $middle_name = null, $last_name = null) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Delete a user from a security database (only for IB6 or later)
  * @link http://php.net/manual/en/function.ibase-delete-user.php
  * @param resource $service_handle 
@@ -619,7 +648,7 @@ function ibase_modify_user ($service_handle, $user_name, $password, $first_name 
 function ibase_delete_user ($service_handle, $user_name) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Connect to the service manager
  * @link http://php.net/manual/en/function.ibase-service-attach.php
  * @param string $host 
@@ -630,7 +659,7 @@ function ibase_delete_user ($service_handle, $user_name) {}
 function ibase_service_attach ($host, $dba_username, $dba_password) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Disconnect from the service manager
  * @link http://php.net/manual/en/function.ibase-service-detach.php
  * @param resource $service_handle 
@@ -639,7 +668,7 @@ function ibase_service_attach ($host, $dba_username, $dba_password) {}
 function ibase_service_detach ($service_handle) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Initiates a backup task in the service manager and returns immediately
  * @link http://php.net/manual/en/function.ibase-backup.php
  * @param resource $service_handle 
@@ -652,7 +681,7 @@ function ibase_service_detach ($service_handle) {}
 function ibase_backup ($service_handle, $source_db, $dest_file, $options = null, $verbose = null) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Initiates a restore task in the service manager and returns immediately
  * @link http://php.net/manual/en/function.ibase-restore.php
  * @param resource $service_handle 
@@ -665,7 +694,7 @@ function ibase_backup ($service_handle, $source_db, $dest_file, $options = null,
 function ibase_restore ($service_handle, $source_file, $dest_db, $options = null, $verbose = null) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Execute a maintenance command on the database server
  * @link http://php.net/manual/en/function.ibase-maintain-db.php
  * @param resource $service_handle 
@@ -677,7 +706,7 @@ function ibase_restore ($service_handle, $source_file, $dest_db, $options = null
 function ibase_maintain_db ($service_handle, $db, $action, $argument = null) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Request statistics about a database
  * @link http://php.net/manual/en/function.ibase-db-info.php
  * @param resource $service_handle 
@@ -689,7 +718,7 @@ function ibase_maintain_db ($service_handle, $db, $action, $argument = null) {}
 function ibase_db_info ($service_handle, $db, $action, $argument = null) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Request information about a database server
  * @link http://php.net/manual/en/function.ibase-server-info.php
  * @param resource $service_handle 
@@ -699,7 +728,7 @@ function ibase_db_info ($service_handle, $db, $action, $argument = null) {}
 function ibase_server_info ($service_handle, $action) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Wait for an event to be posted by the database
  * @link http://php.net/manual/en/function.ibase-wait-event.php
  * @param string $event_name1 <p>
@@ -713,7 +742,7 @@ function ibase_server_info ($service_handle, $action) {}
 function ibase_wait_event ($event_name1, $event_name2 = null, $_ = null) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Register a callback function to be called when events are posted
  * @link http://php.net/manual/en/function.ibase-set-event-handler.php
  * @param callback $event_handler <p>
@@ -739,7 +768,7 @@ function ibase_wait_event ($event_name1, $event_name2 = null, $_ = null) {}
 function ibase_set_event_handler ($event_handler, $event_name1, $event_name2 = null, $_ = null) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Cancels a registered event handler
  * @link http://php.net/manual/en/function.ibase-free-event-handler.php
  * @param resource $event <p>

--- a/intl.php
+++ b/intl.php
@@ -1787,7 +1787,7 @@ class IntlDateFormatter {
      * If <b>NULL</b> or the empty string, the default time zone for the runtime is used.
      * </p>
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
-     * @deprecated in 5.5 http://www.php.net/manual/en/migration55.deprecated.php
+     * @deprecated 5.5 http://www.php.net/manual/en/migration55.deprecated.php
      */
     public function setTimeZoneId($zone) { }
 
@@ -4115,7 +4115,7 @@ function datefmt_get_timezone() { }
  * If <b>NULL</b> or the empty string, the default time zone for the runtime is used.
  * </p>
  * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
- * @deprecated in 5.5 http://www.php.net/manual/en/migration55.deprecated.php
+ * @deprecated 5.5 http://www.php.net/manual/en/migration55.deprecated.php
  */
 function datefmt_set_timezone_id(MessageFormatter $mf, $zone) { }
 

--- a/json.php
+++ b/json.php
@@ -11,7 +11,7 @@
 interface JsonSerializable  {
 
 	/**
-	 * (PHP 5 &gt;= 5.4.0)<br/>
+	 * @since 5.4.0
 	 * Specify data which should be serialized to JSON
 	 * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
 	 * @return mixed data which can be serialized by <b>json_encode</b>,
@@ -124,7 +124,7 @@ function json_encode ($value, $options = 0, $depth = 512) {}
 function json_decode ($json, $assoc = false, $depth = 512, $options = 0) {}
 
 /**
- * (PHP 5 &gt;= 5.3.0)<br/>
+ * @since 5.3.0
  * Returns the last error occurred
  * @link http://php.net/manual/en/function.json-last-error.php
  * @return int an integer, the value can be one of the following
@@ -133,7 +133,7 @@ function json_decode ($json, $assoc = false, $depth = 512, $options = 0) {}
 function json_last_error () {}
 
 /**
- * (PHP 5 &gt;= 5.5.0)<br/>
+ * @since 5.5.0
  * Returns the error string of the last json_encode() or json_decode() call
  * @link http://php.net/manual/en/function.json-last-error-msg.php
  * @return string the error message on success or <b>NULL</b> with wrong parameters.
@@ -143,28 +143,28 @@ function json_last_error_msg () {}
 
 /**
  * All &lt; and &gt; are converted to \u003C and \u003E.
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/json.constants.php
  */
 define ('JSON_HEX_TAG', 1);
 
 /**
  * All &#38;#38;s are converted to \u0026.
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/json.constants.php
  */
 define ('JSON_HEX_AMP', 2);
 
 /**
  * All ' are converted to \u0027.
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/json.constants.php
  */
 define ('JSON_HEX_APOS', 4);
 
 /**
  * All " are converted to \u0022.
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/json.constants.php
  */
 define ('JSON_HEX_QUOT', 8);
@@ -173,35 +173,35 @@ define ('JSON_HEX_QUOT', 8);
  * Outputs an object rather than an array when a non-associative array is
  * used. Especially useful when the recipient of the output is expecting
  * an object and the array is empty.
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/json.constants.php
  */
 define ('JSON_FORCE_OBJECT', 16);
 
 /**
  * Encodes numeric strings as numbers.
- * Available since PHP 5.3.3.
+ * @since 5.3.3
  * @link http://php.net/manual/en/json.constants.php
  */
 define ('JSON_NUMERIC_CHECK', 32);
 
 /**
  * Don't escape /.
- * Available since PHP 5.4.0.
+ * @since 5.4.0
  * @link http://php.net/manual/en/json.constants.php
  */
 define ('JSON_UNESCAPED_SLASHES', 64);
 
 /**
  * Use whitespace in returned data to format it.
- * Available since PHP 5.4.0.
+ * @since 5.4.0
  * @link http://php.net/manual/en/json.constants.php
  */
 define ('JSON_PRETTY_PRINT', 128);
 
 /**
  * Encode multibyte Unicode characters literally (default is to escape as \uXXXX).
- * Available since PHP 5.4.0.
+ * @since 5.4.0
  * @link http://php.net/manual/en/json.constants.php
  */
 define ('JSON_UNESCAPED_UNICODE', 256);
@@ -209,14 +209,14 @@ define ('JSON_PARTIAL_OUTPUT_ON_ERROR', 512);
 
 /**
  * Occurs with underflow or with the modes mismatch.
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/json.constants.php
  */
 define ('JSON_ERROR_STATE_MISMATCH', 2);
 
 /**
  * Control character error, possibly incorrectly encoded.
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/json.constants.php
  */
 define ('JSON_ERROR_CTRL_CHAR', 3);
@@ -274,21 +274,21 @@ define ('JSON_ERROR_UNSUPPORTED_TYPE', 8);
 
 /**
  * No error has occurred.
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/json.constants.php
  */
 define ('JSON_ERROR_NONE', 0);
 
 /**
  * The maximum stack depth has been exceeded.
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/json.constants.php
  */
 define ('JSON_ERROR_DEPTH', 1);
 
 /**
  * Syntax error.
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/json.constants.php
  */
 define ('JSON_ERROR_SYNTAX', 4);
@@ -297,7 +297,7 @@ define ('JSON_PARSER_NOTSTRICT', 4);
 
 /**
  * Encodes large integers as their original string value.
- * Available since PHP 5.4.0.
+ * @since 5.4.0
  * @link http://php.net/manual/en/json.constants.php
  */
 define ('JSON_BIGINT_AS_STRING', 2);

--- a/ldap.php
+++ b/ldap.php
@@ -3,7 +3,8 @@
 // Start of ldap v.
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Connect to an LDAP server
  * @link http://php.net/manual/en/function.ldap-connect.php
  * @param string $hostname [optional] <p>
@@ -29,7 +30,8 @@
 function ldap_connect ($hostname = null, $port = 389) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Alias of <b>ldap_unbind</b>
  * @link http://php.net/manual/en/function.ldap-close.php
  * @param $link_identifier
@@ -37,7 +39,8 @@ function ldap_connect ($hostname = null, $port = 389) {}
 function ldap_close ($link_identifier) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Bind to LDAP directory
  * @link http://php.net/manual/en/function.ldap-bind.php
  * @param resource $link_identifier <p>
@@ -50,7 +53,7 @@ function ldap_close ($link_identifier) {}
 function ldap_bind ($link_identifier, $bind_rdn = null, $bind_password = null) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Bind to LDAP directory using SASL
  * @link http://php.net/manual/en/function.ldap-sasl-bind.php
  * @param resource $link
@@ -66,7 +69,8 @@ function ldap_bind ($link_identifier, $bind_rdn = null, $bind_password = null) {
 function ldap_sasl_bind ($link, $binddn = null, $password = null, $sasl_mech = null, $sasl_realm = null, $sasl_authc_id = null, $sasl_authz_id = null, $props = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Unbind from LDAP directory
  * @link http://php.net/manual/en/function.ldap-unbind.php
  * @param resource $link_identifier <p>
@@ -77,7 +81,8 @@ function ldap_sasl_bind ($link, $binddn = null, $password = null, $sasl_mech = n
 function ldap_unbind ($link_identifier) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Read an entry
  * @link http://php.net/manual/en/function.ldap-read.php
  * @param resource $link_identifier <p>
@@ -141,7 +146,8 @@ function ldap_unbind ($link_identifier) {}
 function ldap_read ($link_identifier, $base_dn, $filter, array $attributes = null, $attrsonly = null, $sizelimit = null, $timelimit = null, $deref = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Single-level search
  * @link http://php.net/manual/en/function.ldap-list.php
  * @param resource $link_identifier <p>
@@ -199,7 +205,8 @@ function ldap_read ($link_identifier, $base_dn, $filter, array $attributes = nul
 function ldap_list ($link_identifier, $base_dn, $filter, array $attributes = null, $attrsonly = null, $sizelimit = null, $timelimit = null, $deref = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Search LDAP tree
  * @link http://php.net/manual/en/function.ldap-search.php
  * @param resource $link_identifier <p>
@@ -261,7 +268,8 @@ function ldap_list ($link_identifier, $base_dn, $filter, array $attributes = nul
 function ldap_search ($link_identifier, $base_dn, $filter, array $attributes = null, $attrsonly = null, $sizelimit = null, $timelimit = null, $deref = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Free result memory
  * @link http://php.net/manual/en/function.ldap-free-result.php
  * @param resource $result_identifier
@@ -270,7 +278,8 @@ function ldap_search ($link_identifier, $base_dn, $filter, array $attributes = n
 function ldap_free_result ($result_identifier) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Count the number of entries in a search
  * @link http://php.net/manual/en/function.ldap-count-entries.php
  * @param resource $link_identifier <p>
@@ -284,7 +293,8 @@ function ldap_free_result ($result_identifier) {}
 function ldap_count_entries ($link_identifier, $result_identifier) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Return first result id
  * @link http://php.net/manual/en/function.ldap-first-entry.php
  * @param resource $link_identifier <p>
@@ -297,7 +307,8 @@ function ldap_count_entries ($link_identifier, $result_identifier) {}
 function ldap_first_entry ($link_identifier, $result_identifier) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get next result entry
  * @link http://php.net/manual/en/function.ldap-next-entry.php
  * @param resource $link_identifier <p>
@@ -311,7 +322,8 @@ function ldap_first_entry ($link_identifier, $result_identifier) {}
 function ldap_next_entry ($link_identifier, $result_entry_identifier) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get all result entries
  * @link http://php.net/manual/en/function.ldap-get-entries.php
  * @param resource $link_identifier <p>
@@ -340,7 +352,8 @@ function ldap_next_entry ($link_identifier, $result_entry_identifier) {}
 function ldap_get_entries ($link_identifier, $result_identifier) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Return first attribute
  * @link http://php.net/manual/en/function.ldap-first-attribute.php
  * @param resource $link_identifier <p>
@@ -353,7 +366,8 @@ function ldap_get_entries ($link_identifier, $result_identifier) {}
 function ldap_first_attribute ($link_identifier, $result_entry_identifier) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get the next attribute in result
  * @link http://php.net/manual/en/function.ldap-next-attribute.php
  * @param resource $link_identifier <p>
@@ -366,7 +380,8 @@ function ldap_first_attribute ($link_identifier, $result_entry_identifier) {}
 function ldap_next_attribute ($link_identifier, $result_entry_identifier) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get attributes from a search result entry
  * @link http://php.net/manual/en/function.ldap-get-attributes.php
  * @param resource $link_identifier <p>
@@ -379,7 +394,8 @@ function ldap_next_attribute ($link_identifier, $result_entry_identifier) {}
 function ldap_get_attributes ($link_identifier, $result_entry_identifier) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get all values from a result entry
  * @link http://php.net/manual/en/function.ldap-get-values.php
  * @param resource $link_identifier <p>
@@ -403,7 +419,8 @@ function ldap_get_attributes ($link_identifier, $result_entry_identifier) {}
 function ldap_get_values ($link_identifier, $result_entry_identifier, $attribute) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get all binary values from a result entry
  * @link http://php.net/manual/en/function.ldap-get-values-len.php
  * @param resource $link_identifier <p>
@@ -419,7 +436,8 @@ function ldap_get_values ($link_identifier, $result_entry_identifier, $attribute
 function ldap_get_values_len ($link_identifier, $result_entry_identifier, $attribute) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get the DN of a result entry
  * @link http://php.net/manual/en/function.ldap-get-dn.php
  * @param resource $link_identifier <p>
@@ -431,7 +449,8 @@ function ldap_get_values_len ($link_identifier, $result_entry_identifier, $attri
 function ldap_get_dn ($link_identifier, $result_entry_identifier) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Splits DN into its component parts
  * @link http://php.net/manual/en/function.ldap-explode-dn.php
  * @param string $dn <p>
@@ -451,7 +470,8 @@ function ldap_get_dn ($link_identifier, $result_entry_identifier) {}
 function ldap_explode_dn ($dn, $with_attrib) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Convert DN to User Friendly Naming format
  * @link http://php.net/manual/en/function.ldap-dn2ufn.php
  * @param string $dn <p>
@@ -462,7 +482,8 @@ function ldap_explode_dn ($dn, $with_attrib) {}
 function ldap_dn2ufn ($dn) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Add entries to LDAP directory
  * @link http://php.net/manual/en/function.ldap-add.php
  * @param resource $link_identifier <p>
@@ -487,7 +508,8 @@ function ldap_dn2ufn ($dn) {}
 function ldap_add ($link_identifier, $dn, array $entry) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Delete an entry from a directory
  * @link http://php.net/manual/en/function.ldap-delete.php
  * @param resource $link_identifier <p>
@@ -501,7 +523,8 @@ function ldap_add ($link_identifier, $dn, array $entry) {}
 function ldap_delete ($link_identifier, $dn) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Modify an LDAP entry
  * @link http://php.net/manual/en/function.ldap-modify.php
  * @param resource $link_identifier <p>
@@ -516,7 +539,8 @@ function ldap_delete ($link_identifier, $dn) {}
 function ldap_modify ($link_identifier, $dn, array $entry) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Add attribute values to current attributes
  * @link http://php.net/manual/en/function.ldap-mod-add.php
  * @param resource $link_identifier <p>
@@ -531,7 +555,8 @@ function ldap_modify ($link_identifier, $dn, array $entry) {}
 function ldap_mod_add ($link_identifier, $dn, array $entry) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Replace attribute values with new ones
  * @link http://php.net/manual/en/function.ldap-mod-replace.php
  * @param resource $link_identifier <p>
@@ -546,7 +571,8 @@ function ldap_mod_add ($link_identifier, $dn, array $entry) {}
 function ldap_mod_replace ($link_identifier, $dn, array $entry) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Delete attribute values from current attributes
  * @link http://php.net/manual/en/function.ldap-mod-del.php
  * @param resource $link_identifier <p>
@@ -561,7 +587,8 @@ function ldap_mod_replace ($link_identifier, $dn, array $entry) {}
 function ldap_mod_del ($link_identifier, $dn, array $entry) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Return the LDAP error number of the last LDAP command
  * @link http://php.net/manual/en/function.ldap-errno.php
  * @param resource $link_identifier <p>
@@ -573,7 +600,8 @@ function ldap_mod_del ($link_identifier, $dn, array $entry) {}
 function ldap_errno ($link_identifier) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Convert LDAP error number into string error message
  * @link http://php.net/manual/en/function.ldap-err2str.php
  * @param int $errno <p>
@@ -584,7 +612,8 @@ function ldap_errno ($link_identifier) {}
 function ldap_err2str ($errno) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Return the LDAP error message of the last LDAP command
  * @link http://php.net/manual/en/function.ldap-error.php
  * @param resource $link_identifier <p>
@@ -595,7 +624,8 @@ function ldap_err2str ($errno) {}
 function ldap_error ($link_identifier) {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Compare value of attribute found in entry specified with DN
  * @link http://php.net/manual/en/function.ldap-compare.php
  * @param resource $link_identifier <p>
@@ -616,7 +646,8 @@ function ldap_error ($link_identifier) {}
 function ldap_compare ($link_identifier, $dn, $attribute, $value) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Sort LDAP result entries
  * @link http://php.net/manual/en/function.ldap-sort.php
  * @param resource $link <p>
@@ -634,7 +665,8 @@ function ldap_compare ($link_identifier, $dn, $attribute, $value) {}
 function ldap_sort ($link, $result, $sortfilter) {}
 
 /**
- * (PHP 4 &gt;= 4.0.5, PHP 5)<br/>
+ * @since 4.0.5
+ * @since 5.0
  * Modify the name of an entry
  * @link http://php.net/manual/en/function.ldap-rename.php
  * @param resource $link_identifier <p>
@@ -658,7 +690,8 @@ function ldap_sort ($link, $result, $sortfilter) {}
 function ldap_rename ($link_identifier, $dn, $newrdn, $newparent, $deleteoldrdn) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Get the current value for given option
  * @link http://php.net/manual/en/function.ldap-get-option.php
  * @param resource $link_identifier <p>
@@ -731,7 +764,8 @@ function ldap_rename ($link_identifier, $dn, $newrdn, $newparent, $deleteoldrdn)
 function ldap_get_option ($link_identifier, $option, &$retval) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Set the value of the given option
  * @link http://php.net/manual/en/function.ldap-set-option.php
  * @param resource $link_identifier <p>
@@ -833,7 +867,8 @@ function ldap_get_option ($link_identifier, $option, &$retval) {}
 function ldap_set_option ($link_identifier, $option, $newval) {}
 
 /**
- * (PHP 4 &gt;= 4.0.5, PHP 5)<br/>
+ * @since 4.0.5
+ * @since 5.0
  * Return first reference
  * @link http://php.net/manual/en/function.ldap-first-reference.php
  * @param resource $link
@@ -843,7 +878,8 @@ function ldap_set_option ($link_identifier, $option, $newval) {}
 function ldap_first_reference ($link, $result) {}
 
 /**
- * (PHP 4 &gt;= 4.0.5, PHP 5)<br/>
+ * @since 4.0.5
+ * @since 5.0
  * Get next reference
  * @link http://php.net/manual/en/function.ldap-next-reference.php
  * @param resource $link
@@ -853,7 +889,8 @@ function ldap_first_reference ($link, $result) {}
 function ldap_next_reference ($link, $entry) {}
 
 /**
- * (PHP 4 &gt;= 4.0.5, PHP 5)<br/>
+ * @since 4.0.5
+ * @since 5.0
  * Extract information from reference entry
  * @link http://php.net/manual/en/function.ldap-parse-reference.php
  * @param resource $link
@@ -864,7 +901,8 @@ function ldap_next_reference ($link, $entry) {}
 function ldap_parse_reference ($link, $entry, array &$referrals) {}
 
 /**
- * (PHP 4 &gt;= 4.0.5, PHP 5)<br/>
+ * @since 4.0.5
+ * @since 5.0
  * Extract information from result
  * @link http://php.net/manual/en/function.ldap-parse-result.php
  * @param resource $link
@@ -878,7 +916,8 @@ function ldap_parse_reference ($link, $entry, array &$referrals) {}
 function ldap_parse_result ($link, $result, &$errcode, &$matcheddn = null, &$errmsg = null, array &$referrals = null) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Start TLS
  * @link http://php.net/manual/en/function.ldap-start-tls.php
  * @param resource $link
@@ -887,7 +926,8 @@ function ldap_parse_result ($link, $result, &$errcode, &$matcheddn = null, &$err
 function ldap_start_tls ($link) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Set a callback function to do re-binds on referral chasing
  * @link http://php.net/manual/en/function.ldap-set-rebind-proc.php
  * @param resource $link
@@ -897,7 +937,7 @@ function ldap_start_tls ($link) {}
 function ldap_set_rebind_proc ($link, callable $callback) {}
 
 /**
- * (PHP 5 &gt;= 5.4.0)<br/>
+ * @since 5.4.0
  * Send LDAP pagination control
  * @link http://php.net/manual/en/function.ldap-control-paged-result.php
  * @param resource $link <p>
@@ -920,7 +960,7 @@ function ldap_set_rebind_proc ($link, callable $callback) {}
 function ldap_control_paged_result ($link, $pagesize, $iscritical = false, $cookie = "") {}
 
 /**
- * (PHP 5 &gt;= 5.4.0)<br/>
+ * @since 5.4.0
  * Retrieve the LDAP pagination cookie
  * @link http://php.net/manual/en/function.ldap-control-paged-result-response.php
  * @param resource $link <p>
@@ -938,7 +978,7 @@ function ldap_control_paged_result ($link, $pagesize, $iscritical = false, $cook
 function ldap_control_paged_result_response ($link, $result, &$cookie = null, &$estimated = null) {}
 
 /**
- * (PHP 5 &gt;= 5.6.0)<br/>
+ * @since 5.6.0
  * @param $subject
  * @param $ignore [optional]
  * @param $escape [optional] LDAP_ESCAPE_FILTER|LDAP_ESCAPE_DN or null

--- a/libxml.php
+++ b/libxml.php
@@ -61,7 +61,7 @@ class LibXMLError  {
 }
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Set the streams context for the next libxml document load or write
  * @link http://php.net/manual/en/function.libxml-set-streams-context.php
  * @param resource $streams_context <p>
@@ -73,7 +73,7 @@ class LibXMLError  {
 function libxml_set_streams_context ($streams_context) {}
 
 /**
- * (PHP 5 &gt;= 5.1.0)<br/>
+ * @since 5.1.0
  * Disable libxml errors and allow user to fetch error information as needed
  * @link http://php.net/manual/en/function.libxml-use-internal-errors.php
  * @param bool $use_errors [optional] <p>
@@ -85,7 +85,7 @@ function libxml_set_streams_context ($streams_context) {}
 function libxml_use_internal_errors ($use_errors = false) {}
 
 /**
- * (PHP 5 &gt;= 5.1.0)<br/>
+ * @since 5.1.0
  * Retrieve last error from libxml
  * @link http://php.net/manual/en/function.libxml-get-last-error.php
  * @return LibXMLError a LibXMLError object if there is any error in the
@@ -94,7 +94,7 @@ function libxml_use_internal_errors ($use_errors = false) {}
 function libxml_get_last_error () {}
 
 /**
- * (PHP 5 &gt;= 5.1.0)<br/>
+ * @since 5.1.0
  * Clear libxml error buffer
  * @link http://php.net/manual/en/function.libxml-clear-errors.php
  * @return void No value is returned.
@@ -102,7 +102,7 @@ function libxml_get_last_error () {}
 function libxml_clear_errors () {}
 
 /**
- * (PHP 5 &gt;= 5.1.0)<br/>
+ * @since 5.1.0
  * Retrieve array of errors
  * @link http://php.net/manual/en/function.libxml-get-errors.php
  * @return array an array with LibXMLError objects if there are any
@@ -111,7 +111,7 @@ function libxml_clear_errors () {}
 function libxml_get_errors () {}
 
 /**
- * (PHP 5 &gt;= 5.2.11)<br/>
+ * @since 5.2.11
  * Disable the ability to load external entities
  * @link http://php.net/manual/en/function.libxml-disable-entity-loader.php
  * @param bool $disable [optional] <p>
@@ -124,7 +124,7 @@ function libxml_get_errors () {}
 function libxml_disable_entity_loader ($disable = true) {}
 
 /**
- * (PHP 5 &gt;= 5.4.0)<br/>
+ * @since 5.4.0
  * Changes the default external entity loader
  * @link http://php.net/manual/en/function.libxml-set-external-entity-loader.php
  * @param callable $resolver_function <p>

--- a/mbstring.php
+++ b/mbstring.php
@@ -3,7 +3,8 @@
 // Start of mbstring v.
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Perform case folding on a string
  * @link http://php.net/manual/en/function.mb-convert-case.php
  * @param string $str <p>
@@ -22,7 +23,8 @@
 function mb_convert_case ($str, $mode, $encoding = null) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Make a string uppercase
  * @link http://php.net/manual/en/function.mb-strtoupper.php
  * @param string $str <p>
@@ -34,7 +36,8 @@ function mb_convert_case ($str, $mode, $encoding = null) {}
 function mb_strtoupper ($str, $encoding = null) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Make a string lowercase
  * @link http://php.net/manual/en/function.mb-strtolower.php
  * @param string $str <p>
@@ -46,7 +49,8 @@ function mb_strtoupper ($str, $encoding = null) {}
 function mb_strtolower ($str, $encoding = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Set/Get current language
  * @link http://php.net/manual/en/function.mb-language.php
  * @param string $language [optional] <p>
@@ -71,7 +75,8 @@ function mb_strtolower ($str, $encoding = null) {}
 function mb_language ($language = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Set/Get internal character encoding
  * @link http://php.net/manual/en/function.mb-internal-encoding.php
  * @param string $encoding [optional] <p>
@@ -88,7 +93,8 @@ function mb_language ($language = null) {}
 function mb_internal_encoding ($encoding = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Detect HTTP input character encoding
  * @link http://php.net/manual/en/function.mb-http-input.php
  * @param string $type [optional] <p>
@@ -104,7 +110,8 @@ function mb_internal_encoding ($encoding = null) {}
 function mb_http_input ($type = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Set/Get HTTP output character encoding
  * @link http://php.net/manual/en/function.mb-http-output.php
  * @param string $encoding [optional] <p>
@@ -125,7 +132,8 @@ function mb_http_input ($type = null) {}
 function mb_http_output ($encoding = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Set/Get character encoding detection order
  * @link http://php.net/manual/en/function.mb-detect-order.php
  * @param mixed $encoding_list [optional] <p>
@@ -168,7 +176,8 @@ function mb_http_output ($encoding = null) {}
 function mb_detect_order ($encoding_list = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Set/Get substitution character
  * @link http://php.net/manual/en/function.mb-substitute-character.php
  * @param mixed $substrchar [optional] <p>
@@ -183,7 +192,8 @@ function mb_detect_order ($encoding_list = null) {}
 function mb_substitute_character ($substrchar = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Parse GET/POST/COOKIE data and set global variable
  * @link http://php.net/manual/en/function.mb-parse-str.php
  * @param string $encoded_string <p>
@@ -197,7 +207,8 @@ function mb_substitute_character ($substrchar = null) {}
 function mb_parse_str ($encoded_string, array &$result = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Callback function converts character encoding in output buffer
  * @link http://php.net/manual/en/function.mb-output-handler.php
  * @param string $contents <p>
@@ -211,7 +222,8 @@ function mb_parse_str ($encoded_string, array &$result = null) {}
 function mb_output_handler ($contents, $status) {}
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Get MIME charset string
  * @link http://php.net/manual/en/function.mb-preferred-mime-name.php
  * @param string $encoding <p>
@@ -223,7 +235,8 @@ function mb_output_handler ($contents, $status) {}
 function mb_preferred_mime_name ($encoding) {}
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Get string length
  * @link http://php.net/manual/en/function.mb-strlen.php
  * @param string $str <p>
@@ -238,7 +251,8 @@ function mb_preferred_mime_name ($encoding) {}
 function mb_strlen ($str, $encoding = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Find position of first occurrence of string in a string
  * @link http://php.net/manual/en/function.mb-strpos.php
  * @param string $haystack <p>
@@ -259,7 +273,8 @@ function mb_strlen ($str, $encoding = null) {}
 function mb_strpos ($haystack, $needle, $offset = null, $encoding = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Find position of last occurrence of a string in a string
  * @link http://php.net/manual/en/function.mb-strrpos.php
  * @param string $haystack <p>
@@ -281,7 +296,7 @@ function mb_strpos ($haystack, $needle, $offset = null, $encoding = null) {}
 function mb_strrpos ($haystack, $needle, $offset = null, $encoding = null) {}
 
 /**
- * (PHP 5 &gt;= 5.2.0)<br/>
+ * @since 5.2.0
  * Finds position of first occurrence of a string within another, case insensitive
  * @link http://php.net/manual/en/function.mb-stripos.php
  * @param string $haystack <p>
@@ -306,7 +321,7 @@ function mb_strrpos ($haystack, $needle, $offset = null, $encoding = null) {}
 function mb_stripos ($haystack, $needle, $offset = null, $encoding = null) {}
 
 /**
- * (PHP 5 &gt;= 5.2.0)<br/>
+ * @since 5.2.0
  * Finds position of last occurrence of a string within another, case insensitive
  * @link http://php.net/manual/en/function.mb-strripos.php
  * @param string $haystack <p>
@@ -332,7 +347,7 @@ function mb_stripos ($haystack, $needle, $offset = null, $encoding = null) {}
 function mb_strripos ($haystack, $needle, $offset = null, $encoding = null) {}
 
 /**
- * (PHP 5 &gt;= 5.2.0)<br/>
+ * @since 5.2.0
  * Finds first occurrence of a string within another
  * @link http://php.net/manual/en/function.mb-strstr.php
  * @param string $haystack <p>
@@ -360,7 +375,7 @@ function mb_strripos ($haystack, $needle, $offset = null, $encoding = null) {}
 function mb_strstr ($haystack, $needle, $part = null, $encoding = null) {}
 
 /**
- * (PHP 5 &gt;= 5.2.0)<br/>
+ * @since 5.2.0
  * Finds the last occurrence of a character in a string within another
  * @link http://php.net/manual/en/function.mb-strrchr.php
  * @param string $haystack <p>
@@ -388,7 +403,7 @@ function mb_strstr ($haystack, $needle, $part = null, $encoding = null) {}
 function mb_strrchr ($haystack, $needle, $part = null, $encoding = null) {}
 
 /**
- * (PHP 5 &gt;= 5.2.0)<br/>
+ * @since 5.2.0
  * Finds first occurrence of a string within another, case insensitive
  * @link http://php.net/manual/en/function.mb-stristr.php
  * @param string $haystack <p>
@@ -416,7 +431,7 @@ function mb_strrchr ($haystack, $needle, $part = null, $encoding = null) {}
 function mb_stristr ($haystack, $needle, $part = null, $encoding = null) {}
 
 /**
- * (PHP 5 &gt;= 5.2.0)<br/>
+ * @since 5.2.0
  * Finds the last occurrence of a character in a string within another, case insensitive
  * @link http://php.net/manual/en/function.mb-strrichr.php
  * @param string $haystack <p>
@@ -444,7 +459,8 @@ function mb_stristr ($haystack, $needle, $part = null, $encoding = null) {}
 function mb_strrichr ($haystack, $needle, $part = null, $encoding = null) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Count the number of substring occurrences
  * @link http://php.net/manual/en/function.mb-substr-count.php
  * @param string $haystack <p>
@@ -461,7 +477,8 @@ function mb_strrichr ($haystack, $needle, $part = null, $encoding = null) {}
 function mb_substr_count ($haystack, $needle, $encoding = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Get part of string
  * @link http://php.net/manual/en/function.mb-substr.php
  * @param string $str <p>
@@ -482,7 +499,8 @@ function mb_substr_count ($haystack, $needle, $encoding = null) {}
 function mb_substr ($str, $start, $length = null, $encoding = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Get part of string
  * @link http://php.net/manual/en/function.mb-strcut.php
  * @param string $str <p>
@@ -503,7 +521,8 @@ function mb_substr ($str, $start, $length = null, $encoding = null) {}
 function mb_strcut ($str, $start, $length = null, $encoding = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Return width of string
  * @link http://php.net/manual/en/function.mb-strwidth.php
  * @param string $str <p>
@@ -515,7 +534,8 @@ function mb_strcut ($str, $start, $length = null, $encoding = null) {}
 function mb_strwidth ($str, $encoding = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Get truncated string with specified width
  * @link http://php.net/manual/en/function.mb-strimwidth.php
  * @param string $str <p>
@@ -539,7 +559,8 @@ function mb_strwidth ($str, $encoding = null) {}
 function mb_strimwidth ($str, $start, $width, $trimmarker = null, $encoding = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Convert character encoding
  * @link http://php.net/manual/en/function.mb-convert-encoding.php
  * @param string $str <p>
@@ -563,7 +584,8 @@ function mb_strimwidth ($str, $start, $width, $trimmarker = null, $encoding = nu
 function mb_convert_encoding ($str, $to_encoding, $from_encoding = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Detect character encoding
  * @link http://php.net/manual/en/function.mb-detect-encoding.php
  * @param string $str <p>
@@ -589,7 +611,7 @@ function mb_convert_encoding ($str, $to_encoding, $from_encoding = null) {}
 function mb_detect_encoding ($str, $encoding_list = null, $strict = null) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Returns an array of all supported encodings
  * @link http://php.net/manual/en/function.mb-list-encodings.php
  * @return array a numerically indexed array.
@@ -606,7 +628,8 @@ function mb_list_encodings () {}
 function mb_encoding_aliases ($encoding) {}
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Convert "kana" one from another ("zen-kaku", "han-kaku" and more)
  * @link http://php.net/manual/en/function.mb-convert-kana.php
  * @param string $str <p>
@@ -723,7 +746,8 @@ function mb_encoding_aliases ($encoding) {}
 function mb_convert_kana ($str, $option = null, $encoding = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Encode string for MIME header
  * @link http://php.net/manual/en/function.mb-encode-mimeheader.php
  * @param string $str <p>
@@ -758,7 +782,8 @@ function mb_convert_kana ($str, $option = null, $encoding = null) {}
 function mb_encode_mimeheader ($str, $charset = null, $transfer_encoding = null, $linefeed = null, $indent = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Decode string in MIME header field
  * @link http://php.net/manual/en/function.mb-decode-mimeheader.php
  * @param string $str <p>
@@ -769,7 +794,8 @@ function mb_encode_mimeheader ($str, $charset = null, $transfer_encoding = null,
 function mb_decode_mimeheader ($str) {}
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Convert character code in variable(s)
  * @link http://php.net/manual/en/function.mb-convert-variables.php
  * @param string $to_encoding <p>
@@ -794,7 +820,8 @@ function mb_decode_mimeheader ($str) {}
 function mb_convert_variables ($to_encoding, $from_encoding, &$vars, &$_ = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Encode character to HTML numeric string reference
  * @link http://php.net/manual/en/function.mb-encode-numericentity.php
  * @param string $str <p>
@@ -810,7 +837,8 @@ function mb_convert_variables ($to_encoding, $from_encoding, &$vars, &$_ = null)
 function mb_encode_numericentity ($str, array $convmap, $encoding = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Decode HTML numeric string reference to character
  * @link http://php.net/manual/en/function.mb-decode-numericentity.php
  * @param string $str <p>
@@ -826,7 +854,8 @@ function mb_encode_numericentity ($str, array $convmap, $encoding = null) {}
 function mb_decode_numericentity ($str, array $convmap, $encoding = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Send encoded mail
  * @link http://php.net/manual/en/function.mb-send-mail.php
  * @param string $to <p>
@@ -857,7 +886,8 @@ function mb_decode_numericentity ($str, array $convmap, $encoding = null) {}
 function mb_send_mail ($to, $subject, $message, $additional_headers = null, $additional_parameter = null) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Get internal settings of mbstring
  * @link http://php.net/manual/en/function.mb-get-info.php
  * @param string $type [optional] <p>
@@ -892,7 +922,8 @@ function mb_get_info ($type = null) {}
 function mb_check_encoding ($var = null, $encoding = null) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Returns current encoding for multibyte regex as string
  * @link http://php.net/manual/en/function.mb-regex-encoding.php
  * @param string $encoding [optional] &mbstring.encoding.parameter;
@@ -901,7 +932,8 @@ function mb_check_encoding ($var = null, $encoding = null) {}
 function mb_regex_encoding ($encoding = null) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Set/Get the default options for mbregex functions
  * @link http://php.net/manual/en/function.mb-regex-set-options.php
  * @param string $options [optional] <p>
@@ -913,7 +945,8 @@ function mb_regex_encoding ($encoding = null) {}
 function mb_regex_set_options ($options = null) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Regular expression match with multibyte support
  * @link http://php.net/manual/en/function.mb-ereg.php
  * @param string $pattern <p>
@@ -930,7 +963,8 @@ function mb_regex_set_options ($options = null) {}
 function mb_ereg ($pattern, $string, array $regs = null) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Regular expression match ignoring case with multibyte support
  * @link http://php.net/manual/en/function.mb-eregi.php
  * @param string $pattern <p>
@@ -947,7 +981,8 @@ function mb_ereg ($pattern, $string, array $regs = null) {}
 function mb_eregi ($pattern, $string, array $regs = null) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Replace regular expression with multibyte support
  * @link http://php.net/manual/en/function.mb-ereg-replace.php
  * @param string $pattern <p>
@@ -977,7 +1012,7 @@ function mb_eregi ($pattern, $string, array $regs = null) {}
 function mb_ereg_replace ($pattern, $replacement, $string, $option = null) {}
 
 /**
- * (PHP 5 &gt;= 5.4.1)<br/>
+ * @since 5.4.1
  * Perform a regular expresssion seach and replace with multibyte support using a callback
  * @link http://www.php.net/manual/en/function.mb-ereg-replace-callback.php
  * @param string $pattern <p>
@@ -1022,7 +1057,8 @@ function mb_ereg_replace ($pattern, $replacement, $string, $option = null) {}
 function mb_ereg_replace_callback ($pattern, callable $callback, $string, $option = "msr") {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Replace regular expression with multibyte support ignoring case
  * @link http://php.net/manual/en/function.mb-eregi-replace.php
  * @param string $pattern <p>
@@ -1041,7 +1077,8 @@ function mb_ereg_replace_callback ($pattern, callable $callback, $string, $optio
 function mb_eregi_replace ($pattern, $replace, $string, $option = null) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Split multibyte string using regular expression
  * @link http://php.net/manual/en/function.mb-split.php
  * @param string $pattern <p>
@@ -1058,7 +1095,8 @@ function mb_eregi_replace ($pattern, $replace, $string, $option = null) {}
 function mb_split ($pattern, $string, $limit = null) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Regular expression match for multibyte string
  * @link http://php.net/manual/en/function.mb-ereg-match.php
  * @param string $pattern <p>
@@ -1074,7 +1112,8 @@ function mb_split ($pattern, $string, $limit = null) {}
 function mb_ereg_match ($pattern, $string, $option = null) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Multibyte regular expression match for predefined multibyte string
  * @link http://php.net/manual/en/function.mb-ereg-search.php
  * @param string $pattern [optional] <p>
@@ -1088,7 +1127,8 @@ function mb_ereg_match ($pattern, $string, $option = null) {}
 function mb_ereg_search ($pattern = null, $option = null) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Returns position and length of a matched part of the multibyte regular expression for a predefined multibyte string
  * @link http://php.net/manual/en/function.mb-ereg-search-pos.php
  * @param string $pattern [optional] <p>
@@ -1102,7 +1142,8 @@ function mb_ereg_search ($pattern = null, $option = null) {}
 function mb_ereg_search_pos ($pattern = null, $option = null) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Returns the matched part of a multibyte regular expression
  * @link http://php.net/manual/en/function.mb-ereg-search-regs.php
  * @param string $pattern [optional] <p>
@@ -1116,7 +1157,8 @@ function mb_ereg_search_pos ($pattern = null, $option = null) {}
 function mb_ereg_search_regs ($pattern = null, $option = null) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Setup string and regular expression for a multibyte regular expression match
  * @link http://php.net/manual/en/function.mb-ereg-search-init.php
  * @param string $string <p>
@@ -1133,7 +1175,8 @@ function mb_ereg_search_regs ($pattern = null, $option = null) {}
 function mb_ereg_search_init ($string, $pattern = null, $option = null) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Retrieve the result from the last multibyte regular expression match
  * @link http://php.net/manual/en/function.mb-ereg-search-getregs.php
  * @return array 
@@ -1141,7 +1184,8 @@ function mb_ereg_search_init ($string, $pattern = null, $option = null) {}
 function mb_ereg_search_getregs () {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Returns start point for next regular expression match
  * @link http://php.net/manual/en/function.mb-ereg-search-getpos.php
  * @return int 
@@ -1149,7 +1193,8 @@ function mb_ereg_search_getregs () {}
 function mb_ereg_search_getpos () {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Set start point of next regular expression match
  * @link http://php.net/manual/en/function.mb-ereg-search-setpos.php
  * @param int $position <p>

--- a/mbstring.php
+++ b/mbstring.php
@@ -907,7 +907,8 @@ function mb_send_mail ($to, $subject, $message, $additional_headers = null, $add
 function mb_get_info ($type = null) {}
 
 /**
- * (PHP 4 &gt;= 4.4.3, PHP 5 &gt;= 5.1.3)<br/>
+ * @since 4.4.3
+ * @since 5.1.3
  * Check if the string is valid for the specified encoding
  * @link http://php.net/manual/en/function.mb-check-encoding.php
  * @param string $var [optional] <p>

--- a/mcrypt.php
+++ b/mcrypt.php
@@ -7,7 +7,7 @@
  * @since 5.0
  * Deprecated: Encrypt/decrypt data in ECB mode
  * @link http://php.net/manual/en/function.mcrypt-ecb.php
- * @deprecated in 5.5 http://www.php.net/manual/en/migration55.deprecated.php
+ * @deprecated 5.5 http://www.php.net/manual/en/migration55.deprecated.php
  * @param int $cipher
  * @param string $key 
  * @param string $data 
@@ -21,7 +21,7 @@ function mcrypt_ecb ($cipher, $key, $data, $mode) {}
  * @since 5.0
  * Encrypt/decrypt data in CBC mode
  * @link http://php.net/manual/en/function.mcrypt-cbc.php
- * @deprecated in 5.5 http://www.php.net/manual/en/migration55.deprecated.php
+ * @deprecated 5.5 http://www.php.net/manual/en/migration55.deprecated.php
  * @param int $cipher 
  * @param string $key 
  * @param string $data 
@@ -36,7 +36,7 @@ function mcrypt_cbc ($cipher, $key, $data, $mode, $iv = null) {}
  * @since 5.0
  * Encrypt/decrypt data in CFB mode
  * @link http://php.net/manual/en/function.mcrypt-cfb.php
- * @deprecated in 5.5 http://www.php.net/manual/en/migration55.deprecated.php
+ * @deprecated 5.5 http://www.php.net/manual/en/migration55.deprecated.php
  * @param int $cipher
  * @param string $key 
  * @param string $data 
@@ -51,7 +51,7 @@ function mcrypt_cfb ($cipher, $key, $data, $mode, $iv) {}
  * @since 5.0
  * Encrypt/decrypt data in OFB mode
  * @link http://php.net/manual/en/function.mcrypt-ofb.php
- * @deprecated in 5.5 http://www.php.net/manual/en/migration55.deprecated.php
+ * @deprecated 5.5 http://www.php.net/manual/en/migration55.deprecated.php
  * @param int $cipher
  * @param string $key 
  * @param string $data 
@@ -351,12 +351,13 @@ function mcrypt_generic ($td, $data) {}
 function mdecrypt_generic ($td, $data) {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5 &lt;= 5.1.6)<br/>
+ * @since 4.0.2
+ * @since 5.1.6
  * This function terminates encryption
  * @link http://php.net/manual/en/function.mcrypt-generic-end.php
  * @param resource $td 
  * @return bool
- * @deprecated This function has been DEPRECATED as of PHP 5.4.0.
+ * @deprecated 5.4.0 This function has been DEPRECATED as of PHP 5.4.0.
  */
 function mcrypt_generic_end ($td) {}
 

--- a/mcrypt.php
+++ b/mcrypt.php
@@ -3,7 +3,8 @@
 // Start of mcrypt v.
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Deprecated: Encrypt/decrypt data in ECB mode
  * @link http://php.net/manual/en/function.mcrypt-ecb.php
  * @deprecated in 5.5 http://www.php.net/manual/en/migration55.deprecated.php
@@ -16,7 +17,8 @@
 function mcrypt_ecb ($cipher, $key, $data, $mode) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Encrypt/decrypt data in CBC mode
  * @link http://php.net/manual/en/function.mcrypt-cbc.php
  * @deprecated in 5.5 http://www.php.net/manual/en/migration55.deprecated.php
@@ -30,7 +32,8 @@ function mcrypt_ecb ($cipher, $key, $data, $mode) {}
 function mcrypt_cbc ($cipher, $key, $data, $mode, $iv = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Encrypt/decrypt data in CFB mode
  * @link http://php.net/manual/en/function.mcrypt-cfb.php
  * @deprecated in 5.5 http://www.php.net/manual/en/migration55.deprecated.php
@@ -44,7 +47,8 @@ function mcrypt_cbc ($cipher, $key, $data, $mode, $iv = null) {}
 function mcrypt_cfb ($cipher, $key, $data, $mode, $iv) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Encrypt/decrypt data in OFB mode
  * @link http://php.net/manual/en/function.mcrypt-ofb.php
  * @deprecated in 5.5 http://www.php.net/manual/en/migration55.deprecated.php
@@ -58,7 +62,8 @@ function mcrypt_cfb ($cipher, $key, $data, $mode, $iv) {}
 function mcrypt_ofb ($cipher, $key, $data, $mode, $iv) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get the key size of the specified cipher
  * @link http://php.net/manual/en/function.mcrypt-get-key-size.php
  * @param int $cipher 
@@ -67,7 +72,8 @@ function mcrypt_ofb ($cipher, $key, $data, $mode, $iv) {}
 function mcrypt_get_key_size ($cipher) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get the block size of the specified cipher
  * @link http://php.net/manual/en/function.mcrypt-get-block-size.php
  * @param int $cipher <p>
@@ -79,7 +85,8 @@ function mcrypt_get_key_size ($cipher) {}
 function mcrypt_get_block_size ($cipher) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get the name of the specified cipher
  * @link http://php.net/manual/en/function.mcrypt-get-cipher-name.php
  * @param int $cipher <p>
@@ -92,7 +99,8 @@ function mcrypt_get_block_size ($cipher) {}
 function mcrypt_get_cipher_name ($cipher) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Create an initialization vector (IV) from a random source
  * @link http://php.net/manual/en/function.mcrypt-create-iv.php
  * @param int $size <p>
@@ -121,7 +129,8 @@ function mcrypt_get_cipher_name ($cipher) {}
 function mcrypt_create_iv ($size, $source = MCRYPT_DEV_URANDOM) {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Get an array of all supported ciphers
  * @link http://php.net/manual/en/function.mcrypt-list-algorithms.php
  * @param string $lib_dir [optional] <p>
@@ -134,7 +143,8 @@ function mcrypt_create_iv ($size, $source = MCRYPT_DEV_URANDOM) {}
 function mcrypt_list_algorithms ($lib_dir = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Get an array of all supported modes
  * @link http://php.net/manual/en/function.mcrypt-list-modes.php
  * @param string $lib_dir [optional] <p>
@@ -147,7 +157,8 @@ function mcrypt_list_algorithms ($lib_dir = null) {}
 function mcrypt_list_modes ($lib_dir = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Returns the size of the IV belonging to a specific cipher/mode combination
  * @link http://php.net/manual/en/function.mcrypt-get-iv-size.php
  * @param string $cipher <p>
@@ -168,7 +179,8 @@ function mcrypt_list_modes ($lib_dir = null) {}
 function mcrypt_get_iv_size ($cipher, $mode) {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Encrypts plaintext with given parameters
  * @link http://php.net/manual/en/function.mcrypt-encrypt.php
  * @param string $cipher <p>
@@ -209,7 +221,8 @@ function mcrypt_get_iv_size ($cipher, $mode) {}
 function mcrypt_encrypt ($cipher, $key, $data, $mode, $iv = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Decrypts crypttext with given parameters
  * @link http://php.net/manual/en/function.mcrypt-decrypt.php
  * @param string $cipher <p>
@@ -242,7 +255,8 @@ function mcrypt_encrypt ($cipher, $key, $data, $mode, $iv = null) {}
 function mcrypt_decrypt ($cipher, $key, $data, $mode, $iv = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Opens the module of the algorithm and the mode to be used
  * @link http://php.net/manual/en/function.mcrypt-module-open.php
  * @param string $algorithm <p>
@@ -269,7 +283,8 @@ function mcrypt_decrypt ($cipher, $key, $data, $mode, $iv = null) {}
 function mcrypt_module_open ($algorithm, $algorithm_directory, $mode, $mode_directory) {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * This function initializes all buffers needed for encryption
  * @link http://php.net/manual/en/function.mcrypt-generic-init.php
  * @param resource $td <p>
@@ -298,7 +313,8 @@ function mcrypt_module_open ($algorithm, $algorithm_directory, $mode, $mode_dire
 function mcrypt_generic_init ($td, $key, $iv) {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * This function encrypts data
  * @link http://php.net/manual/en/function.mcrypt-generic.php
  * @param resource $td <p>
@@ -319,7 +335,8 @@ function mcrypt_generic_init ($td, $key, $iv) {}
 function mcrypt_generic ($td, $data) {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Decrypt data
  * @link http://php.net/manual/en/function.mdecrypt-generic.php
  * @param resource $td <p>
@@ -344,7 +361,8 @@ function mdecrypt_generic ($td, $data) {}
 function mcrypt_generic_end ($td) {}
 
 /**
- * (PHP 4 &gt;= 4.0.7, PHP 5)<br/>
+ * @since 4.0.7
+ * @since 5.0
  * This function deinitializes an encryption module
  * @link http://php.net/manual/en/function.mcrypt-generic-deinit.php
  * @param resource $td <p>
@@ -355,7 +373,8 @@ function mcrypt_generic_end ($td) {}
 function mcrypt_generic_deinit ($td) {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Runs a self test on the opened module
  * @link http://php.net/manual/en/function.mcrypt-enc-self-test.php
  * @param resource $td <p>
@@ -367,7 +386,8 @@ function mcrypt_generic_deinit ($td) {}
 function mcrypt_enc_self_test ($td) {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Checks whether the encryption of the opened mode works on blocks
  * @link http://php.net/manual/en/function.mcrypt-enc-is-block-algorithm-mode.php
  * @param resource $td <p>
@@ -379,7 +399,8 @@ function mcrypt_enc_self_test ($td) {}
 function mcrypt_enc_is_block_algorithm_mode ($td) {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Checks whether the algorithm of the opened mode is a block algorithm
  * @link http://php.net/manual/en/function.mcrypt-enc-is-block-algorithm.php
  * @param resource $td <p>
@@ -391,7 +412,8 @@ function mcrypt_enc_is_block_algorithm_mode ($td) {}
 function mcrypt_enc_is_block_algorithm ($td) {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Checks whether the opened mode outputs blocks
  * @link http://php.net/manual/en/function.mcrypt-enc-is-block-mode.php
  * @param resource $td <p>
@@ -402,7 +424,8 @@ function mcrypt_enc_is_block_algorithm ($td) {}
 function mcrypt_enc_is_block_mode ($td) {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Returns the blocksize of the opened algorithm
  * @link http://php.net/manual/en/function.mcrypt-enc-get-block-size.php
  * @param resource $td <p>
@@ -413,7 +436,8 @@ function mcrypt_enc_is_block_mode ($td) {}
 function mcrypt_enc_get_block_size ($td) {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Returns the maximum supported keysize of the opened mode
  * @link http://php.net/manual/en/function.mcrypt-enc-get-key-size.php
  * @param resource $td <p>
@@ -424,7 +448,8 @@ function mcrypt_enc_get_block_size ($td) {}
 function mcrypt_enc_get_key_size ($td) {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Returns an array with the supported keysizes of the opened algorithm
  * @link http://php.net/manual/en/function.mcrypt-enc-get-supported-key-sizes.php
  * @param resource $td <p>
@@ -439,7 +464,8 @@ function mcrypt_enc_get_key_size ($td) {}
 function mcrypt_enc_get_supported_key_sizes ($td) {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Returns the size of the IV of the opened algorithm
  * @link http://php.net/manual/en/function.mcrypt-enc-get-iv-size.php
  * @param resource $td <p>
@@ -450,7 +476,8 @@ function mcrypt_enc_get_supported_key_sizes ($td) {}
 function mcrypt_enc_get_iv_size ($td) {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Returns the name of the opened algorithm
  * @link http://php.net/manual/en/function.mcrypt-enc-get-algorithms-name.php
  * @param resource $td <p>
@@ -461,7 +488,8 @@ function mcrypt_enc_get_iv_size ($td) {}
 function mcrypt_enc_get_algorithms_name ($td) {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Returns the name of the opened mode
  * @link http://php.net/manual/en/function.mcrypt-enc-get-modes-name.php
  * @param resource $td <p>
@@ -472,7 +500,8 @@ function mcrypt_enc_get_algorithms_name ($td) {}
 function mcrypt_enc_get_modes_name ($td) {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * This function runs a self test on the specified module
  * @link http://php.net/manual/en/function.mcrypt-module-self-test.php
  * @param string $algorithm <p>
@@ -488,7 +517,8 @@ function mcrypt_enc_get_modes_name ($td) {}
 function mcrypt_module_self_test ($algorithm, $lib_dir = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Returns if the specified module is a block algorithm or not
  * @link http://php.net/manual/en/function.mcrypt-module-is-block-algorithm-mode.php
  * @param string $mode <p>
@@ -505,7 +535,8 @@ function mcrypt_module_self_test ($algorithm, $lib_dir = null) {}
 function mcrypt_module_is_block_algorithm_mode ($mode, $lib_dir = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * This function checks whether the specified algorithm is a block algorithm
  * @link http://php.net/manual/en/function.mcrypt-module-is-block-algorithm.php
  * @param string $algorithm <p>
@@ -521,7 +552,8 @@ function mcrypt_module_is_block_algorithm_mode ($mode, $lib_dir = null) {}
 function mcrypt_module_is_block_algorithm ($algorithm, $lib_dir = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Returns if the specified mode outputs blocks or not
  * @link http://php.net/manual/en/function.mcrypt-module-is-block-mode.php
  * @param string $mode <p>
@@ -538,7 +570,8 @@ function mcrypt_module_is_block_algorithm ($algorithm, $lib_dir = null) {}
 function mcrypt_module_is_block_mode ($mode, $lib_dir = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Returns the blocksize of the specified algorithm
  * @link http://php.net/manual/en/function.mcrypt-module-get-algo-block-size.php
  * @param string $algorithm <p>
@@ -553,7 +586,8 @@ function mcrypt_module_is_block_mode ($mode, $lib_dir = null) {}
 function mcrypt_module_get_algo_block_size ($algorithm, $lib_dir = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Returns the maximum supported keysize of the opened mode
  * @link http://php.net/manual/en/function.mcrypt-module-get-algo-key-size.php
  * @param string $algorithm <p>
@@ -569,7 +603,8 @@ function mcrypt_module_get_algo_block_size ($algorithm, $lib_dir = null) {}
 function mcrypt_module_get_algo_key_size ($algorithm, $lib_dir = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Returns an array with the supported keysizes of the opened algorithm
  * @link http://php.net/manual/en/function.mcrypt-module-get-supported-key-sizes.php
  * @param string $algorithm <p>
@@ -587,7 +622,8 @@ function mcrypt_module_get_algo_key_size ($algorithm, $lib_dir = null) {}
 function mcrypt_module_get_supported_key_sizes ($algorithm, $lib_dir = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Close the mcrypt module
  * @link http://php.net/manual/en/function.mcrypt-module-close.php
  * @param resource $td <p>

--- a/mysql.php
+++ b/mysql.php
@@ -1,11 +1,12 @@
 <?php
 
 // Start of mysql v.1.0
-// @deprecated in 5.5 entire extension is deprecated in favor of mysqli
+// @deprecated 5.5 entire extension is deprecated in favor of mysqli
 
 /**
  * @since 4.0
  * @since 5.0
+ * @deprecated 5.5
  * Open a connection to a MySQL Server
  * @link http://php.net/manual/en/function.mysql-connect.php
  * @param string $server [optional] <p>
@@ -56,6 +57,7 @@ function mysql_connect ($server = 'ini_get("mysql.default_host")', $username = '
 /**
  * @since 4.0
  * @since 5.0
+ * @deprecated 5.5
  * Open a persistent connection to a MySQL server
  * @link http://php.net/manual/en/function.mysql-pconnect.php
  * @param string $server [optional] <p>
@@ -92,6 +94,7 @@ function mysql_pconnect ($server = 'ini_get("mysql.default_host")', $username = 
 /**
  * @since 4.0
  * @since 5.0
+ * @deprecated 5.5
  * Close MySQL connection
  * @link http://php.net/manual/en/function.mysql-close.php
  * @param resource $link_identifier [optional] 
@@ -102,6 +105,7 @@ function mysql_close ($link_identifier = null) {}
 /**
  * @since 4.0
  * @since 5.0
+ * @deprecated 5.5
  * Select a MySQL database
  * @link http://php.net/manual/en/function.mysql-select-db.php
  * @param string $database_name <p>
@@ -115,6 +119,7 @@ function mysql_select_db ($database_name, $link_identifier = null) {}
 /**
  * @since 4.0
  * @since 5.0
+ * @deprecated 5.5
  * Send a MySQL query
  * @link http://php.net/manual/en/function.mysql-query.php
  * @param string $query <p>
@@ -157,6 +162,7 @@ function mysql_query ($query, $link_identifier = null) {}
 /**
  * @since 4.0.6
  * @since 5.0
+ * @deprecated 5.5
  * Send an SQL query to MySQL without fetching and buffering the result rows.
  * @link http://php.net/manual/en/function.mysql-unbuffered-query.php
  * @param string $query <p>
@@ -183,7 +189,7 @@ function mysql_unbuffered_query ($query, $link_identifier = null) {}
  * @since 5.0
  * Selects a database and executes a query on it
  * @link http://php.net/manual/en/function.mysql-db-query.php
- * @deprecated since 5.3.0, use mysql_select_db() and mysql_query() instead
+ * @deprecated 5.3.0 Use mysql_select_db() and mysql_query() instead
  * @param string $database <p>
  * The name of the database that will be selected.
  * </p>
@@ -211,7 +217,7 @@ function mysql_db_query ($database, $query, $link_identifier = null) {}
  * failure. Use the <b>mysql_tablename</b> function to traverse
  * this result pointer, or any function for result tables, such as 
  * <b>mysql_fetch_array</b>.
- * @deprecated This function has been DEPRECATED as of PHP 5.4.0.
+ * @deprecated 5.4.0
  */
 function mysql_list_dbs ($link_identifier = null) {}
 
@@ -230,13 +236,14 @@ function mysql_list_dbs ($link_identifier = null) {}
  * Use the <b>mysql_tablename</b> function to
  * traverse this result pointer, or any function for result tables,
  * such as <b>mysql_fetch_array</b>.
- * @deprecated This function has been DEPRECATED as of PHP 5.2.0.
+ * @deprecated 5.2.0
  */
 function mysql_list_tables ($database, $link_identifier = null) {}
 
 /**
  * @since 4.0
  * @since 5.0
+ * @deprecated 5.5
  * List MySQL table fields
  * @link http://php.net/manual/en/function.mysql-list-fields.php
  * @param string $database_name <p>
@@ -260,6 +267,7 @@ function mysql_list_fields ($database_name, $table_name, $link_identifier = null
 /**
  * @since 4.3.0
  * @since 5.0
+ * @deprecated 5.5
  * List MySQL processes
  * @link http://php.net/manual/en/function.mysql-list-processes.php
  * @param resource $link_identifier [optional] 
@@ -270,6 +278,7 @@ function mysql_list_processes ($link_identifier = null) {}
 /**
  * @since 4.0
  * @since 5.0
+ * @deprecated 5.5
  * Returns the text of the error message from previous MySQL operation
  * @link http://php.net/manual/en/function.mysql-error.php
  * @param resource $link_identifier [optional] 
@@ -281,6 +290,7 @@ function mysql_error ($link_identifier = null) {}
 /**
  * @since 4.0
  * @since 5.0
+ * @deprecated 5.5
  * Returns the numerical value of the error message from previous MySQL operation
  * @link http://php.net/manual/en/function.mysql-errno.php
  * @param resource $link_identifier [optional] 
@@ -292,6 +302,7 @@ function mysql_errno ($link_identifier = null) {}
 /**
  * @since 4.0
  * @since 5.0
+ * @deprecated 5.5
  * Get number of affected rows in previous MySQL operation
  * @link http://php.net/manual/en/function.mysql-affected-rows.php
  * @param resource $link_identifier [optional] 
@@ -320,6 +331,7 @@ function mysql_affected_rows ($link_identifier = null) {}
 /**
  * @since 4.0
  * @since 5.0
+ * @deprecated 5.5
  * Get the ID generated in the last query
  * @link http://php.net/manual/en/function.mysql-insert-id.php
  * @param resource $link_identifier [optional] 
@@ -333,6 +345,7 @@ function mysql_insert_id ($link_identifier = null) {}
 /**
  * @since 4.0
  * @since 5.0
+ * @deprecated 5.5
  * Get result data
  * @link http://php.net/manual/en/function.mysql-result.php
  * @param resource $result 
@@ -367,6 +380,7 @@ function mysql_num_rows ($result) {}
 /**
  * @since 4.0
  * @since 5.0
+ * @deprecated 5.5
  * Get number of fields in result
  * @link http://php.net/manual/en/function.mysql-num-fields.php
  * @param resource $result 
@@ -378,6 +392,7 @@ function mysql_num_fields ($result) {}
 /**
  * @since 4.0
  * @since 5.0
+ * @deprecated 5.5
  * Get a result row as an enumerated array
  * @link http://php.net/manual/en/function.mysql-fetch-row.php
  * @param resource $result 
@@ -395,6 +410,7 @@ function mysql_fetch_row ($result) {}
 /**
  * @since 4.0
  * @since 5.0
+ * @deprecated 5.5
  * Fetch a result row as an associative array, a numeric array, or both
  * @link http://php.net/manual/en/function.mysql-fetch-array.php
  * @param resource $result 
@@ -425,6 +441,7 @@ function mysql_fetch_array ($result, $result_type = MYSQL_BOTH) {}
 /**
  * @since 4.0.3
  * @since 5.0
+ * @deprecated 5.5
  * Fetch a result row as an associative array
  * @link http://php.net/manual/en/function.mysql-fetch-assoc.php
  * @param resource $result 
@@ -445,6 +462,7 @@ function mysql_fetch_assoc ($result) {}
 /**
  * @since 4.0
  * @since 5.0
+ * @deprecated 5.5
  * Fetch a result row as an object
  * @link http://php.net/manual/en/function.mysql-fetch-object.php
  * @param resource $result 
@@ -470,6 +488,7 @@ function mysql_fetch_object ($result, $class_name = null, array $params = null )
 /**
  * @since 4.0
  * @since 5.0
+ * @deprecated 5.5
  * Move internal result pointer
  * @link http://php.net/manual/en/function.mysql-data-seek.php
  * @param resource $result 
@@ -483,6 +502,7 @@ function mysql_data_seek ($result, $row_number) {}
 /**
  * @since 4.0
  * @since 5.0
+ * @deprecated 5.5
  * Get the length of each output in a result
  * @link http://php.net/manual/en/function.mysql-fetch-lengths.php
  * @param resource $result 
@@ -493,6 +513,7 @@ function mysql_fetch_lengths ($result) {}
 /**
  * @since 4.0
  * @since 5.0
+ * @deprecated 5.5
  * Get column information from a result and return as an object
  * @link http://php.net/manual/en/function.mysql-fetch-field.php
  * @param resource $result 
@@ -524,6 +545,7 @@ function mysql_fetch_field ($result, $field_offset = 0) {}
 /**
  * @since 4.0
  * @since 5.0
+ * @deprecated 5.5
  * Set result pointer to a specified field offset
  * @link http://php.net/manual/en/function.mysql-field-seek.php
  * @param resource $result 
@@ -535,6 +557,7 @@ function mysql_field_seek ($result, $field_offset) {}
 /**
  * @since 4.0
  * @since 5.0
+ * @deprecated 5.5
  * Free result memory
  * @link http://php.net/manual/en/function.mysql-free-result.php
  * @param resource $result 
@@ -551,6 +574,7 @@ function mysql_free_result ($result) {}
 /**
  * @since 4.0
  * @since 5.0
+ * @deprecated 5.5
  * Get the name of the specified field in a result
  * @link http://php.net/manual/en/function.mysql-field-name.php
  * @param resource $result 
@@ -562,6 +586,7 @@ function mysql_field_name ($result, $field_offset) {}
 /**
  * @since 4.0
  * @since 5.0
+ * @deprecated 5.5
  * Get name of the table the specified field is in
  * @link http://php.net/manual/en/function.mysql-field-table.php
  * @param resource $result 
@@ -573,6 +598,7 @@ function mysql_field_table ($result, $field_offset) {}
 /**
  * @since 4.0
  * @since 5.0
+ * @deprecated 5.5
  * Returns the length of the specified field
  * @link http://php.net/manual/en/function.mysql-field-len.php
  * @param resource $result 
@@ -584,6 +610,7 @@ function mysql_field_len ($result, $field_offset) {}
 /**
  * @since 4.0
  * @since 5.0
+ * @deprecated 5.5
  * Get the type of the specified field in a result
  * @link http://php.net/manual/en/function.mysql-field-type.php
  * @param resource $result 
@@ -599,6 +626,7 @@ function mysql_field_type ($result, $field_offset) {}
 /**
  * @since 4.0
  * @since 5.0
+ * @deprecated 5.5
  * Get the flags associated with the specified field in a result
  * @link http://php.net/manual/en/function.mysql-field-flags.php
  * @param resource $result 
@@ -621,7 +649,7 @@ function mysql_field_flags ($result, $field_offset) {}
  * @since 5.0
  * Escapes a string for use in a mysql_query
  * @link http://php.net/manual/en/function.mysql-escape-string.php
- * @deprecated since 5.3.0, use mysql_real_escape_string() instead
+ * @deprecated 5.3.0 Use mysql_real_escape_string() instead
  * @param string $unescaped_string <p>
  * The string that is to be escaped.
  * </p>
@@ -632,6 +660,7 @@ function mysql_escape_string ($unescaped_string) {}
 /**
  * @since 4.3.0
  * @since 5.0
+ * @deprecated 5.5
  * Escapes special characters in a string for use in an SQL statement
  * @link http://php.net/manual/en/function.mysql-real-escape-string.php
  * @param string $unescaped_string <p>
@@ -645,6 +674,7 @@ function mysql_real_escape_string ($unescaped_string, $link_identifier = null) {
 /**
  * @since 4.3.0
  * @since 5.0
+ * @deprecated 5.5
  * Get current system status
  * @link http://php.net/manual/en/function.mysql-stat.php
  * @param resource $link_identifier [optional] 
@@ -658,6 +688,7 @@ function mysql_stat ($link_identifier = null) {}
 /**
  * @since 4.3.0
  * @since 5.0
+ * @deprecated 5.5
  * Return the current thread ID
  * @link http://php.net/manual/en/function.mysql-thread-id.php
  * @param resource $link_identifier [optional] 
@@ -668,6 +699,7 @@ function mysql_thread_id ($link_identifier = null) {}
 /**
  * @since 4.3.0
  * @since 5.0
+ * @deprecated 5.5
  * Returns the name of the character set
  * @link http://php.net/manual/en/function.mysql-client-encoding.php
  * @param resource $link_identifier [optional] 
@@ -678,6 +710,7 @@ function mysql_client_encoding ($link_identifier = null) {}
 /**
  * @since 4.3.0
  * @since 5.0
+ * @deprecated 5.5
  * Ping a server connection or reconnect if there is no connection
  * @link http://php.net/manual/en/function.mysql-ping.php
  * @param resource $link_identifier [optional] 
@@ -689,6 +722,7 @@ function mysql_ping ($link_identifier = null) {}
 /**
  * @since 4.0.5
  * @since 5.0
+ * @deprecated 5.5
  * Get MySQL client info
  * @link http://php.net/manual/en/function.mysql-get-client-info.php
  * @return string The MySQL client version.
@@ -698,6 +732,7 @@ function mysql_get_client_info () {}
 /**
  * @since 4.0.5
  * @since 5.0
+ * @deprecated 5.5
  * Get MySQL host info
  * @link http://php.net/manual/en/function.mysql-get-host-info.php
  * @param resource $link_identifier [optional] 
@@ -709,6 +744,7 @@ function mysql_get_host_info ($link_identifier = null) {}
 /**
  * @since 4.0.5
  * @since 5.0
+ * @deprecated 5.5
  * Get MySQL protocol info
  * @link http://php.net/manual/en/function.mysql-get-proto-info.php
  * @param resource $link_identifier [optional] 
@@ -719,6 +755,7 @@ function mysql_get_proto_info ($link_identifier = null) {}
 /**
  * @since 4.0.5
  * @since 5.0
+ * @deprecated 5.5
  * Get MySQL server info
  * @link http://php.net/manual/en/function.mysql-get-server-info.php
  * @param resource $link_identifier [optional] 
@@ -729,6 +766,7 @@ function mysql_get_server_info ($link_identifier = null) {}
 /**
  * @since 4.3.0
  * @since 5.0
+ * @deprecated 5.5
  * Get information about the most recent query
  * @link http://php.net/manual/en/function.mysql-info.php
  * @param resource $link_identifier [optional] 
@@ -741,6 +779,7 @@ function mysql_info ($link_identifier = null) {}
 
 /**
  * @since 5.2.3
+ * @deprecated 5.5 Use mysqli_set_charset instead.
  * Sets the client character set
  * @link http://php.net/manual/en/function.mysql-set-charset.php
  * @param string $charset <p>
@@ -755,61 +794,61 @@ function mysql_set_charset ($charset, $link_identifier = null) {}
  * @param $database_name
  * @param $query
  * @param $link_identifier [optional]
- * @deprecated This function has been DEPRECATED as of PHP 5.5.0. Use mysql_db_query instead.
+ * @deprecated 5.3.0 Use mysql_db_query instead.
  */
 function mysql ($database_name, $query, $link_identifier) {}
 
 /**
  * @param $result
  * @param $field_index
- * @deprecated This function has been DEPRECATED as of PHP 5.5.0. Use mysql_field_name instead.
+ * @deprecated 5.5 Use mysql_field_name instead.
  */
 function mysql_fieldname ($result, $field_index) {}
 
 /**
  * @param $result
  * @param $field_offset
- * @deprecated This function has been DEPRECATED as of PHP 5.5.0. Use mysql_field_table instead.
+ * @deprecated 5.5 Use mysql_field_table instead.
  */
 function mysql_fieldtable ($result, $field_offset) {}
 
 /**
  * @param $result
  * @param $field_offset
- * @deprecated This function has been DEPRECATED as of PHP 5.5.0. Use mysql_field_len instead.
+ * @deprecated 5.5 Use mysql_field_len instead.
  */
 function mysql_fieldlen ($result, $field_offset) {}
 
 /**
  * @param $result
  * @param $field_offset
- * @deprecated This function has been DEPRECATED as of PHP 5.5.0. Use mysql_field_type instead.
+ * @deprecated 5.5 Use mysql_field_type instead.
  */
 function mysql_fieldtype ($result, $field_offset) {}
 
 /**
  * @param $result
  * @param $field_offset
- * @deprecated This function has been DEPRECATED as of PHP 5.5.0. Use mysql_field_flags instead.
+ * @deprecated 5.5 Use mysql_field_flags instead.
  */
 function mysql_fieldflags ($result, $field_offset) {}
 
 /**
  * @param $database_name
  * @param $link_identifier [optional]
- * @deprecated This function has been DEPRECATED as of PHP 5.5.0. Use mysql_select_db instead.
+ * @deprecated 5.5 Use mysql_select_db instead.
  */
 function mysql_selectdb ($database_name, $link_identifier) {}
 
 /**
  * @param $result
- * @deprecated This function has been DEPRECATED as of PHP 5.5.0. Use mysql_free_result instead.
+ * @deprecated 5.5 Use mysql_free_result instead.
  */
 function mysql_freeresult ($result) {}
 
 /**
  * @param $result
- * @deprecated This function has been DEPRECATED as of PHP 5.5.0. Use mysql_num_fields instead.
+ * @deprecated 5.5 Use mysql_num_fields instead.
  */
 function mysql_numfields ($result) {}
 
@@ -819,20 +858,20 @@ function mysql_numfields ($result) {}
  * @link http://php.net/manual/en/function.mysql-num-rows.php
  * @param resource $result <p>The result resource that is being evaluated. This result comes from a call to mysql_query().</p>
  * @return int <p>The number of rows in the result set on success or FALSE on failure. </p>
- * @deprecated This function has been DEPRECATED as of PHP 5.5.0. Use mysql_num_rows instead.
+ * @deprecated 5.5 Use mysql_num_rows instead.
  */
 function mysql_numrows ($result) {}
 
 /**
  * @param $link_identifier [optional]
- * @deprecated This function has been DEPRECATED as of PHP 5.5.0. Use mysql_list_dbs instead.
+ * @deprecated 5.5 Use mysql_list_dbs instead.
  */
 function mysql_listdbs ($link_identifier) {}
 
 /**
  * @param $database_name
  * @param $link_identifier [optional]
- * @deprecated This function has been DEPRECATED as of PHP 5.5.0. Use mysql_list_tables instead.
+ * @deprecated 5.5 Use mysql_list_tables instead.
  */
 function mysql_listtables ($database_name, $link_identifier) {}
 
@@ -840,13 +879,14 @@ function mysql_listtables ($database_name, $link_identifier) {}
  * @param $database_name
  * @param $table_name
  * @param $link_identifier [optional]
- * @deprecated This function has been DEPRECATED as of PHP 5.5.0. Use mysql_list_fields instead.
+ * @deprecated 5.5 Use mysql_list_fields instead.
  */
 function mysql_listfields ($database_name, $table_name, $link_identifier) {}
 
 /**
  * @since 4.0
  * @since 5.0
+ * @deprecated 5.5
  * Retrieves database name from the call to <b>mysql_list_dbs</b>
  * @link http://php.net/manual/en/function.mysql-db-name.php
  * @param resource $result <p>
@@ -868,13 +908,14 @@ function mysql_db_name ($result, $row, $field = null) {}
  * @param $result
  * @param $row
  * @param $field [optional]
- * @deprecated This function has been DEPRECATED as of PHP 5.5.0. Use mysql_db_name instead.
+ * @deprecated 5.5 Use mysql_db_name instead.
  */
 function mysql_dbname ($result, $row, $field) {}
 
 /**
  * @since 4.0
  * @since 5.0
+ * @deprecated 5.5
  * Get table name of field
  * @link http://php.net/manual/en/function.mysql-tablename.php
  * @param resource $result <p>
@@ -894,6 +935,7 @@ function mysql_dbname ($result, $row, $field) {}
 function mysql_tablename ($result, $i) {}
 
 /**
+ * @deprecated 5.5
  * @param $result
  * @param $row
  * @param $field [optional]
@@ -905,6 +947,7 @@ function mysql_table_name ($result, $row, $field) {}
  * Columns are returned into the array having the fieldname as the array
  * index.
  * @link http://php.net/manual/en/mysql.constants.php
+ * @deprecated 5.5
  */
 define ('MYSQL_ASSOC', 1);
 
@@ -912,6 +955,7 @@ define ('MYSQL_ASSOC', 1);
  * Columns are returned into the array having a numerical index to the
  * fields. This index starts with 0, the first field in the result.
  * @link http://php.net/manual/en/mysql.constants.php
+ * @deprecated 5.5
  */
 define ('MYSQL_NUM', 2);
 
@@ -919,12 +963,14 @@ define ('MYSQL_NUM', 2);
  * Columns are returned into the array having both a numerical index
  * and the fieldname as the array index.
  * @link http://php.net/manual/en/mysql.constants.php
+ * @deprecated 5.5
  */
 define ('MYSQL_BOTH', 3);
 
 /**
  * Use compression protocol
  * @link http://php.net/manual/en/mysql.constants.php
+ * @deprecated 5.5
  */
 define ('MYSQL_CLIENT_COMPRESS', 32);
 
@@ -933,6 +979,7 @@ define ('MYSQL_CLIENT_COMPRESS', 32);
  * of the MySQL client library or newer. Version 3.23.x is bundled both
  * with PHP 4 and Windows binaries of PHP 5.
  * @link http://php.net/manual/en/mysql.constants.php
+ * @deprecated 5.5
  */
 define ('MYSQL_CLIENT_SSL', 2048);
 
@@ -940,12 +987,14 @@ define ('MYSQL_CLIENT_SSL', 2048);
  * Allow interactive_timeout seconds (instead of wait_timeout) of
  * inactivity before closing the connection.
  * @link http://php.net/manual/en/mysql.constants.php
+ * @deprecated 5.5
  */
 define ('MYSQL_CLIENT_INTERACTIVE', 1024);
 
 /**
  * Allow space after function names
  * @link http://php.net/manual/en/mysql.constants.php
+ * @deprecated 5.5
  */
 define ('MYSQL_CLIENT_IGNORE_SPACE', 256);
 

--- a/mysql.php
+++ b/mysql.php
@@ -4,7 +4,8 @@
 // @deprecated in 5.5 entire extension is deprecated in favor of mysqli
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Open a connection to a MySQL Server
  * @link http://php.net/manual/en/function.mysql-connect.php
  * @param string $server [optional] <p>
@@ -53,7 +54,8 @@
 function mysql_connect ($server = 'ini_get("mysql.default_host")', $username = 'ini_get("mysql.default_user")', $password = 'ini_get("mysql.default_password")', $new_link = false, $client_flags = 0) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Open a persistent connection to a MySQL server
  * @link http://php.net/manual/en/function.mysql-pconnect.php
  * @param string $server [optional] <p>
@@ -88,7 +90,8 @@ function mysql_connect ($server = 'ini_get("mysql.default_host")', $username = '
 function mysql_pconnect ($server = 'ini_get("mysql.default_host")', $username = 'ini_get("mysql.default_user")', $password = 'ini_get("mysql.default_password")', $client_flags = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Close MySQL connection
  * @link http://php.net/manual/en/function.mysql-close.php
  * @param resource $link_identifier [optional] 
@@ -97,7 +100,8 @@ function mysql_pconnect ($server = 'ini_get("mysql.default_host")', $username = 
 function mysql_close ($link_identifier = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Select a MySQL database
  * @link http://php.net/manual/en/function.mysql-select-db.php
  * @param string $database_name <p>
@@ -109,7 +113,8 @@ function mysql_close ($link_identifier = null) {}
 function mysql_select_db ($database_name, $link_identifier = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Send a MySQL query
  * @link http://php.net/manual/en/function.mysql-query.php
  * @param string $query <p>
@@ -150,7 +155,8 @@ function mysql_select_db ($database_name, $link_identifier = null) {}
 function mysql_query ($query, $link_identifier = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Send an SQL query to MySQL without fetching and buffering the result rows.
  * @link http://php.net/manual/en/function.mysql-unbuffered-query.php
  * @param string $query <p>
@@ -173,7 +179,8 @@ function mysql_query ($query, $link_identifier = null) {}
 function mysql_unbuffered_query ($query, $link_identifier = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Selects a database and executes a query on it
  * @link http://php.net/manual/en/function.mysql-db-query.php
  * @deprecated since 5.3.0, use mysql_select_db() and mysql_query() instead
@@ -195,7 +202,8 @@ function mysql_unbuffered_query ($query, $link_identifier = null) {}
 function mysql_db_query ($database, $query, $link_identifier = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * List databases available on a MySQL server
  * @link http://php.net/manual/en/function.mysql-list-dbs.php
  * @param resource $link_identifier [optional] 
@@ -208,7 +216,8 @@ function mysql_db_query ($database, $query, $link_identifier = null) {}
 function mysql_list_dbs ($link_identifier = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * List tables in a MySQL database
  * @link http://php.net/manual/en/function.mysql-list-tables.php
  * @param string $database <p>
@@ -226,7 +235,8 @@ function mysql_list_dbs ($link_identifier = null) {}
 function mysql_list_tables ($database, $link_identifier = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * List MySQL table fields
  * @link http://php.net/manual/en/function.mysql-list-fields.php
  * @param string $database_name <p>
@@ -248,7 +258,8 @@ function mysql_list_tables ($database, $link_identifier = null) {}
 function mysql_list_fields ($database_name, $table_name, $link_identifier = null) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * List MySQL processes
  * @link http://php.net/manual/en/function.mysql-list-processes.php
  * @param resource $link_identifier [optional] 
@@ -257,7 +268,8 @@ function mysql_list_fields ($database_name, $table_name, $link_identifier = null
 function mysql_list_processes ($link_identifier = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Returns the text of the error message from previous MySQL operation
  * @link http://php.net/manual/en/function.mysql-error.php
  * @param resource $link_identifier [optional] 
@@ -267,7 +279,8 @@ function mysql_list_processes ($link_identifier = null) {}
 function mysql_error ($link_identifier = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Returns the numerical value of the error message from previous MySQL operation
  * @link http://php.net/manual/en/function.mysql-errno.php
  * @param resource $link_identifier [optional] 
@@ -277,7 +290,8 @@ function mysql_error ($link_identifier = null) {}
 function mysql_errno ($link_identifier = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get number of affected rows in previous MySQL operation
  * @link http://php.net/manual/en/function.mysql-affected-rows.php
  * @param resource $link_identifier [optional] 
@@ -304,7 +318,8 @@ function mysql_errno ($link_identifier = null) {}
 function mysql_affected_rows ($link_identifier = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get the ID generated in the last query
  * @link http://php.net/manual/en/function.mysql-insert-id.php
  * @param resource $link_identifier [optional] 
@@ -316,7 +331,8 @@ function mysql_affected_rows ($link_identifier = null) {}
 function mysql_insert_id ($link_identifier = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get result data
  * @link http://php.net/manual/en/function.mysql-result.php
  * @param resource $result 
@@ -339,7 +355,8 @@ function mysql_insert_id ($link_identifier = null) {}
 function mysql_result ($result, $row, $field = 0) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get number of rows in result
  * @link http://php.net/manual/en/function.mysql-num-rows.php
  * @param resource $result <p>The result resource that is being evaluated. This result comes from a call to mysql_query().</p>
@@ -348,7 +365,8 @@ function mysql_result ($result, $row, $field = 0) {}
 function mysql_num_rows ($result) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get number of fields in result
  * @link http://php.net/manual/en/function.mysql-num-fields.php
  * @param resource $result 
@@ -358,7 +376,8 @@ function mysql_num_rows ($result) {}
 function mysql_num_fields ($result) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get a result row as an enumerated array
  * @link http://php.net/manual/en/function.mysql-fetch-row.php
  * @param resource $result 
@@ -374,7 +393,8 @@ function mysql_num_fields ($result) {}
 function mysql_fetch_row ($result) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Fetch a result row as an associative array, a numeric array, or both
  * @link http://php.net/manual/en/function.mysql-fetch-array.php
  * @param resource $result 
@@ -403,7 +423,8 @@ function mysql_fetch_row ($result) {}
 function mysql_fetch_array ($result, $result_type = MYSQL_BOTH) {}
 
 /**
- * (PHP 4 &gt;= 4.0.3, PHP 5)<br/>
+ * @since 4.0.3
+ * @since 5.0
  * Fetch a result row as an associative array
  * @link http://php.net/manual/en/function.mysql-fetch-assoc.php
  * @param resource $result 
@@ -422,7 +443,8 @@ function mysql_fetch_array ($result, $result_type = MYSQL_BOTH) {}
 function mysql_fetch_assoc ($result) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Fetch a result row as an object
  * @link http://php.net/manual/en/function.mysql-fetch-object.php
  * @param resource $result 
@@ -446,7 +468,8 @@ function mysql_fetch_assoc ($result) {}
 function mysql_fetch_object ($result, $class_name = null, array $params = null ) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Move internal result pointer
  * @link http://php.net/manual/en/function.mysql-data-seek.php
  * @param resource $result 
@@ -458,7 +481,8 @@ function mysql_fetch_object ($result, $class_name = null, array $params = null )
 function mysql_data_seek ($result, $row_number) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get the length of each output in a result
  * @link http://php.net/manual/en/function.mysql-fetch-lengths.php
  * @param resource $result 
@@ -467,7 +491,8 @@ function mysql_data_seek ($result, $row_number) {}
 function mysql_fetch_lengths ($result) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get column information from a result and return as an object
  * @link http://php.net/manual/en/function.mysql-fetch-field.php
  * @param resource $result 
@@ -497,7 +522,8 @@ function mysql_fetch_lengths ($result) {}
 function mysql_fetch_field ($result, $field_offset = 0) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Set result pointer to a specified field offset
  * @link http://php.net/manual/en/function.mysql-field-seek.php
  * @param resource $result 
@@ -507,7 +533,8 @@ function mysql_fetch_field ($result, $field_offset = 0) {}
 function mysql_field_seek ($result, $field_offset) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Free result memory
  * @link http://php.net/manual/en/function.mysql-free-result.php
  * @param resource $result 
@@ -522,7 +549,8 @@ function mysql_field_seek ($result, $field_offset) {}
 function mysql_free_result ($result) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get the name of the specified field in a result
  * @link http://php.net/manual/en/function.mysql-field-name.php
  * @param resource $result 
@@ -532,7 +560,8 @@ function mysql_free_result ($result) {}
 function mysql_field_name ($result, $field_offset) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get name of the table the specified field is in
  * @link http://php.net/manual/en/function.mysql-field-table.php
  * @param resource $result 
@@ -542,7 +571,8 @@ function mysql_field_name ($result, $field_offset) {}
 function mysql_field_table ($result, $field_offset) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Returns the length of the specified field
  * @link http://php.net/manual/en/function.mysql-field-len.php
  * @param resource $result 
@@ -552,7 +582,8 @@ function mysql_field_table ($result, $field_offset) {}
 function mysql_field_len ($result, $field_offset) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get the type of the specified field in a result
  * @link http://php.net/manual/en/function.mysql-field-type.php
  * @param resource $result 
@@ -566,7 +597,8 @@ function mysql_field_len ($result, $field_offset) {}
 function mysql_field_type ($result, $field_offset) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get the flags associated with the specified field in a result
  * @link http://php.net/manual/en/function.mysql-field-flags.php
  * @param resource $result 
@@ -585,7 +617,8 @@ function mysql_field_type ($result, $field_offset) {}
 function mysql_field_flags ($result, $field_offset) {}
 
 /**
- * (PHP 4 &gt;= 4.0.3, PHP 5)<br/>
+ * @since 4.0.3
+ * @since 5.0
  * Escapes a string for use in a mysql_query
  * @link http://php.net/manual/en/function.mysql-escape-string.php
  * @deprecated since 5.3.0, use mysql_real_escape_string() instead
@@ -597,7 +630,8 @@ function mysql_field_flags ($result, $field_offset) {}
 function mysql_escape_string ($unescaped_string) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Escapes special characters in a string for use in an SQL statement
  * @link http://php.net/manual/en/function.mysql-real-escape-string.php
  * @param string $unescaped_string <p>
@@ -609,7 +643,8 @@ function mysql_escape_string ($unescaped_string) {}
 function mysql_real_escape_string ($unescaped_string, $link_identifier = null) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Get current system status
  * @link http://php.net/manual/en/function.mysql-stat.php
  * @param resource $link_identifier [optional] 
@@ -621,7 +656,8 @@ function mysql_real_escape_string ($unescaped_string, $link_identifier = null) {
 function mysql_stat ($link_identifier = null) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Return the current thread ID
  * @link http://php.net/manual/en/function.mysql-thread-id.php
  * @param resource $link_identifier [optional] 
@@ -630,7 +666,8 @@ function mysql_stat ($link_identifier = null) {}
 function mysql_thread_id ($link_identifier = null) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Returns the name of the character set
  * @link http://php.net/manual/en/function.mysql-client-encoding.php
  * @param resource $link_identifier [optional] 
@@ -639,7 +676,8 @@ function mysql_thread_id ($link_identifier = null) {}
 function mysql_client_encoding ($link_identifier = null) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Ping a server connection or reconnect if there is no connection
  * @link http://php.net/manual/en/function.mysql-ping.php
  * @param resource $link_identifier [optional] 
@@ -649,7 +687,8 @@ function mysql_client_encoding ($link_identifier = null) {}
 function mysql_ping ($link_identifier = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.5, PHP 5)<br/>
+ * @since 4.0.5
+ * @since 5.0
  * Get MySQL client info
  * @link http://php.net/manual/en/function.mysql-get-client-info.php
  * @return string The MySQL client version.
@@ -657,7 +696,8 @@ function mysql_ping ($link_identifier = null) {}
 function mysql_get_client_info () {}
 
 /**
- * (PHP 4 &gt;= 4.0.5, PHP 5)<br/>
+ * @since 4.0.5
+ * @since 5.0
  * Get MySQL host info
  * @link http://php.net/manual/en/function.mysql-get-host-info.php
  * @param resource $link_identifier [optional] 
@@ -667,7 +707,8 @@ function mysql_get_client_info () {}
 function mysql_get_host_info ($link_identifier = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.5, PHP 5)<br/>
+ * @since 4.0.5
+ * @since 5.0
  * Get MySQL protocol info
  * @link http://php.net/manual/en/function.mysql-get-proto-info.php
  * @param resource $link_identifier [optional] 
@@ -676,7 +717,8 @@ function mysql_get_host_info ($link_identifier = null) {}
 function mysql_get_proto_info ($link_identifier = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.5, PHP 5)<br/>
+ * @since 4.0.5
+ * @since 5.0
  * Get MySQL server info
  * @link http://php.net/manual/en/function.mysql-get-server-info.php
  * @param resource $link_identifier [optional] 
@@ -685,7 +727,8 @@ function mysql_get_proto_info ($link_identifier = null) {}
 function mysql_get_server_info ($link_identifier = null) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Get information about the most recent query
  * @link http://php.net/manual/en/function.mysql-info.php
  * @param resource $link_identifier [optional] 
@@ -697,7 +740,7 @@ function mysql_get_server_info ($link_identifier = null) {}
 function mysql_info ($link_identifier = null) {}
 
 /**
- * (PHP 5 &gt;= 5.2.3)<br/>
+ * @since 5.2.3
  * Sets the client character set
  * @link http://php.net/manual/en/function.mysql-set-charset.php
  * @param string $charset <p>
@@ -802,7 +845,8 @@ function mysql_listtables ($database_name, $link_identifier) {}
 function mysql_listfields ($database_name, $table_name, $link_identifier) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Retrieves database name from the call to <b>mysql_list_dbs</b>
  * @link http://php.net/manual/en/function.mysql-db-name.php
  * @param resource $result <p>
@@ -829,7 +873,8 @@ function mysql_db_name ($result, $row, $field = null) {}
 function mysql_dbname ($result, $row, $field) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get table name of field
  * @link http://php.net/manual/en/function.mysql-tablename.php
  * @param resource $result <p>

--- a/mysqli.php
+++ b/mysqli.php
@@ -127,7 +127,7 @@ class mysqli  {
 
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Open a new connection to the MySQL server
 	 * </p>
 	 * @param string $host [optional] Can be either a host name or an IP address. Passing the NULL value or the string "localhost" to this parameter, the local host is assumed. When possible, pipes will be used instead of the TCP/IP protocol. Prepending host by p: opens a persistent connection. mysqli_change_user() is automatically called on connections opened from the connection pool. Defaults to ini_get("mysqli.default_host")
@@ -147,7 +147,7 @@ class mysqli  {
 	) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Turns on or off auto-commiting database modifications
 	 * @link http://php.net/manual/en/mysqli.autocommit.php
 	 * @param bool $mode <p>
@@ -158,7 +158,7 @@ class mysqli  {
 	public function autocommit ($mode) {}
 
     /**
-     * (PHP 5 &gt;= 5.5.0)<br/>
+     * @since 5.5.0
      * Starts a transaction
      * @link http://www.php.net/manual/en/mysqli.begin-transaction.php
      * @param int $flags [optional]
@@ -168,7 +168,7 @@ class mysqli  {
     public function begin_transaction ($flags = 0, $name = null) {}
 
     /**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Changes the user of the specified database connection
 	 * @link http://php.net/manual/en/mysqli.change-user.php
 	 * @param string $user <p>
@@ -190,7 +190,7 @@ class mysqli  {
 	public function change_user ($user, $password, $database) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Returns the default character set for the database connection
 	 * @link http://php.net/manual/en/mysqli.character-set-name.php
 	 * @return string The default character set for the current connection
@@ -203,7 +203,7 @@ class mysqli  {
 	public function client_encoding () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Closes a previously opened database connection
 	 * @link http://php.net/manual/en/mysqli.close.php
 	 * @return bool true on success or false on failure.
@@ -211,7 +211,7 @@ class mysqli  {
 	public function close () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Commits the current transaction
 	 * @link http://php.net/manual/en/mysqli.commit.php
 	 * @return bool true on success or false on failure.
@@ -229,7 +229,7 @@ class mysqli  {
 	public function connect ($host, $user, $password, $database, $port, $socket) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Dump debugging information into the log
 	 * @link http://php.net/manual/en/mysqli.dump-debug-info.php
 	 * @return bool true on success or false on failure.
@@ -237,7 +237,7 @@ class mysqli  {
 	public function dump_debug_info () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Performs debugging operations
 	 * @link http://php.net/manual/en/mysqli.debug.php
 	 * @param string $message <p>
@@ -248,7 +248,7 @@ class mysqli  {
 	public function debug ($message) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.1.0)<br/>
+	 * @since 5.1.0
 	 * Returns a character set object
 	 * @link http://php.net/manual/en/mysqli.get-charset.php
 	 * @return object The function returns a character set object with the following properties:
@@ -270,7 +270,7 @@ class mysqli  {
 	public function get_charset () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Returns the MySQL client version as a string
 	 * @link http://php.net/manual/en/mysqli.get-client-info.php
 	 * @return string A string that represents the MySQL client library version
@@ -278,7 +278,7 @@ class mysqli  {
 	public function get_client_info () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
 	 * Returns statistics about the client connection
 	 * @link http://php.net/manual/en/mysqli.get-connection-stats.php
 	 * @return bool an array with connection stats if success, false otherwise.
@@ -293,7 +293,7 @@ class mysqli  {
 	public function get_server_info () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.1.0)<br/>
+	 * @since 5.1.0
 	 * Get result of SHOW WARNINGS
 	 * @link http://php.net/manual/en/mysqli.get-warnings.php
 	 * @return mysqli_warning
@@ -301,7 +301,7 @@ class mysqli  {
 	public function get_warnings () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Initializes MySQLi and returns a resource for use with mysqli_real_connect()
 	 * @link http://php.net/manual/en/mysqli.init.php
 	 * @return mysqli an object.
@@ -309,7 +309,7 @@ class mysqli  {
 	public function init () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Asks the server to kill a MySQL thread
 	 * @link http://php.net/manual/en/mysqli.kill.php
 	 * @param int $processid
@@ -318,7 +318,7 @@ class mysqli  {
 	public function kill ($processid) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Performs a query on the database
 	 * @link http://php.net/manual/en/mysqli.multi-query.php
 	 * @param string $query <p>
@@ -344,7 +344,7 @@ class mysqli  {
 	public function mysqli ($host, $user, $password, $database, $port, $socket) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Check if there are any more query results from a multi query
 	 * @link http://php.net/manual/en/mysqli.more-results.php
 	 * @return bool true on success or false on failure.
@@ -352,7 +352,7 @@ class mysqli  {
 	public function more_results () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Prepare next result from multi_query
 	 * @link http://php.net/manual/en/mysqli.next-result.php
 	 * @return bool true on success or false on failure.
@@ -360,7 +360,7 @@ class mysqli  {
 	public function next_result () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Set options
 	 * @link http://php.net/manual/en/mysqli.options.php
 	 * @param int $option <p>
@@ -412,7 +412,7 @@ class mysqli  {
 	public function options ($option, $value) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Pings a server connection, or tries to reconnect if the connection has gone down
 	 * @link http://php.net/manual/en/mysqli.ping.php
 	 * @return bool true on success or false on failure.
@@ -420,7 +420,7 @@ class mysqli  {
 	public function ping () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Prepare an SQL statement for execution
 	 * @link http://php.net/manual/en/mysqli.prepare.php
 	 * @param string $query <p>
@@ -459,7 +459,7 @@ class mysqli  {
 	public function prepare ($query) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Performs a query on the database
 	 * @link http://php.net/manual/en/mysqli.query.php
 	 * @param string $query <p>
@@ -492,7 +492,7 @@ class mysqli  {
 	public function query ($query, $resultmode = MYSQLI_STORE_RESULT) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Opens a connection to a mysql server
 	 * @link http://php.net/manual/en/mysqli.real-connect.php
 	 * @param string $host [optional] <p>
@@ -571,7 +571,7 @@ class mysqli  {
 	public function real_connect ($host = null, $username = null, $passwd = null, $dbname = null, $port = null, $socket = null, $flags = null) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Escapes special characters in a string for use in an SQL statement, taking into account the current charset of the connection
 	 * @link http://php.net/manual/en/mysqli.real-escape-string.php
 	 * @param string $escapestr <p>
@@ -586,7 +586,7 @@ class mysqli  {
 	public function real_escape_string ($escapestr) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
 	 * Poll connections
 	 * @link http://php.net/manual/en/mysqli.poll.php
 	 * @param array $read <p>
@@ -606,7 +606,7 @@ class mysqli  {
 	public function poll (array &$read , array &$error , array &$reject , $sec, $usec = null) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
 	 * Get result from async query
 	 * @link http://php.net/manual/en/mysqli.reap-async-query.php
 	 * @return mysqli_result mysqli_result in success, false otherwise.
@@ -623,7 +623,7 @@ class mysqli  {
 	public function escape_string ($escapestr) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Execute an SQL query
 	 * @link http://php.net/manual/en/mysqli.real-query.php
 	 * @param string $query <p>
@@ -637,7 +637,7 @@ class mysqli  {
 	public function real_query ($query) {}
 
     /**
-     * (PHP 5 &gt;= 5.5.0)<br/>
+     * @since 5.5.0
      * Execute an SQL query
      * @link http://php.net/manual/en/mysqli.release-savepoint.php
      * @param string $name
@@ -646,7 +646,7 @@ class mysqli  {
     public function release_savepoint ($name) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Rolls back current transaction
 	 * @link http://php.net/manual/en/mysqli.rollback.php
 	 * @return bool true on success or false on failure.
@@ -654,7 +654,7 @@ class mysqli  {
 	public function rollback () {}
 
     /**
-     * (PHP 5 &gt;= 5.5.0)<br/>
+     * @since 5.5.0
      * Set a named transaction savepoint
      * @link http://www.php.net/manual/en/mysqli.savepoint.php
      * @param string $name
@@ -663,7 +663,7 @@ class mysqli  {
     public function savepoint ($name) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Selects the default database for database queries
 	 * @link http://php.net/manual/en/mysqli.select-db.php
 	 * @param string $dbname <p>
@@ -674,7 +674,7 @@ class mysqli  {
 	public function select_db ($dbname) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.0.5)<br/>
+	 * @since 5.0.5
 	 * Sets the default client character set
 	 * @link http://php.net/manual/en/mysqli.set-charset.php
 	 * @param string $charset <p>
@@ -692,7 +692,7 @@ class mysqli  {
 
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Used for establishing secure connections using SSL
 	 * @link http://www.php.net/manual/en/mysqli.ssl-set.php
 	 * @param $key <p>
@@ -715,7 +715,7 @@ class mysqli  {
 	public function ssl_set($key , $cert , $ca , $capath , $cipher) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Gets the current system status
 	 * @link http://php.net/manual/en/mysqli.stat.php
 	 * @return string A string describing the server status. false if an error occurred.
@@ -723,7 +723,7 @@ class mysqli  {
 	public function stat () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Initializes a statement and returns an object for use with mysqli_stmt_prepare
 	 * @link http://php.net/manual/en/mysqli.stmt-init.php
 	 * @return mysqli_stmt an object.
@@ -731,7 +731,7 @@ class mysqli  {
 	public function stmt_init () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Transfers a result set from the last query
 	 * @link http://php.net/manual/en/mysqli.store-result.php
 	 * @return mysqli_result a buffered result object or false if an error occurred.
@@ -753,7 +753,7 @@ class mysqli  {
 	public function store_result () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Returns whether thread safety is given or not
 	 * @link http://php.net/manual/en/mysqli.thread-safe.php
 	 * @return bool true if the client library is thread-safe, otherwise false.
@@ -761,7 +761,7 @@ class mysqli  {
 	public function thread_safe () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Initiate a result set retrieval
 	 * @link http://php.net/manual/en/mysqli.use-result.php
 	 * @return mysqli_result an unbuffered result object or false if an error occurred.
@@ -847,7 +847,7 @@ class mysqli_result implements Traversable  {
 	public function close () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Frees the memory associated with a result
 	 * @link http://php.net/manual/en/mysqli-result.free.php
 	 * @return void
@@ -855,7 +855,7 @@ class mysqli_result implements Traversable  {
 	public function free () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Adjusts the result pointer to an arbitary row in the result
 	 * @link http://php.net/manual/en/mysqli-result.data-seek.php
 	 * @param int $offset <p>
@@ -867,7 +867,7 @@ class mysqli_result implements Traversable  {
 	public function data_seek ($offset) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Returns the next field in the result set
 	 * @link http://php.net/manual/en/mysqli-result.fetch-field.php
 	 * @return object an object which contains field definition information or false
@@ -937,7 +937,7 @@ class mysqli_result implements Traversable  {
 	public function fetch_field () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Returns an array of objects representing the fields in a result set
 	 * @link http://php.net/manual/en/mysqli-result.fetch-fields.php
 	 * @return array an array of objects which contains field definition information or
@@ -999,7 +999,7 @@ class mysqli_result implements Traversable  {
 	public function fetch_fields () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Fetch meta-data for a single field
 	 * @link http://php.net/manual/en/mysqli-result.fetch-field-direct.php
 	 * @param int $fieldnr <p>
@@ -1066,7 +1066,7 @@ class mysqli_result implements Traversable  {
 	public function fetch_field_direct ($fieldnr) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
 	 * Fetches all result rows as an associative array, a numeric array, or both
 	 * @link http://php.net/manual/en/mysqli-result.fetch-all.php
 	 * @param int $resulttype [optional] <p>
@@ -1080,7 +1080,7 @@ class mysqli_result implements Traversable  {
 	public function fetch_all ($resulttype = null) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Fetch a result row as an associative, a numeric array, or both
 	 * @link http://php.net/manual/en/mysqli-result.fetch-array.php
 	 * @param int $resulttype [optional] <p>
@@ -1103,7 +1103,7 @@ class mysqli_result implements Traversable  {
 	public function fetch_array ($resulttype = MYSQLI_BOTH) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Fetch a result row as an associative array
 	 * @link http://php.net/manual/en/mysqli-result.fetch-assoc.php
 	 * @return array an associative array of strings representing the fetched row in the result
@@ -1119,7 +1119,7 @@ class mysqli_result implements Traversable  {
 	public function fetch_assoc () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Returns the current row of a result set as an object
 	 * @link http://php.net/manual/en/mysqli-result.fetch-object.php
 	 * @param string $class_name [optional] <p>
@@ -1136,7 +1136,7 @@ class mysqli_result implements Traversable  {
 	public function fetch_object ($class_name = null, array $params = null) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Get a result row as an enumerated array
 	 * @link http://php.net/manual/en/mysqli-result.fetch-row.php
 	 * @return mixed mysqli_fetch_row returns an array of strings that corresponds to the fetched row
@@ -1145,7 +1145,7 @@ class mysqli_result implements Traversable  {
 	public function fetch_row () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Set result pointer to a specified field offset
 	 * @link http://php.net/manual/en/mysqli-result.field-seek.php
 	 * @param int $fieldnr <p>
@@ -1213,7 +1213,7 @@ class mysqli_stmt  {
 	public function __construct ($link, $query) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Used to get the current value of a statement attribute
 	 * @link http://php.net/manual/en/mysqli-stmt.attr-get.php
 	 * @param int $attr <p>
@@ -1224,7 +1224,7 @@ class mysqli_stmt  {
 	public function attr_get ($attr) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Used to modify the behavior of a prepared statement
 	 * @link http://php.net/manual/en/mysqli-stmt.attr-set.php
 	 * @param int $attr <p>
@@ -1279,7 +1279,7 @@ class mysqli_stmt  {
 	public function attr_set ($attr, $mode) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Binds variables to a prepared statement as parameters
 	 * @link http://php.net/manual/en/mysqli-stmt.bind-param.php
 	 * @param string $types <p>
@@ -1319,7 +1319,7 @@ class mysqli_stmt  {
 	public function bind_param ($types, &$var1, &$_ = null) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Binds variables to a prepared statement for result storage
 	 * @link http://php.net/manual/en/mysqli-stmt.bind-result.php
 	 * @param mixed $var1 The variable to be bound.
@@ -1329,7 +1329,7 @@ class mysqli_stmt  {
 	public function bind_result (&$var1, &...$_) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Closes a prepared statement
 	 * @link http://php.net/manual/en/mysqli-stmt.close.php
 	 * @return bool true on success or false on failure.
@@ -1337,7 +1337,7 @@ class mysqli_stmt  {
 	public function close () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Seeks to an arbitrary row in statement result set
 	 * @link http://php.net/manual/en/mysqli-stmt.data-seek.php
 	 * @param int $offset <p>
@@ -1349,7 +1349,7 @@ class mysqli_stmt  {
 	public function data_seek ($offset) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Executes a prepared Query
 	 * @link http://php.net/manual/en/mysqli-stmt.execute.php
 	 * @return bool true on success or false on failure.
@@ -1357,7 +1357,7 @@ class mysqli_stmt  {
 	public function execute () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Fetch results from a prepared statement into the bound variables
 	 * @link http://php.net/manual/en/mysqli-stmt.fetch.php
 	 * @return bool
@@ -1365,7 +1365,7 @@ class mysqli_stmt  {
 	public function fetch () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.1.0)<br/>
+	 * @since 5.1.0
 	 * Get result of SHOW WARNINGS
 	 * @link http://php.net/manual/en/mysqli-stmt.get-warnings.php
 	 * @param mysqli_stmt $stmt
@@ -1374,7 +1374,7 @@ class mysqli_stmt  {
 	public function get_warnings (mysqli_stmt $stmt) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Returns result set metadata from a prepared statement
 	 * @link http://php.net/manual/en/mysqli-stmt.result-metadata.php
 	 * @return mysqli_result a result object or false if an error occurred.
@@ -1396,7 +1396,7 @@ class mysqli_stmt  {
 	public function next_result () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Return the number of rows in statements result set
 	 * @link http://php.net/manual/en/mysqli-stmt.num-rows.php
 	 * @param mysqli_stmt $stmt
@@ -1405,7 +1405,7 @@ class mysqli_stmt  {
 	public function num_rows (mysqli_stmt $stmt) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Send data in blocks
 	 * @link http://php.net/manual/en/mysqli-stmt.send-long-data.php
 	 * @param int $param_nr <p>
@@ -1426,7 +1426,7 @@ class mysqli_stmt  {
 	public function stmt () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Frees stored result memory for the given statement handle
 	 * @link http://php.net/manual/en/mysqli-stmt.free-result.php
 	 * @return void
@@ -1434,7 +1434,7 @@ class mysqli_stmt  {
 	public function free_result () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Resets a prepared statement
 	 * @link http://php.net/manual/en/mysqli-stmt.reset.php
 	 * @return bool true on success or false on failure.
@@ -1442,7 +1442,7 @@ class mysqli_stmt  {
 	public function reset () {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Prepare an SQL statement for execution
 	 * @link http://php.net/manual/en/mysqli-stmt.prepare.php
 	 * @param string $query <p>
@@ -1477,7 +1477,7 @@ class mysqli_stmt  {
 	public function prepare ($query) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Transfers a result set from a prepared statement
 	 * @link http://php.net/manual/en/mysqli-stmt.store-result.php
 	 * @return bool true on success or false on failure.
@@ -1514,7 +1514,7 @@ function mysqli_affected_rows ($link) {}
 function mysqli_autocommit ($link, $mode) {}
 
 /**
- * (PHP 5 &gt;= 5.5.0)<br/>
+ * @since 5.5.0
  * Starts a transaction
  * @link http://www.php.net/manual/en/mysqli.begin-transaction.php
  * @param mysqli $link A link identifier returned by mysqli_connect() or mysqli_init()
@@ -1656,7 +1656,7 @@ function mysqli_stmt_execute ($stmt) {}
 
 /**
  * Executes a prepared Query
- * (PHP 5)<br/>
+ * @since 5.0
  * Alias for <b>mysqli_stmt_execute</b>
  * @link http://php.net/manual/en/function.mysqli-execute.php
  * @param mysqli_stmt $stmt
@@ -1798,7 +1798,7 @@ function mysqli_free_result ($result) {}
 
 /**
  * Returns client Zval cache statistics
- * (PHP 5 &gt;= 5.3.0)<br/>
+ * @since 5.3.0
  * Available only with mysqlnd.
  * @link http://php.net/manual/en/mysqli.get-cache-stats.php
  * @param mysqli $link A link identifier returned by mysqli_connect() or mysqli_init()
@@ -1816,7 +1816,7 @@ function mysqli_get_connection_stats ($link) {}
 
 /**
  * Returns client per-process statistics
- * (PHP 5 &gt;= 5.3.0)<br/>
+ * @since 5.3.0
  * @link http://php.net/manual/en/mysqli.get-client-stats.php
  * @return array|bool an array with client stats if success, false otherwise.
  */
@@ -2023,7 +2023,7 @@ function mysqli_prepare ($link, $query) {}
 
 /**
  * Enables or disables internal report functions
- * (PHP 5)<br/>
+ * @since 5.0
  * @link http://php.net/manual/en/function.mysqli-report.php
  * @param int $flags <p>
  * <table>
@@ -2120,7 +2120,7 @@ function mysqli_real_query ($link, $query) {}
 function mysqli_reap_async_query ($link) {}
 
 /**
- * (PHP 5 &gt;= 5.5.0)<br/>
+ * @since 5.5.0
  * Set a named transaction savepoint
  * @link http://www.php.net/manual/en/mysqli.release-savepoint.php
  * @param mysqli $link A link identifier returned by mysqli_connect() or mysqli_init()
@@ -2138,7 +2138,7 @@ function mysqli_release_savepoint ($link ,$name) {}
 function mysqli_rollback ($link) {}
 
 /**
- * (PHP 5 &gt;= 5.5.0)<br/>
+ * @since 5.5.0
  * Set a named transaction savepoint
  * @link http://www.php.net/manual/en/mysqli.savepoint.php
  * @param mysqli $link A link identifier returned by mysqli_connect() or mysqli_init()
@@ -2448,7 +2448,7 @@ function mysqli_warning_count ($link) {}
 function mysqli_refresh ($link, $options) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Alias for <b>mysqli_stmt_bind_param</b>
  * @link http://php.net/manual/en/function.mysqli-bind-param.php
  * @param mysqli_stmt $stmt
@@ -2458,7 +2458,7 @@ function mysqli_refresh ($link, $options) {}
 function mysqli_bind_param ($stmt, $types) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Alias for <b>mysqli_stmt_bind_result</b>
  * @link http://php.net/manual/en/function.mysqli-bind-result.php
  * @param mysqli_stmt $stmt
@@ -2469,7 +2469,7 @@ function mysqli_bind_param ($stmt, $types) {}
 function mysqli_bind_result ($stmt, $types, &$var1) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Alias of <b>mysqli_character_set_name</b>
  * @link http://php.net/manual/en/function.mysqli-client-encoding.php
  * @param mysqli $link A link identifier returned by mysqli_connect() or mysqli_init()
@@ -2479,7 +2479,7 @@ function mysqli_bind_result ($stmt, $types, &$var1) {}
 function mysqli_client_encoding ($link) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Alias of <b>mysqli_real_escape_string</b>
  * @link http://php.net/manual/en/function.mysqli-escape-string.php
  * @param mysqli $link A link identifier returned by mysqli_connect() or mysqli_init()
@@ -2489,7 +2489,7 @@ function mysqli_client_encoding ($link) {}
 function mysqli_escape_string ($link, $query) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Alias for <b>mysqli_stmt_fetch</b>
  * @link http://php.net/manual/en/function.mysqli-fetch.php
  * @param mysqli_stmt $stmt
@@ -2499,7 +2499,7 @@ function mysqli_escape_string ($link, $query) {}
 function mysqli_fetch ($stmt) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Alias for <b>mysqli_stmt_param_count</b>
  * @link http://php.net/manual/en/function.mysqli-param-count.php
  * @param mysqli_stmt $stmt
@@ -2509,7 +2509,7 @@ function mysqli_fetch ($stmt) {}
 function mysqli_param_count ($stmt) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Alias for <b>mysqli_stmt_result_metadata</b>
  * @link http://php.net/manual/en/function.mysqli-get-metadata.php
  * @param mysqli_stmt $stmt
@@ -2519,7 +2519,7 @@ function mysqli_param_count ($stmt) {}
 function mysqli_get_metadata ($stmt) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Alias for <b>mysqli_stmt_send_long_data</b>
  * @link http://php.net/manual/en/function.mysqli-send-long-data.php
  * @param mysqli_stmt $stmt
@@ -2531,7 +2531,7 @@ function mysqli_get_metadata ($stmt) {}
 function mysqli_send_long_data ($stmt, $param_nr, $data) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Alias of <b>mysqli_options</b>
  * @link http://php.net/manual/en/function.mysqli-set-opt.php
  * @param mysqli $link A link identifier returned by mysqli_connect() or mysqli_init()

--- a/mysqli.php
+++ b/mysqli.php
@@ -198,7 +198,7 @@ class mysqli  {
 	public function character_set_name () {}
 
 	/**
-	 * @deprecated This function has been DEPRECATED as of PHP 5.3.0 and REMOVED as of PHP 5.4.0.
+	 * @deprecated 5.3 This function has been DEPRECATED as of PHP 5.3.0 and REMOVED as of PHP 5.4.0.
 	 */
 	public function client_encoding () {}
 
@@ -1421,7 +1421,7 @@ class mysqli_stmt  {
 
 	/**
 	 * No documentation available
-	 * @deprecated This function has been DEPRECATED as of PHP 5.3.0 and REMOVED as of PHP 5.4.0.
+	 * @deprecated 5.3 This function has been DEPRECATED as of PHP 5.3.0 and REMOVED as of PHP 5.4.0.
 	 */
 	public function stmt () {}
 
@@ -2453,7 +2453,7 @@ function mysqli_refresh ($link, $options) {}
  * @link http://php.net/manual/en/function.mysqli-bind-param.php
  * @param mysqli_stmt $stmt
  * @param $types
- * @deprecated This function has been DEPRECATED as of PHP 5.3.0 and REMOVED as of PHP 5.4.0.
+ * @deprecated 5.3 This function has been DEPRECATED as of PHP 5.3.0 and REMOVED as of PHP 5.4.0.
  */
 function mysqli_bind_param ($stmt, $types) {}
 
@@ -2464,7 +2464,7 @@ function mysqli_bind_param ($stmt, $types) {}
  * @param mysqli_stmt $stmt
  * @param string $types
  * @param mixed $var1
- * @deprecated This function has been DEPRECATED as of PHP 5.3.0 and REMOVED as of PHP 5.4.0.
+ * @deprecated 5.3 This function has been DEPRECATED as of PHP 5.3.0 and REMOVED as of PHP 5.4.0.
  */
 function mysqli_bind_result ($stmt, $types, &$var1) {}
 
@@ -2474,7 +2474,7 @@ function mysqli_bind_result ($stmt, $types, &$var1) {}
  * @link http://php.net/manual/en/function.mysqli-client-encoding.php
  * @param mysqli $link A link identifier returned by mysqli_connect() or mysqli_init()
  * @return string
- * @deprecated This function has been DEPRECATED as of PHP 5.3.0 and REMOVED as of PHP 5.4.0.
+ * @deprecated 5.3 This function has been DEPRECATED as of PHP 5.3.0 and REMOVED as of PHP 5.4.0.
  */
 function mysqli_client_encoding ($link) {}
 
@@ -2494,7 +2494,7 @@ function mysqli_escape_string ($link, $query) {}
  * @link http://php.net/manual/en/function.mysqli-fetch.php
  * @param mysqli_stmt $stmt
  * @return bool
- * @deprecated This function has been DEPRECATED as of PHP 5.3.0 and REMOVED as of PHP 5.4.0.
+ * @deprecated 5.3 This function has been DEPRECATED as of PHP 5.3.0 and REMOVED as of PHP 5.4.0.
  */
 function mysqli_fetch ($stmt) {}
 
@@ -2504,7 +2504,7 @@ function mysqli_fetch ($stmt) {}
  * @link http://php.net/manual/en/function.mysqli-param-count.php
  * @param mysqli_stmt $stmt
  * @return int
- * @deprecated This function has been DEPRECATED as of PHP 5.3.0 and REMOVED as of PHP 5.4.0.
+ * @deprecated 5.3 This function has been DEPRECATED as of PHP 5.3.0 and REMOVED as of PHP 5.4.0.
  */
 function mysqli_param_count ($stmt) {}
 
@@ -2514,7 +2514,7 @@ function mysqli_param_count ($stmt) {}
  * @link http://php.net/manual/en/function.mysqli-get-metadata.php
  * @param mysqli_stmt $stmt
  * @return mysqli_result|bool Returns a result object or FALSE if an error occurred
- * @deprecated This function has been DEPRECATED as of PHP 5.3.0 and REMOVED as of PHP 5.4.0.
+ * @deprecated 5.3 This function has been DEPRECATED as of PHP 5.3.0 and REMOVED as of PHP 5.4.0.
  */
 function mysqli_get_metadata ($stmt) {}
 
@@ -2526,7 +2526,7 @@ function mysqli_get_metadata ($stmt) {}
  * @param int $param_nr
  * @param string $data
  * @return bool
- * @deprecated This function has been DEPRECATED as of PHP 5.3.0 and REMOVED as of PHP 5.4.0.
+ * @deprecated 5.3 This function has been DEPRECATED as of PHP 5.3.0 and REMOVED as of PHP 5.4.0.
  */
 function mysqli_send_long_data ($stmt, $param_nr, $data) {}
 

--- a/odbc.php
+++ b/odbc.php
@@ -3,7 +3,8 @@
 // Start of odbc v.1.0
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Toggle autocommit behaviour
  * @link http://php.net/manual/en/function.odbc-autocommit.php
  * @param resource $connection_id The ODBC connection identifier,
@@ -24,7 +25,8 @@
 function odbc_autocommit ($connection_id, $OnOff = false) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Handling of binary column data
  * @link http://php.net/manual/en/function.odbc-binmode.php
  * @param resource $result_id <p>
@@ -46,7 +48,8 @@ function odbc_autocommit ($connection_id, $OnOff = false) {}
 function odbc_binmode ($result_id, $mode) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Close an ODBC connection
  * @link http://php.net/manual/en/function.odbc-close.php
  * @param resource $connection_id The ODBC connection identifier,
@@ -56,7 +59,8 @@ function odbc_binmode ($result_id, $mode) {}
 function odbc_close ($connection_id) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Close all ODBC connections
  * @link http://php.net/manual/en/function.odbc-close-all.php
  * @return void No value is returned.
@@ -64,7 +68,8 @@ function odbc_close ($connection_id) {}
 function odbc_close_all () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Lists the column names in specified tables
  * @link http://php.net/manual/en/function.odbc-columns.php
  * @param resource $connection_id The ODBC connection identifier,
@@ -105,7 +110,8 @@ function odbc_close_all () {}
 function odbc_columns ($connection_id, $qualifier = null, $schema = null, $table_name = null, $column_name = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Commit an ODBC transaction
  * @link http://php.net/manual/en/function.odbc-commit.php
  * @param resource $connection_id The ODBC connection identifier,
@@ -115,7 +121,8 @@ function odbc_columns ($connection_id, $qualifier = null, $schema = null, $table
 function odbc_commit ($connection_id) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Connect to a datasource
  * @link http://php.net/manual/en/function.odbc-connect.php
  * @param string $dsn <p>
@@ -141,7 +148,8 @@ function odbc_commit ($connection_id) {}
 function odbc_connect ($dsn, $user, $password, $cursor_type = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get cursorname
  * @link http://php.net/manual/en/function.odbc-cursor.php
  * @param resource $result_id <p>
@@ -152,7 +160,8 @@ function odbc_connect ($dsn, $user, $password, $cursor_type = null) {}
 function odbc_cursor ($result_id) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Returns information about a current connection
  * @link http://php.net/manual/en/function.odbc-data-source.php
  * @param resource $connection_id The ODBC connection identifier,
@@ -168,7 +177,8 @@ function odbc_cursor ($result_id) {}
 function odbc_data_source ($connection_id, $fetch_type) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Execute a prepared statement
  * @link http://php.net/manual/en/function.odbc-execute.php
  * @param resource $result_id <p>
@@ -197,7 +207,8 @@ function odbc_data_source ($connection_id, $fetch_type) {}
 function odbc_execute ($result_id, array $parameters_array = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.5, PHP 5)<br/>
+ * @since 4.0.5
+ * @since 5.0
  * Get the last error code
  * @link http://php.net/manual/en/function.odbc-error.php
  * @param resource $connection_id [optional] The ODBC connection identifier,
@@ -213,7 +224,8 @@ function odbc_execute ($result_id, array $parameters_array = null) {}
 function odbc_error ($connection_id = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.5, PHP 5)<br/>
+ * @since 4.0.5
+ * @since 5.0
  * Get the last error message
  * @link http://php.net/manual/en/function.odbc-errormsg.php
  * @param resource $connection_id [optional] The ODBC connection identifier,
@@ -229,7 +241,8 @@ function odbc_error ($connection_id = null) {}
 function odbc_errormsg ($connection_id = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Prepare and execute an SQL statement
  * @link http://php.net/manual/en/function.odbc-exec.php
  * @param resource $connection_id The ODBC connection identifier,
@@ -246,7 +259,8 @@ function odbc_errormsg ($connection_id = null) {}
 function odbc_exec ($connection_id, $query_string, $flags = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Fetch a result row as an associative array
  * @link http://php.net/manual/en/function.odbc-fetch-array.php
  * @param resource $result <p>
@@ -261,7 +275,8 @@ function odbc_exec ($connection_id, $query_string, $flags = null) {}
 function odbc_fetch_array ($result, $rownumber = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Fetch a result row as an object
  * @link http://php.net/manual/en/function.odbc-fetch-object.php
  * @param resource $result <p>
@@ -276,7 +291,8 @@ function odbc_fetch_array ($result, $rownumber = null) {}
 function odbc_fetch_object ($result, $rownumber = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Fetch a row
  * @link http://php.net/manual/en/function.odbc-fetch-row.php
  * @param resource $result_id <p>
@@ -302,7 +318,8 @@ function odbc_fetch_object ($result, $rownumber = null) {}
 function odbc_fetch_row ($result_id, $row_number = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Fetch one result row into array
  * @link http://php.net/manual/en/function.odbc-fetch-into.php
  * @param resource $result_id <p>
@@ -323,7 +340,8 @@ function odbc_fetch_row ($result_id, $row_number = null) {}
 function odbc_fetch_into ($result_id, array &$result_array, $rownumber = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get the length (precision) of a field
  * @link http://php.net/manual/en/function.odbc-field-len.php
  * @param resource $result_id <p>
@@ -337,7 +355,8 @@ function odbc_fetch_into ($result_id, array &$result_array, $rownumber = null) {
 function odbc_field_len ($result_id, $field_number) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get the scale of a field
  * @link http://php.net/manual/en/function.odbc-field-scale.php
  * @param resource $result_id <p>
@@ -351,7 +370,8 @@ function odbc_field_len ($result_id, $field_number) {}
 function odbc_field_scale ($result_id, $field_number) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get the columnname
  * @link http://php.net/manual/en/function.odbc-field-name.php
  * @param resource $result_id <p>
@@ -365,7 +385,8 @@ function odbc_field_scale ($result_id, $field_number) {}
 function odbc_field_name ($result_id, $field_number) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Datatype of a field
  * @link http://php.net/manual/en/function.odbc-field-type.php
  * @param resource $result_id <p>
@@ -379,7 +400,8 @@ function odbc_field_name ($result_id, $field_number) {}
 function odbc_field_type ($result_id, $field_number) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Return column number
  * @link http://php.net/manual/en/function.odbc-field-num.php
  * @param resource $result_id <p>
@@ -394,7 +416,8 @@ function odbc_field_type ($result_id, $field_number) {}
 function odbc_field_num ($result_id, $field_name) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Free resources associated with a result
  * @link http://php.net/manual/en/function.odbc-free-result.php
  * @param resource $result_id <p>
@@ -405,7 +428,8 @@ function odbc_field_num ($result_id, $field_name) {}
 function odbc_free_result ($result_id) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Retrieves information about data types supported by the data source
  * @link http://php.net/manual/en/function.odbc-gettypeinfo.php
  * @param resource $connection_id The ODBC connection identifier,
@@ -441,7 +465,8 @@ function odbc_free_result ($result_id) {}
 function odbc_gettypeinfo ($connection_id, $data_type = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Handling of LONG columns
  * @link http://php.net/manual/en/function.odbc-longreadlen.php
  * @param resource $result_id <p>
@@ -457,7 +482,8 @@ function odbc_gettypeinfo ($connection_id, $data_type = null) {}
 function odbc_longreadlen ($result_id, $length) {}
 
 /**
- * (PHP 4 &gt;= 4.0.5, PHP 5)<br/>
+ * @since 4.0.5
+ * @since 5.0
  * Checks if multiple results are available
  * @link http://php.net/manual/en/function.odbc-next-result.php
  * @param resource $result_id <p>
@@ -468,7 +494,8 @@ function odbc_longreadlen ($result_id, $length) {}
 function odbc_next_result ($result_id) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Number of columns in a result
  * @link http://php.net/manual/en/function.odbc-num-fields.php
  * @param resource $result_id <p>
@@ -479,7 +506,8 @@ function odbc_next_result ($result_id) {}
 function odbc_num_fields ($result_id) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Number of rows in a result
  * @link http://php.net/manual/en/function.odbc-num-rows.php
  * @param resource $result_id <p>
@@ -491,7 +519,8 @@ function odbc_num_fields ($result_id) {}
 function odbc_num_rows ($result_id) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Open a persistent database connection
  * @link http://php.net/manual/en/function.odbc-pconnect.php
  * @param string $dsn
@@ -504,7 +533,8 @@ function odbc_num_rows ($result_id) {}
 function odbc_pconnect ($dsn, $user, $password, $cursor_type = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Prepares a statement for execution
  * @link http://php.net/manual/en/function.odbc-prepare.php
  * @param resource $connection_id The ODBC connection identifier,
@@ -518,7 +548,8 @@ function odbc_pconnect ($dsn, $user, $password, $cursor_type = null) {}
 function odbc_prepare ($connection_id, $query_string) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get result data
  * @link http://php.net/manual/en/function.odbc-result.php
  * @param resource $result_id <p>
@@ -535,7 +566,8 @@ function odbc_prepare ($connection_id, $query_string) {}
 function odbc_result ($result_id, $field) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Print result as HTML table
  * @link http://php.net/manual/en/function.odbc-result-all.php
  * @param resource $result_id <p>
@@ -549,7 +581,8 @@ function odbc_result ($result_id, $field) {}
 function odbc_result_all ($result_id, $format = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Rollback a transaction
  * @link http://php.net/manual/en/function.odbc-rollback.php
  * @param resource $connection_id The ODBC connection identifier,
@@ -559,7 +592,8 @@ function odbc_result_all ($result_id, $format = null) {}
 function odbc_rollback ($connection_id) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Adjust ODBC settings
  * @link http://php.net/manual/en/function.odbc-setoption.php
  * @param resource $id <p>
@@ -583,7 +617,8 @@ function odbc_rollback ($connection_id) {}
 function odbc_setoption ($id, $function, $option, $param) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Retrieves special columns
  * @link http://php.net/manual/en/function.odbc-specialcolumns.php
  * @param resource $connection_id The ODBC connection identifier,
@@ -627,7 +662,8 @@ function odbc_setoption ($id, $function, $option, $param) {}
 function odbc_specialcolumns ($connection_id, $type, $qualifier, $owner, $table, $scope, $nullable) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Retrieve statistics about a table
  * @link http://php.net/manual/en/function.odbc-statistics.php
  * @param resource $connection_id The ODBC connection identifier,
@@ -668,7 +704,8 @@ function odbc_specialcolumns ($connection_id, $type, $qualifier, $owner, $table,
 function odbc_statistics ($connection_id, $qualifier, $owner, $table_name, $unique, $accuracy) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get the list of table names stored in a specific data source
  * @link http://php.net/manual/en/function.odbc-tables.php
  * @param resource $connection_id The ODBC connection identifier,
@@ -707,7 +744,8 @@ function odbc_statistics ($connection_id, $qualifier, $owner, $table_name, $uniq
 function odbc_tables ($connection_id, $qualifier = null, $owner = null, $name = null, $types = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Gets the primary keys for a table
  * @link http://php.net/manual/en/function.odbc-primarykeys.php
  * @param resource $connection_id The ODBC connection identifier,
@@ -729,7 +767,8 @@ function odbc_tables ($connection_id, $qualifier = null, $owner = null, $name = 
 function odbc_primarykeys ($connection_id, $qualifier, $owner, $table) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Lists columns and associated privileges for the given table
  * @link http://php.net/manual/en/function.odbc-columnprivileges.php
  * @param resource $connection_id The ODBC connection identifier,
@@ -769,7 +808,8 @@ function odbc_primarykeys ($connection_id, $qualifier, $owner, $table) {}
 function odbc_columnprivileges ($connection_id, $qualifier, $owner, $table_name, $column_name) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Lists tables and the privileges associated with each table
  * @link http://php.net/manual/en/function.odbc-tableprivileges.php
  * @param resource $connection_id The ODBC connection identifier,
@@ -800,7 +840,8 @@ function odbc_columnprivileges ($connection_id, $qualifier, $owner, $table_name,
 function odbc_tableprivileges ($connection_id, $qualifier, $owner, $name) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Retrieves a list of foreign keys
  * @link http://php.net/manual/en/function.odbc-foreignkeys.php
  * @param resource $connection_id The ODBC connection identifier,
@@ -859,7 +900,8 @@ function odbc_tableprivileges ($connection_id, $qualifier, $owner, $name) {}
 function odbc_foreignkeys ($connection_id, $pk_qualifier, $pk_owner, $pk_table, $fk_qualifier, $fk_owner, $fk_table) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get the list of procedures stored in a specific data source
  * @link http://php.net/manual/en/function.odbc-procedures.php
  * @param resource $connection_id The ODBC connection identifier,
@@ -881,7 +923,8 @@ function odbc_foreignkeys ($connection_id, $pk_qualifier, $pk_owner, $pk_table, 
 function odbc_procedures ($connection_id) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Retrieve information about parameters to procedures
  * @link http://php.net/manual/en/function.odbc-procedurecolumns.php
  * @param resource $connection_id The ODBC connection identifier,
@@ -909,7 +952,8 @@ function odbc_procedures ($connection_id) {}
 function odbc_procedurecolumns ($connection_id) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Alias of <b>odbc_exec</b>
  * @link http://php.net/manual/en/function.odbc-do.php
  * @param $connection_id
@@ -919,7 +963,8 @@ function odbc_procedurecolumns ($connection_id) {}
 function odbc_do ($connection_id, $query, $flags) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Alias of <b>odbc_field_len</b>
  * @link http://php.net/manual/en/function.odbc-field-precision.php
  * @param $result_id

--- a/openssl.php
+++ b/openssl.php
@@ -3,7 +3,8 @@
 // Start of openssl v.
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Frees a private key
  * @link http://php.net/manual/en/function.openssl-pkey-free.php
  * @param resource $key <p>
@@ -14,7 +15,8 @@
 function openssl_pkey_free($key) { }
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Generates a new private key
  * @link http://php.net/manual/en/function.openssl-pkey-new.php
  * @param array $configargs [optional] <p>
@@ -29,7 +31,8 @@ function openssl_pkey_free($key) { }
 function openssl_pkey_new(array $configargs = null) { }
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Gets an exportable representation of a key into a string
  * @link http://php.net/manual/en/function.openssl-pkey-export.php
  * @param mixed $key
@@ -48,7 +51,8 @@ function openssl_pkey_new(array $configargs = null) { }
 function openssl_pkey_export($key, &$out, $passphrase = null, array $configargs = null) { }
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Gets an exportable representation of a key into a file
  * @link http://php.net/manual/en/function.openssl-pkey-export-to-file.php
  * @param mixed $key
@@ -70,7 +74,8 @@ function openssl_pkey_export($key, &$out, $passphrase = null, array $configargs 
 function openssl_pkey_export_to_file($key, $outfilename, $passphrase = null, array $configargs = null) { }
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Get a private key
  * @link http://php.net/manual/en/function.openssl-pkey-get-private.php
  * @param $key
@@ -92,7 +97,8 @@ function openssl_pkey_export_to_file($key, $outfilename, $passphrase = null, arr
 function openssl_pkey_get_private($key, $passphrase = "") { }
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Extract public key from certificate and prepare it for use
  * @link http://php.net/manual/en/function.openssl-pkey-get-public.php
  * @param mixed $certificate <p><em><b>certificate</b></em> can be one of the following:
@@ -110,7 +116,7 @@ function openssl_pkey_get_private($key, $passphrase = "") { }
 function openssl_pkey_get_public($certificate) { }
 
 /**
- * (PHP 5 &gt;= 5.2.0)<br/>
+ * @since 5.2.0
  * Returns an array with the key details
  * @link http://php.net/manual/en/function.openssl-pkey-get-details.php
  * @param resource $key <p>
@@ -132,7 +138,8 @@ function openssl_pkey_get_public($certificate) { }
 function openssl_pkey_get_details($key) { }
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Free key resource
  * @link http://php.net/manual/en/function.openssl-free-key.php
  * @param resource $key_identifier
@@ -141,7 +148,8 @@ function openssl_pkey_get_details($key) { }
 function openssl_free_key($key_identifier) { }
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Alias of <b>openssl_pkey_get_private</b>
  * @link http://php.net/manual/en/function.openssl-get-privatekey.php
  * @param $key
@@ -163,7 +171,8 @@ function openssl_free_key($key_identifier) { }
 function openssl_get_privatekey($key, $passphrase) { }
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Alias of <b>openssl_pkey_get_public</b>
  * @link http://php.net/manual/en/function.openssl-get-publickey.php
  * @param mixed $certificate <p>
@@ -182,7 +191,7 @@ function openssl_get_privatekey($key, $passphrase) { }
 function openssl_get_publickey($certificate) { }
 
 /**
- * (PHP 5 &gt;= 5.6.0)<br/>
+ * @since 5.6.0
  * Generate a new signed public key and challenge
  * @link http://php.net/manual/en/function.openssl-spki-new.php
  * @param resource $privkey <p>
@@ -200,7 +209,7 @@ function openssl_spki_new(&$privkey, &$challenge, $algorithm = 0) {}
 
 
 /**
- * (PHP 5 &gt;= 5.6.0)<br/>
+ * @since 5.6.0
  * Verifies a signed public key and challenge
  * @link http://php.net/manual/en/function.openssl-spki-verify.php
  * @param string $spkac <p>Expects a valid signed public key and challenge</p>
@@ -209,7 +218,7 @@ function openssl_spki_new(&$privkey, &$challenge, $algorithm = 0) {}
 function openssl_spki_verify(&$spkac) {}
 
 /**
- * (PHP 5 &gt;= 5.6.0)<br/>
+ * @since 5.6.0
  * Exports the challenge assoicated with a signed public key and challenge
  * @link http://php.net/manual/en/function.openssl-spki-export-challenge.php
  * @param string $spkac <p>Expects a valid signed public key and challenge</p>
@@ -218,7 +227,7 @@ function openssl_spki_verify(&$spkac) {}
 function openssl_spki_export_challenge (&$spkac ) {}
 
 /**
- * (PHP 5 &gt;= 5.6.0)<br/>
+ * @since 5.6.0
  * Exports a valid PEM formatted public key signed public key and challenge
  * @link http://php.net/manual/en/function.openssl-spki-export.php
  * @param string $spkac <p>Expects a valid signed public key and challenge</p>
@@ -226,7 +235,8 @@ function openssl_spki_export_challenge (&$spkac ) {}
  */
 function openssl_spki_export (&$spkac ) {}
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Parse an X.509 certificate and return a resource identifier for
 it
  * @link http://php.net/manual/en/function.openssl-x509-read.php
@@ -236,7 +246,7 @@ it
 function openssl_x509_read($x509certdata) { }
 
 /**
- * (PHP 5 &gt;= 5.6.0)<br/>
+ * @since 5.6.0
  * @param string $x509
  * @param string $type [optional] hash method
  * @param bool $binary [optional]
@@ -244,7 +254,8 @@ function openssl_x509_read($x509certdata) { }
  */
 function openssl_x509_fingerprint($x509, $type, $binary) {}
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Free certificate resource
  * @link http://php.net/manual/en/function.openssl-x509-free.php
  * @param resource $x509cert
@@ -253,7 +264,8 @@ function openssl_x509_fingerprint($x509, $type, $binary) {}
 function openssl_x509_free($x509cert) { }
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Parse an X509 certificate and return the information as an array
  * @link http://php.net/manual/en/function.openssl-x509-parse.php
  * @param mixed $x509cert
@@ -269,7 +281,8 @@ function openssl_x509_free($x509cert) { }
 function openssl_x509_parse($x509cert, $shortnames = true) { }
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Verifies if a certificate can be used for a particular purpose
  * @link http://php.net/manual/en/function.openssl-x509-checkpurpose.php
  * @param mixed $x509cert <p>
@@ -332,7 +345,8 @@ function openssl_x509_parse($x509cert, $shortnames = true) { }
 function openssl_x509_checkpurpose($x509cert, $purpose, array $cainfo = null, $untrustedfile = null) { }
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Checks if a private key corresponds to a certificate
  * @link http://php.net/manual/en/function.openssl-x509-check-private-key.php
  * @param mixed $cert <p>
@@ -347,7 +361,8 @@ function openssl_x509_checkpurpose($x509cert, $purpose, array $cainfo = null, $u
 function openssl_x509_check_private_key($cert, $key) { }
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Exports a certificate as a string
  * @link http://php.net/manual/en/function.openssl-x509-export.php
  * @param mixed $x509
@@ -360,7 +375,8 @@ function openssl_x509_check_private_key($cert, $key) { }
 function openssl_x509_export($x509, &$output, $notext = true) { }
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Exports a certificate to file
  * @link http://php.net/manual/en/function.openssl-x509-export-to-file.php
  * @param mixed $x509
@@ -373,7 +389,7 @@ function openssl_x509_export($x509, &$output, $notext = true) { }
 function openssl_x509_export_to_file($x509, $outfilename, $notext = '&true;') { }
 
 /**
- * (PHP 5 &gt;= 5.2.2)<br/>
+ * @since 5.2.2
  * Exports a PKCS#12 Compatible Certificate Store File to variable.
  * @link http://php.net/manual/en/function.openssl-pkcs12-export.php
  * @param mixed $x509
@@ -392,7 +408,7 @@ function openssl_x509_export_to_file($x509, $outfilename, $notext = '&true;') { 
 function openssl_pkcs12_export($x509, &$out, $priv_key, $pass, array $args = null) { }
 
 /**
- * (PHP 5 &gt;= 5.2.2)<br/>
+ * @since 5.2.2
  * Exports a PKCS#12 Compatible Certificate Store File
  * @link http://php.net/manual/en/function.openssl-pkcs12-export-to-file.php
  * @param mixed $x509
@@ -411,7 +427,7 @@ function openssl_pkcs12_export($x509, &$out, $priv_key, $pass, array $args = nul
 function openssl_pkcs12_export_to_file($x509, $filename, $priv_key, $pass, array $args = null) { }
 
 /**
- * (PHP 5 &gt;= 5.2.2)<br/>
+ * @since 5.2.2
  * Parse a PKCS#12 Certificate Store into an array
  * @link http://php.net/manual/en/function.openssl-pkcs12-read.php
  * @param string $pkcs12
@@ -426,7 +442,8 @@ function openssl_pkcs12_export_to_file($x509, $filename, $priv_key, $pass, array
 function openssl_pkcs12_read($pkcs12, array &$certs, $pass) { }
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Generates a CSR
  * @link http://php.net/manual/en/function.openssl-csr-new.php
  * @param array $dn <p>
@@ -522,7 +539,8 @@ function openssl_pkcs12_read($pkcs12, array &$certs, $pass) { }
 function openssl_csr_new(array $dn, &$privkey, array $configargs = null, array $extraattribs = null) { }
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Exports a CSR as a string
  * @link http://php.net/manual/en/function.openssl-csr-export.php
  * @param resource $csr
@@ -533,7 +551,8 @@ function openssl_csr_new(array $dn, &$privkey, array $configargs = null, array $
 function openssl_csr_export($csr, &$out, $notext = true) { }
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Exports a CSR to a file
  * @link http://php.net/manual/en/function.openssl-csr-export-to-file.php
  * @param resource $csr
@@ -546,7 +565,8 @@ function openssl_csr_export($csr, &$out, $notext = true) { }
 function openssl_csr_export_to_file($csr, $outfilename, $notext = true) { }
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Sign a CSR with another certificate (or itself) and generate a certificate
  * @link http://php.net/manual/en/function.openssl-csr-sign.php
  * @param mixed $csr <p>
@@ -582,7 +602,7 @@ function openssl_csr_export_to_file($csr, $outfilename, $notext = true) { }
 function openssl_csr_sign($csr, $cacert, $priv_key, $days, array $configargs = null, $serial = 0) { }
 
 /**
- * (PHP 5 &gt;= 5.2.0)<br/>
+ * @since 5.2.0
  * Returns the subject of a CERT
  * @link http://php.net/manual/en/function.openssl-csr-get-subject.php
  * @param mixed $csr
@@ -592,7 +612,7 @@ function openssl_csr_sign($csr, $cacert, $priv_key, $days, array $configargs = n
 function openssl_csr_get_subject($csr, $use_shortnames = true) { }
 
 /**
- * (PHP 5 &gt;= 5.2.0)<br/>
+ * @since 5.2.0
  * Returns the public key of a CERT
  * @link http://php.net/manual/en/function.openssl-csr-get-public-key.php
  * @param mixed $csr
@@ -602,7 +622,7 @@ function openssl_csr_get_subject($csr, $use_shortnames = true) { }
 function openssl_csr_get_public_key($csr, $use_shortnames = true) { }
 
 /**
- * (PHP 5 &gt;= 5.3.0)<br/>
+ * @since 5.3.0
  * Computes a digest
  * @link http://php.net/manual/en/function.openssl-digest.php
  * @param string $data <p>
@@ -620,7 +640,7 @@ function openssl_csr_get_public_key($csr, $use_shortnames = true) { }
 function openssl_digest($data, $method, $raw_output = false) { }
 
 /**
- * (PHP 5 &gt;= 5.3.0)<br/>
+ * @since 5.3.0
  * Encrypts data
  * @link http://php.net/manual/en/function.openssl-encrypt.php
  * @param string $data <p>
@@ -644,7 +664,7 @@ function openssl_digest($data, $method, $raw_output = false) { }
 function openssl_encrypt($data, $method, $password, $raw_output = false, $iv = "") { }
 
 /**
- * (PHP 5 &gt;= 5.3.0)<br/>
+ * @since 5.3.0
  * Decrypts data
  * @link http://php.net/manual/en/function.openssl-decrypt.php
  * @param string $data <p>
@@ -680,7 +700,8 @@ function openssl_decrypt($data, $method, $password, $raw_input = false, $iv = ""
 function openssl_cipher_iv_length($method) { }
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Generate signature
  * @link http://php.net/manual/en/function.openssl-sign.php
  * @param string $data
@@ -697,7 +718,8 @@ function openssl_cipher_iv_length($method) { }
 function openssl_sign($data, &$signature, $priv_key_id, $signature_alg = OPENSSL_ALGO_SHA1) { }
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Verify signature
  * @link http://php.net/manual/en/function.openssl-verify.php
  * @param string $data
@@ -712,7 +734,8 @@ function openssl_sign($data, &$signature, $priv_key_id, $signature_alg = OPENSSL
 function openssl_verify($data, $signature, $pub_key_id, $signature_alg = OPENSSL_ALGO_SHA1) { }
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Seal (encrypt) data
  * @link http://php.net/manual/en/function.openssl-seal.php
  * @param string $data
@@ -728,7 +751,8 @@ function openssl_verify($data, $signature, $pub_key_id, $signature_alg = OPENSSL
 function openssl_seal($data, &$sealed_data, array &$env_keys, array $pub_key_ids, $method = null) { }
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Open sealed data
  * @link http://php.net/manual/en/function.openssl-open.php
  * @param string $sealed_data
@@ -744,7 +768,7 @@ function openssl_seal($data, &$sealed_data, array &$env_keys, array $pub_key_ids
 function openssl_open($sealed_data, &$open_data, $env_key, $priv_key_id, $method = null) { }
 
 /**
- * (PHP 5 &gt;= 5.5.0)<br/>
+ * @since 5.5.0
  * Generates a PKCS5 v2 PBKDF2 string, defaults to SHA-1
  * @link http://www.php.net/manual/en/function.openssl-pbkdf2.php
  * @param string $password
@@ -757,7 +781,8 @@ function openssl_open($sealed_data, &$open_data, $env_key, $priv_key_id, $method
 function openssl_pbkdf2($password, $salt, $key_length, $iterations, $digest_algorithm) { }
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Verifies the signature of an S/MIME signed message
  * @link http://php.net/manual/en/function.openssl-pkcs7-verify.php
  * @param string $filename <p>
@@ -795,7 +820,8 @@ function openssl_pbkdf2($password, $salt, $key_length, $iterations, $digest_algo
 function openssl_pkcs7_verify($filename, $flags, $outfilename = null, array $cainfo = null, $extracerts = null, $content = null) { }
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Decrypts an S/MIME encrypted message
  * @link http://php.net/manual/en/function.openssl-pkcs7-decrypt.php
  * @param string $infilename
@@ -810,7 +836,8 @@ function openssl_pkcs7_verify($filename, $flags, $outfilename = null, array $cai
 function openssl_pkcs7_decrypt($infilename, $outfilename, $recipcert, $recipkey = null) { }
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Sign an S/MIME message
  * @link http://php.net/manual/en/function.openssl-pkcs7-sign.php
  * @param string $infilename
@@ -836,7 +863,8 @@ function openssl_pkcs7_decrypt($infilename, $outfilename, $recipcert, $recipkey 
 function openssl_pkcs7_sign($infilename, $outfilename, $signcert, $privkey, array $headers, $flags = PKCS7_DETACHED, $extracerts = null) { }
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Encrypt an S/MIME message
  * @link http://php.net/manual/en/function.openssl-pkcs7-encrypt.php
  * @param string $infile
@@ -866,7 +894,8 @@ function openssl_pkcs7_sign($infilename, $outfilename, $signcert, $privkey, arra
 function openssl_pkcs7_encrypt($infile, $outfile, $recipcerts, array $headers, $flags = 0, $cipherid = OPENSSL_CIPHER_RC2_40) { }
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Encrypts data with private key
  * @link http://php.net/manual/en/function.openssl-private-encrypt.php
  * @param string $data
@@ -882,7 +911,8 @@ function openssl_pkcs7_encrypt($infile, $outfile, $recipcerts, array $headers, $
 function openssl_private_encrypt($data, &$crypted, $key, $padding = OPENSSL_PKCS1_PADDING) { }
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Decrypts data with private key
  * @link http://php.net/manual/en/function.openssl-private-decrypt.php
  * @param string $data
@@ -903,7 +933,8 @@ function openssl_private_encrypt($data, &$crypted, $key, $padding = OPENSSL_PKCS
 function openssl_private_decrypt($data, &$decrypted, $key, $padding = OPENSSL_PKCS1_PADDING) { }
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Encrypts data with public key
  * @link http://php.net/manual/en/function.openssl-public-encrypt.php
  * @param string $data
@@ -925,7 +956,8 @@ function openssl_private_decrypt($data, &$decrypted, $key, $padding = OPENSSL_PK
 function openssl_public_encrypt($data, &$crypted, $key, $padding = OPENSSL_PKCS1_PADDING) { }
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Decrypts data with public key
  * @link http://php.net/manual/en/function.openssl-public-decrypt.php
  * @param string $data
@@ -944,7 +976,7 @@ function openssl_public_encrypt($data, &$crypted, $key, $padding = OPENSSL_PKCS1
 function openssl_public_decrypt($data, &$decrypted, $key, $padding = OPENSSL_PKCS1_PADDING) { }
 
 /**
- * (PHP 5 &gt;= 5.3.0)<br/>
+ * @since 5.3.0
  * Gets available digest methods
  * @link http://php.net/manual/en/function.openssl-get-md-methods.php
  * @param bool $aliases [optional] <p>
@@ -956,7 +988,7 @@ function openssl_public_decrypt($data, &$decrypted, $key, $padding = OPENSSL_PKC
 function openssl_get_md_methods($aliases = false) { }
 
 /**
- * (PHP 5 &gt;= 5.3.0)<br/>
+ * @since 5.3.0
  * Gets available cipher methods
  * @link http://php.net/manual/en/function.openssl-get-cipher-methods.php
  * @param bool $aliases [optional] <p>
@@ -982,7 +1014,7 @@ function openssl_get_cipher_methods($aliases = false) { }
 function openssl_dh_compute_key($pub_key, $dh_key) { }
 
 /**
- * (PHP 5 &gt;= 5.3.0)<br/>
+ * @since 5.3.0
  * Generates a string of pseudo-random bytes, with the number of bytes determined by the length parameter.
  * <p>It also indicates if a cryptographically strong algorithm was used to produce the pseudo-random bytes,
  * and does this via the optional crypto_strong parameter. It's rare for this to be FALSE, but some systems may be broken or old.
@@ -1001,7 +1033,8 @@ function openssl_dh_compute_key($pub_key, $dh_key) { }
 function openssl_random_pseudo_bytes($length, &$crypto_strong = null) { }
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Return openSSL error message
  * @link http://php.net/manual/en/function.openssl-error-string.php
  * @return string an error message string, or false if there are no more error

--- a/pcntl.php
+++ b/pcntl.php
@@ -3,7 +3,8 @@
 // Start of pcntl v.
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Forks the currently running process
  * @link http://php.net/manual/en/function.pcntl-fork.php
  * @return int On success, the PID of the child process is returned in the
@@ -15,7 +16,8 @@
 function pcntl_fork () {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Waits on or returns the status of a forked child
  * @link http://php.net/manual/en/function.pcntl-waitpid.php
  * @param int $pid <p>
@@ -96,7 +98,7 @@ function pcntl_fork () {}
 function pcntl_waitpid ($pid, &$status, $options = 0) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Waits on or returns the status of a forked child
  * @link http://php.net/manual/en/function.pcntl-wait.php
  * @param int $status <p>
@@ -142,7 +144,8 @@ function pcntl_waitpid ($pid, &$status, $options = 0) {}
 function pcntl_wait (&$status, $options = 0) {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Installs a signal handler
  * @link http://php.net/manual/en/function.pcntl-signal.php
  * @param int $signo <p>
@@ -173,7 +176,7 @@ function pcntl_wait (&$status, $options = 0) {}
 function pcntl_signal ($signo, $handler, $restart_syscalls = true) {}
 
 /**
- * (PHP 5 &gt;= 5.3.0)<br/>
+ * @since 5.3.0
  * Calls signal handlers for pending signals
  * @link http://php.net/manual/en/function.pcntl-signal-dispatch.php
  * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
@@ -181,7 +184,8 @@ function pcntl_signal ($signo, $handler, $restart_syscalls = true) {}
 function pcntl_signal_dispatch () {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Checks if status code represents a normal exit
  * @link http://php.net/manual/en/function.pcntl-wifexited.php
  * @param int $status The <i>status</i>
@@ -193,7 +197,8 @@ function pcntl_signal_dispatch () {}
 function pcntl_wifexited ($status) {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Checks whether the child process is currently stopped
  * @link http://php.net/manual/en/function.pcntl-wifstopped.php
  * @param int $status The <i>status</i>
@@ -205,7 +210,8 @@ function pcntl_wifexited ($status) {}
 function pcntl_wifstopped ($status) {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Checks whether the status code represents a termination due to a signal
  * @link http://php.net/manual/en/function.pcntl-wifsignaled.php
  * @param int $status The <i>status</i>
@@ -217,7 +223,8 @@ function pcntl_wifstopped ($status) {}
 function pcntl_wifsignaled ($status) {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Returns the return code of a terminated child
  * @link http://php.net/manual/en/function.pcntl-wexitstatus.php
  * @param int $status The <i>status</i>
@@ -228,7 +235,8 @@ function pcntl_wifsignaled ($status) {}
 function pcntl_wexitstatus ($status) {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Returns the signal which caused the child to terminate
  * @link http://php.net/manual/en/function.pcntl-wtermsig.php
  * @param int $status The <i>status</i>
@@ -239,7 +247,8 @@ function pcntl_wexitstatus ($status) {}
 function pcntl_wtermsig ($status) {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Returns the signal which caused the child to stop
  * @link http://php.net/manual/en/function.pcntl-wstopsig.php
  * @param int $status The <i>status</i>
@@ -250,7 +259,8 @@ function pcntl_wtermsig ($status) {}
 function pcntl_wstopsig ($status) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Executes specified program in current process space
  * @link http://php.net/manual/en/function.pcntl-exec.php
  * @param string $path <p>
@@ -274,7 +284,8 @@ function pcntl_wstopsig ($status) {}
 function pcntl_exec ($path, array $args = null, array $envs = null) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Set an alarm clock for delivery of a signal
  * @link http://php.net/manual/en/function.pcntl-alarm.php
  * @param int $seconds <p>
@@ -288,7 +299,7 @@ function pcntl_exec ($path, array $args = null, array $envs = null) {}
 function pcntl_alarm ($seconds) {}
 
 /**
- * (PHP 5 &gt;= 5.3.4)<br/>
+ * @since 5.3.4
  * Retrieve the error number set by the last pcntl function which failed
  * @link http://php.net/manual/en/function.pcntl-get-last-error.php
  * @return int error code.
@@ -296,14 +307,14 @@ function pcntl_alarm ($seconds) {}
 function pcntl_get_last_error () {}
 
 /**
- * (PHP 5 &gt;= 5.3.4)<br/>
+ * @since 5.3.4
  * Alias of <b>pcntl_strerror</b>
  * @link http://php.net/manual/en/function.pcntl-errno.php
  */
 function pcntl_errno () {}
 
 /**
- * (PHP 5 &gt;= 5.3.4)<br/>
+ * @since 5.3.4
  * Retrieve the system error message associated with the given errno
  * @link http://php.net/manual/en/function.pcntl-strerror.php
  * @param int $errno <p>
@@ -313,7 +324,7 @@ function pcntl_errno () {}
 function pcntl_strerror ($errno) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Get the priority of any process
  * @link http://php.net/manual/en/function.pcntl-getpriority.php
  * @param int $pid [optional] <p>
@@ -330,7 +341,7 @@ function pcntl_strerror ($errno) {}
 function pcntl_getpriority ($pid, $process_identifier = PRIO_PROCESS) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Change the priority of any process
  * @link http://php.net/manual/en/function.pcntl-setpriority.php
  * @param int $priority <p>
@@ -353,7 +364,7 @@ function pcntl_getpriority ($pid, $process_identifier = PRIO_PROCESS) {}
 function pcntl_setpriority ($priority, $pid, $process_identifier = PRIO_PROCESS) {}
 
 /**
- * (PHP 5 &gt;= 5.3.0)<br/>
+ * @since 5.3.0
  * Sets and retrieves blocked signals
  * @link http://php.net/manual/en/function.pcntl-sigprocmask.php
  * @param int $how <p>
@@ -378,7 +389,7 @@ function pcntl_setpriority ($priority, $pid, $process_identifier = PRIO_PROCESS)
 function pcntl_sigprocmask ($how, array $set, array &$oldset = null) {}
 
 /**
- * (PHP 5 &gt;= 5.3.0)<br/>
+ * @since 5.3.0
  * Waits for signals
  * @link http://php.net/manual/en/function.pcntl-sigwaitinfo.php
  * @param array $set <p>
@@ -419,7 +430,7 @@ function pcntl_sigprocmask ($how, array $set, array &$oldset = null) {}
 function pcntl_sigwaitinfo (array $set, array &$siginfo = null) {}
 
 /**
- * (PHP 5 &gt;= 5.3.0)<br/>
+ * @since 5.3.0
  * Waits for signals, with a timeout
  * @link http://php.net/manual/en/function.pcntl-sigtimedwait.php
  * @param array $set <p>
@@ -485,272 +496,272 @@ define ('PRIO_USER', 2);
 define ('PRIO_PROCESS', 0);
 
 /**
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/pcntl.constants.php
  */
 define ('SIG_BLOCK', 0);
 
 /**
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/pcntl.constants.php
  */
 define ('SIG_UNBLOCK', 1);
 
 /**
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/pcntl.constants.php
  */
 define ('SIG_SETMASK', 2);
 
 /**
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/pcntl.constants.php
  */
 define ('SI_USER', 0);
 
 /**
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/pcntl.constants.php
  */
 define ('SI_KERNEL', 128);
 
 /**
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/pcntl.constants.php
  */
 define ('SI_QUEUE', -1);
 
 /**
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/pcntl.constants.php
  */
 define ('SI_TIMER', -2);
 define ('SI_MESGQ', -3);
 
 /**
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/pcntl.constants.php
  */
 define ('SI_ASYNCIO', -4);
 
 /**
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/pcntl.constants.php
  */
 define ('SI_SIGIO', -5);
 
 /**
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/pcntl.constants.php
  */
 define ('SI_TKILL', -6);
 
 /**
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/pcntl.constants.php
  */
 define ('CLD_EXITED', 1);
 
 /**
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/pcntl.constants.php
  */
 define ('CLD_KILLED', 2);
 
 /**
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/pcntl.constants.php
  */
 define ('CLD_DUMPED', 3);
 
 /**
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/pcntl.constants.php
  */
 define ('CLD_TRAPPED', 4);
 
 /**
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/pcntl.constants.php
  */
 define ('CLD_STOPPED', 5);
 
 /**
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/pcntl.constants.php
  */
 define ('CLD_CONTINUED', 6);
 
 /**
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/pcntl.constants.php
  */
 define ('TRAP_BRKPT', 1);
 
 /**
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/pcntl.constants.php
  */
 define ('TRAP_TRACE', 2);
 
 /**
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/pcntl.constants.php
  */
 define ('POLL_IN', 1);
 
 /**
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/pcntl.constants.php
  */
 define ('POLL_OUT', 2);
 
 /**
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/pcntl.constants.php
  */
 define ('POLL_MSG', 3);
 
 /**
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/pcntl.constants.php
  */
 define ('POLL_ERR', 4);
 
 /**
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/pcntl.constants.php
  */
 define ('POLL_PRI', 5);
 
 /**
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/pcntl.constants.php
  */
 define ('POLL_HUP', 6);
 
 /**
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/pcntl.constants.php
  */
 define ('ILL_ILLOPC', 1);
 
 /**
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/pcntl.constants.php
  */
 define ('ILL_ILLOPN', 2);
 
 /**
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/pcntl.constants.php
  */
 define ('ILL_ILLADR', 3);
 
 /**
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/pcntl.constants.php
  */
 define ('ILL_ILLTRP', 4);
 
 /**
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/pcntl.constants.php
  */
 define ('ILL_PRVOPC', 5);
 
 /**
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/pcntl.constants.php
  */
 define ('ILL_PRVREG', 6);
 
 /**
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/pcntl.constants.php
  */
 define ('ILL_COPROC', 7);
 
 /**
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/pcntl.constants.php
  */
 define ('ILL_BADSTK', 8);
 
 /**
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/pcntl.constants.php
  */
 define ('FPE_INTDIV', 1);
 
 /**
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/pcntl.constants.php
  */
 define ('FPE_INTOVF', 2);
 
 /**
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/pcntl.constants.php
  */
 define ('FPE_FLTDIV', 3);
 
 /**
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/pcntl.constants.php
  */
 define ('FPE_FLTOVF', 4);
 
 /**
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/pcntl.constants.php
  */
 define ('FPE_FLTUND', 7);
 
 /**
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/pcntl.constants.php
  */
 define ('FPE_FLTRES', 6);
 
 /**
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/pcntl.constants.php
  */
 define ('FPE_FLTINV', 7);
 
 /**
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/pcntl.constants.php
  */
 define ('FPE_FLTSUB', 8);
 
 /**
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/pcntl.constants.php
  */
 define ('SEGV_MAPERR', 1);
 
 /**
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/pcntl.constants.php
  */
 define ('SEGV_ACCERR', 2);
 
 /**
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/pcntl.constants.php
  */
 define ('BUS_ADRALN', 1);
 
 /**
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/pcntl.constants.php
  */
 define ('BUS_ADRERR', 2);
 
 /**
- * Available since PHP 5.3.0.
+ * @since 5.3.0
  * @link http://php.net/manual/en/pcntl.constants.php
  */
 define ('BUS_OBJERR', 3);

--- a/pcre.php
+++ b/pcre.php
@@ -3,7 +3,8 @@
 // Start of pcre v.
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Perform a regular expression match
  * @link http://php.net/manual/en/function.preg-match.php
  * @param string $pattern <p>
@@ -82,7 +83,8 @@
 function preg_match ($pattern, $subject, array &$matches = null, $flags = 0, $offset = 0) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Perform a global regular expression match
  * @link http://php.net/manual/en/function.preg-match-all.php
  * @param string $pattern <p>
@@ -140,7 +142,8 @@ function preg_match ($pattern, $subject, array &$matches = null, $flags = 0, $of
 function preg_match_all ($pattern, $subject, array &$matches = null, $flags = PREG_PATTERN_ORDER, $offset = 0) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Perform a regular expression search and replace
  * @link http://php.net/manual/en/function.preg-replace.php
  * @param mixed $pattern <p>
@@ -229,7 +232,8 @@ function preg_match_all ($pattern, $subject, array &$matches = null, $flags = PR
 function preg_replace ($pattern, $replacement, $subject, $limit = -1, &$count = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.5, PHP 5)<br/>
+ * @since 4.0.5
+ * @since 5.0
  * Perform a regular expression search and replace using a callback
  * @link http://php.net/manual/en/function.preg-replace-callback.php
  * @param mixed $pattern <p>
@@ -300,7 +304,7 @@ function preg_replace ($pattern, $replacement, $subject, $limit = -1, &$count = 
 function preg_replace_callback ($pattern, callable $callback, $subject, $limit = -1, &$count = null) {}
 
 /**
- * (PHP 5 &gt;= 5.3.0)<br/>
+ * @since 5.3.0
  * Perform a regular expression search and replace
  * @link http://php.net/manual/en/function.preg-filter.php
  * @param mixed $pattern
@@ -319,7 +323,8 @@ function preg_replace_callback ($pattern, callable $callback, $subject, $limit =
 function preg_filter ($pattern, $replacement, $subject, $limit = -1, &$count = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Split string by a regular expression
  * @link http://php.net/manual/en/function.preg-split.php
  * @param string $pattern <p>
@@ -347,7 +352,8 @@ function preg_filter ($pattern, $replacement, $subject, $limit = -1, &$count = n
 function preg_split ($pattern, $subject, $limit = -1, $flags = 0) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Quote regular expression characters
  * @link http://php.net/manual/en/function.preg-quote.php
  * @param string $str <p>
@@ -364,7 +370,8 @@ function preg_split ($pattern, $subject, $limit = -1, $flags = 0) {}
 function preg_quote ($str, $delimiter = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Return array entries that match the pattern
  * @link http://php.net/manual/en/function.preg-grep.php
  * @param string $pattern <p>
@@ -384,7 +391,7 @@ function preg_quote ($str, $delimiter = null) {}
 function preg_grep ($pattern, array $input, $flags = 0) {}
 
 /**
- * (PHP 5 &gt;= 5.2.0)<br/>
+ * @since 5.2.0
  * Returns the error code of the last PCRE regex execution
  * @link http://php.net/manual/en/function.preg-last-error.php
  * @return int one of the following constants (explained on their own page):

--- a/pgsql.php
+++ b/pgsql.php
@@ -3,7 +3,8 @@
 // Start of pgsql v.
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Open a PostgreSQL connection
  * @link http://php.net/manual/en/function.pg-connect.php
  * @param string $connection_string <p>
@@ -40,7 +41,8 @@
 function pg_connect ($connection_string, $connect_type = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Open a persistent PostgreSQL connection
  * @link http://php.net/manual/en/function.pg-pconnect.php
  * @param string $connection_string <p>
@@ -72,7 +74,8 @@ function pg_connect ($connection_string, $connect_type = null) {}
 function pg_pconnect ($connection_string, $connect_type = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Closes a PostgreSQL connection
  * @link http://php.net/manual/en/function.pg-close.php
  * @param resource $connection [optional] <p>
@@ -86,7 +89,8 @@ function pg_pconnect ($connection_string, $connect_type = null) {}
 function pg_close ($connection = null) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Get connection status
  * @link http://php.net/manual/en/function.pg-connection-status.php
  * @param resource $connection <p>
@@ -98,7 +102,8 @@ function pg_close ($connection = null) {}
 function pg_connection_status ($connection) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Get connection is busy or not
  * @link http://php.net/manual/en/function.pg-connection-busy.php
  * @param resource $connection <p>
@@ -109,7 +114,8 @@ function pg_connection_status ($connection) {}
 function pg_connection_busy ($connection) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Reset connection (reconnect)
  * @link http://php.net/manual/en/function.pg-connection-reset.php
  * @param resource $connection <p>
@@ -120,7 +126,8 @@ function pg_connection_busy ($connection) {}
 function pg_connection_reset ($connection) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Returns the host name associated with the connection
  * @link http://php.net/manual/en/function.pg-host.php
  * @param resource $connection [optional] <p>
@@ -135,7 +142,8 @@ function pg_connection_reset ($connection) {}
 function pg_host ($connection = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get the database name
  * @link http://php.net/manual/en/function.pg-dbname.php
  * @param resource $connection [optional] <p>
@@ -150,7 +158,8 @@ function pg_host ($connection = null) {}
 function pg_dbname ($connection = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Return the port number associated with the connection
  * @link http://php.net/manual/en/function.pg-port.php
  * @param resource $connection [optional] <p>
@@ -166,7 +175,8 @@ function pg_dbname ($connection = null) {}
 function pg_port ($connection = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Return the TTY name associated with the connection
  * @link http://php.net/manual/en/function.pg-tty.php
  * @param resource $connection [optional] <p>
@@ -181,7 +191,8 @@ function pg_port ($connection = null) {}
 function pg_tty ($connection = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get the options associated with the connection
  * @link http://php.net/manual/en/function.pg-options.php
  * @param resource $connection [optional] <p>
@@ -196,7 +207,7 @@ function pg_tty ($connection = null) {}
 function pg_options ($connection = null) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Returns an array with client, protocol and server version (when available)
  * @link http://php.net/manual/en/function.pg-version.php
  * @param resource $connection [optional] <p>
@@ -212,7 +223,8 @@ function pg_options ($connection = null) {}
 function pg_version ($connection = null) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Ping database connection
  * @link http://php.net/manual/en/function.pg-ping.php
  * @param resource $connection [optional] <p>
@@ -226,7 +238,7 @@ function pg_version ($connection = null) {}
 function pg_ping ($connection = null) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Looks up a current parameter setting of the server.
  * @link http://php.net/manual/en/function.pg-parameter-status.php
  * @param resource $connection [optional] <p>
@@ -248,7 +260,7 @@ function pg_ping ($connection = null) {}
 function pg_parameter_status ($connection = null, $param_name) {}
 
 /**
- * (PHP 5 &gt;= 5.1.0)<br/>
+ * @since 5.1.0
  * Returns the current in-transaction status of the server.
  * @link http://php.net/manual/en/function.pg-transaction-status.php
  * @param resource $connection <p>
@@ -265,7 +277,8 @@ function pg_parameter_status ($connection = null, $param_name) {}
 function pg_transaction_status ($connection) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Execute a query
  * @link http://php.net/manual/en/function.pg-query.php
  * @param resource $connection [optional] <p>
@@ -296,7 +309,7 @@ function pg_transaction_status ($connection) {}
 function pg_query ($connection = null, $query) {}
 
 /**
- * (PHP 5 &gt;= 5.1.0)<br/>
+ * @since 5.1.0
  * Submits a command to the server and waits for the result, with the ability to pass parameters separately from the SQL command text.
  * @link http://php.net/manual/en/function.pg-query-params.php
  * @param resource $connection [optional] <p>
@@ -333,7 +346,7 @@ function pg_query ($connection = null, $query) {}
 function pg_query_params ($connection = null, $query, array $params) {}
 
 /**
- * (PHP 5 &gt;= 5.1.0)<br/>
+ * @since 5.1.0
  * Submits a request to create a prepared statement with the 
 given parameters, and waits for completion.
  * @link http://php.net/manual/en/function.pg-prepare.php
@@ -358,7 +371,7 @@ given parameters, and waits for completion.
 function pg_prepare ($connection = null, $stmtname, $query) {}
 
 /**
- * (PHP 5 &gt;= 5.1.0)<br/>
+ * @since 5.1.0
  * Sends a request to execute a prepared statement with given parameters, and waits for the result.
  * @link http://php.net/manual/en/function.pg-execute.php
  * @param resource $connection [optional] <p>
@@ -387,7 +400,8 @@ function pg_prepare ($connection = null, $stmtname, $query) {}
 function pg_execute ($connection = null, $stmtname, array $params) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Sends asynchronous query
  * @link http://php.net/manual/en/function.pg-send-query.php
  * @param resource $connection <p>
@@ -406,7 +420,7 @@ function pg_execute ($connection = null, $stmtname, array $params) {}
 function pg_send_query ($connection, $query) {}
 
 /**
- * (PHP 5 &gt;= 5.1.0)<br/>
+ * @since 5.1.0
  * Submits a command and separate parameters to the server without waiting for the result(s).
  * @link http://php.net/manual/en/function.pg-send-query-params.php
  * @param resource $connection <p>
@@ -429,7 +443,7 @@ function pg_send_query ($connection, $query) {}
 function pg_send_query_params ($connection, $query, array $params) {}
 
 /**
- * (PHP 5 &gt;= 5.1.0)<br/>
+ * @since 5.1.0
  * Sends a request to create a prepared statement with the given parameters, without waiting for completion.
  * @link http://php.net/manual/en/function.pg-send-prepare.php
  * @param resource $connection <p>
@@ -454,7 +468,7 @@ function pg_send_query_params ($connection, $query, array $params) {}
 function pg_send_prepare ($connection, $stmtname, $query) {}
 
 /**
- * (PHP 5 &gt;= 5.1.0)<br/>
+ * @since 5.1.0
  * Sends a request to execute a prepared statement with given parameters, without waiting for the result(s).
  * @link http://php.net/manual/en/function.pg-send-execute.php
  * @param resource $connection <p>
@@ -481,7 +495,8 @@ function pg_send_prepare ($connection, $stmtname, $query) {}
 function pg_send_execute ($connection, $stmtname, array $params) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Cancel an asynchronous query
  * @link http://php.net/manual/en/function.pg-cancel-query.php
  * @param resource $connection <p>
@@ -492,7 +507,8 @@ function pg_send_execute ($connection, $stmtname, array $params) {}
 function pg_cancel_query ($connection) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Returns values from a result resource
  * @link http://php.net/manual/en/function.pg-fetch-result.php
  * @param resource $result <p>
@@ -522,7 +538,8 @@ function pg_cancel_query ($connection) {}
 function pg_fetch_result ($result, $row = null, $field) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get a row as an enumerated array
  * @link http://php.net/manual/en/function.pg-fetch-row.php
  * @param resource $result <p>
@@ -546,7 +563,8 @@ function pg_fetch_result ($result, $row = null, $field) {}
 function pg_fetch_row ($result, $row = null, $result_type = null) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Fetch a row as an associative array
  * @link http://php.net/manual/en/function.pg-fetch-assoc.php
  * @param resource $result <p>
@@ -570,7 +588,8 @@ function pg_fetch_row ($result, $row = null, $result_type = null) {}
 function pg_fetch_assoc ($result, $row = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Fetch a row as an array
  * @link http://php.net/manual/en/function.pg-fetch-array.php
  * @param resource $result <p>
@@ -607,7 +626,8 @@ function pg_fetch_assoc ($result, $row = null) {}
 function pg_fetch_array ($result, $row = null, $result_type = PGSQL_BOTH) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Fetch a row as an object
  * @link http://php.net/manual/en/function.pg-fetch-object.php
  * @param resource $result <p>
@@ -633,7 +653,8 @@ function pg_fetch_array ($result, $row = null, $result_type = PGSQL_BOTH) {}
 function pg_fetch_object ($result, $row = null, $result_type = PGSQL_ASSOC) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Fetches all rows from a result as an array
  * @link http://php.net/manual/en/function.pg-fetch-all.php
  * @param resource $result <p>
@@ -651,7 +672,7 @@ function pg_fetch_object ($result, $row = null, $result_type = PGSQL_ASSOC) {}
 function pg_fetch_all ($result) {}
 
 /**
- * (PHP 5 &gt;= 5.1.0)<br/>
+ * @since 5.1.0
  * Fetches all rows in a particular result column as an array
  * @link http://php.net/manual/en/function.pg-fetch-all-columns.php
  * @param resource $result <p>
@@ -672,7 +693,8 @@ function pg_fetch_all ($result) {}
 function pg_fetch_all_columns ($result, $column = 0) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Returns number of affected records (tuples)
  * @link http://php.net/manual/en/function.pg-affected-rows.php
  * @param resource $result <p>
@@ -686,7 +708,8 @@ function pg_fetch_all_columns ($result, $column = 0) {}
 function pg_affected_rows ($result) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Get asynchronous query result
  * @link http://php.net/manual/en/function.pg-get-result.php
  * @param resource $connection [optional] <p>
@@ -697,7 +720,8 @@ function pg_affected_rows ($result) {}
 function pg_get_result ($connection = null) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Set internal row offset in result resource
  * @link http://php.net/manual/en/function.pg-result-seek.php
  * @param resource $result <p>
@@ -714,7 +738,8 @@ function pg_get_result ($connection = null) {}
 function pg_result_seek ($result, $offset) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Get status of query result
  * @link http://php.net/manual/en/function.pg-result-status.php
  * @param resource $result <p>
@@ -737,7 +762,8 @@ function pg_result_seek ($result, $offset) {}
 function pg_result_status ($result, $type = PGSQL_STATUS_LONG) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Free result memory
  * @link http://php.net/manual/en/function.pg-free-result.php
  * @param resource $result <p>
@@ -750,7 +776,8 @@ function pg_result_status ($result, $type = PGSQL_STATUS_LONG) {}
 function pg_free_result ($result) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Returns the last row's OID
  * @link http://php.net/manual/en/function.pg-last-oid.php
  * @param resource $result <p>
@@ -765,7 +792,8 @@ function pg_free_result ($result) {}
 function pg_last_oid ($result) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Returns the number of rows in a result
  * @link http://php.net/manual/en/function.pg-num-rows.php
  * @param resource $result <p>
@@ -778,7 +806,8 @@ function pg_last_oid ($result) {}
 function pg_num_rows ($result) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Returns the number of fields in a result
  * @link http://php.net/manual/en/function.pg-num-fields.php
  * @param resource $result <p>
@@ -791,7 +820,8 @@ function pg_num_rows ($result) {}
 function pg_num_fields ($result) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Returns the name of a field
  * @link http://php.net/manual/en/function.pg-field-name.php
  * @param resource $result <p>
@@ -807,7 +837,8 @@ function pg_num_fields ($result) {}
 function pg_field_name ($result, $field_number) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Returns the field number of the named field
  * @link http://php.net/manual/en/function.pg-field-num.php
  * @param resource $result <p>
@@ -823,7 +854,8 @@ function pg_field_name ($result, $field_number) {}
 function pg_field_num ($result, $field_name) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Returns the internal storage size of the named field
  * @link http://php.net/manual/en/function.pg-field-size.php
  * @param resource $result <p>
@@ -840,7 +872,8 @@ function pg_field_num ($result, $field_name) {}
 function pg_field_size ($result, $field_number) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Returns the type name for the corresponding field number
  * @link http://php.net/manual/en/function.pg-field-type.php
  * @param resource $result <p>
@@ -857,7 +890,7 @@ function pg_field_size ($result, $field_number) {}
 function pg_field_type ($result, $field_number) {}
 
 /**
- * (PHP 5 &gt;= 5.1.0)<br/>
+ * @since 5.1.0
  * Returns the type ID (OID) for the corresponding field number
  * @link http://php.net/manual/en/function.pg-field-type-oid.php
  * @param resource $result <p>
@@ -873,7 +906,8 @@ function pg_field_type ($result, $field_number) {}
 function pg_field_type_oid ($result, $field_number) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Returns the printed length
  * @link http://php.net/manual/en/function.pg-field-prtlen.php
  * @param resource $result <p>
@@ -888,7 +922,8 @@ function pg_field_type_oid ($result, $field_number) {}
 function pg_field_prtlen ($result, $row_number, $field_name_or_number) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Test if a field is SQL NULL
  * @link http://php.net/manual/en/function.pg-field-is-null.php
  * @param resource $result <p>
@@ -910,7 +945,7 @@ function pg_field_prtlen ($result, $row_number, $field_name_or_number) {}
 function pg_field_is_null ($result, $row, $field) {}
 
 /**
- * (PHP 5 &gt;= 5.2.0)<br/>
+ * @since 5.2.0
  * Returns the name or oid of the tables field
  * @link http://php.net/manual/en/function.pg-field-table.php
  * @param resource $result <p>
@@ -931,7 +966,8 @@ function pg_field_is_null ($result, $row, $field) {}
 function pg_field_table ($result, $field_number, $oid_only = false) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Gets SQL NOTIFY message
  * @link http://php.net/manual/en/function.pg-get-notify.php
  * @param resource $connection <p>
@@ -955,7 +991,8 @@ function pg_field_table ($result, $field_number, $oid_only = false) {}
 function pg_get_notify ($connection, $result_type = null) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Gets the backend's process ID
  * @link http://php.net/manual/en/function.pg-get-pid.php
  * @param resource $connection <p>
@@ -966,7 +1003,8 @@ function pg_get_notify ($connection, $result_type = null) {}
 function pg_get_pid ($connection) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Get error message associated with result
  * @link http://php.net/manual/en/function.pg-result-error.php
  * @param resource $result <p>
@@ -980,7 +1018,7 @@ function pg_get_pid ($connection) {}
 function pg_result_error ($result) {}
 
 /**
- * (PHP 5 &gt;= 5.1.0)<br/>
+ * @since 5.1.0
  * Returns an individual field of an error report.
  * @link http://php.net/manual/en/function.pg-result-error-field.php
  * @param resource $result <p>
@@ -1004,7 +1042,8 @@ function pg_result_error ($result) {}
 function pg_result_error_field ($result, $fieldcode) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Get the last error message string of a connection
  * @link http://php.net/manual/en/function.pg-last-error.php
  * @param resource $connection [optional] <p>
@@ -1019,7 +1058,8 @@ function pg_result_error_field ($result, $fieldcode) {}
 function pg_last_error ($connection = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Returns the last notice message from PostgreSQL server
  * @link http://php.net/manual/en/function.pg-last-notice.php
  * @param resource $connection <p>
@@ -1031,7 +1071,8 @@ function pg_last_error ($connection = null) {}
 function pg_last_notice ($connection) {}
 
 /**
- * (PHP 4 &gt;= 4.0.3, PHP 5)<br/>
+ * @since 4.0.3
+ * @since 5.0
  * Send a NULL-terminated string to PostgreSQL backend
  * @link http://php.net/manual/en/function.pg-put-line.php
  * @param resource $connection [optional] <p>
@@ -1049,7 +1090,8 @@ function pg_last_notice ($connection) {}
 function pg_put_line ($connection = null, $data) {}
 
 /**
- * (PHP 4 &gt;= 4.0.3, PHP 5)<br/>
+ * @since 4.0.3
+ * @since 5.0
  * Sync with PostgreSQL backend
  * @link http://php.net/manual/en/function.pg-end-copy.php
  * @param resource $connection [optional] <p>
@@ -1063,7 +1105,8 @@ function pg_put_line ($connection = null, $data) {}
 function pg_end_copy ($connection = null) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Copy a table to an array
  * @link http://php.net/manual/en/function.pg-copy-to.php
  * @param resource $connection <p>
@@ -1086,7 +1129,8 @@ function pg_end_copy ($connection = null) {}
 function pg_copy_to ($connection, $table_name, $delimiter = null, $null_as = null) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Insert records into a table from an array
  * @link http://php.net/manual/en/function.pg-copy-from.php
  * @param resource $connection <p>
@@ -1114,7 +1158,8 @@ function pg_copy_to ($connection, $table_name, $delimiter = null, $null_as = nul
 function pg_copy_from ($connection, $table_name, array $rows, $delimiter = null, $null_as = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.1, PHP 5)<br/>
+ * @since 4.0.1
+ * @since 5.0
  * Enable tracing a PostgreSQL connection
  * @link http://php.net/manual/en/function.pg-trace.php
  * @param string $pathname <p>
@@ -1136,7 +1181,8 @@ function pg_copy_from ($connection, $table_name, array $rows, $delimiter = null,
 function pg_trace ($pathname, $mode = "w", $connection = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.1, PHP 5)<br/>
+ * @since 4.0.1
+ * @since 5.0
  * Disable tracing of a PostgreSQL connection
  * @link http://php.net/manual/en/function.pg-untrace.php
  * @param resource $connection [optional] <p>
@@ -1150,7 +1196,8 @@ function pg_trace ($pathname, $mode = "w", $connection = null) {}
 function pg_untrace ($connection = null) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Create a large object
  * @link http://php.net/manual/en/function.pg-lo-create.php
  * @param resource $connection [optional] <p>
@@ -1171,7 +1218,8 @@ function pg_untrace ($connection = null) {}
 function pg_lo_create ($connection = null, $object_id = null) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Delete a large object
  * @link http://php.net/manual/en/function.pg-lo-unlink.php
  * @param resource $connection <p>
@@ -1188,7 +1236,8 @@ function pg_lo_create ($connection = null, $object_id = null) {}
 function pg_lo_unlink ($connection, $oid) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Open a large object
  * @link http://php.net/manual/en/function.pg-lo-open.php
  * @param resource $connection <p>
@@ -1209,7 +1258,8 @@ function pg_lo_unlink ($connection, $oid) {}
 function pg_lo_open ($connection, $oid, $mode) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Close a large object
  * @link http://php.net/manual/en/function.pg-lo-close.php
  * @param resource $large_object
@@ -1218,7 +1268,8 @@ function pg_lo_open ($connection, $oid, $mode) {}
 function pg_lo_close ($large_object) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Read a large object
  * @link http://php.net/manual/en/function.pg-lo-read.php
  * @param resource $large_object <p>
@@ -1233,7 +1284,8 @@ function pg_lo_close ($large_object) {}
 function pg_lo_read ($large_object, $len = 8192) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Write to a large object
  * @link http://php.net/manual/en/function.pg-lo-write.php
  * @param resource $large_object <p>
@@ -1254,7 +1306,8 @@ function pg_lo_read ($large_object, $len = 8192) {}
 function pg_lo_write ($large_object, $data, $len = null) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Reads an entire large object and send straight to browser
  * @link http://php.net/manual/en/function.pg-lo-read-all.php
  * @param resource $large_object <p>
@@ -1265,7 +1318,8 @@ function pg_lo_write ($large_object, $data, $len = null) {}
 function pg_lo_read_all ($large_object) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Import a large object from file
  * @link http://php.net/manual/en/function.pg-lo-import.php
  * @param resource $connection [optional] <p>
@@ -1291,7 +1345,8 @@ function pg_lo_read_all ($large_object) {}
 function pg_lo_import ($connection = null, $pathname, $object_id = null) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Export a large object to file
  * @link http://php.net/manual/en/function.pg-lo-export.php
  * @param resource $connection [optional] <p>
@@ -1312,7 +1367,8 @@ function pg_lo_import ($connection = null, $pathname, $object_id = null) {}
 function pg_lo_export ($connection = null, $oid, $pathname) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Seeks position within a large object
  * @link http://php.net/manual/en/function.pg-lo-seek.php
  * @param resource $large_object <p>
@@ -1331,7 +1387,8 @@ function pg_lo_export ($connection = null, $oid, $pathname) {}
 function pg_lo_seek ($large_object, $offset, $whence = PGSQL_SEEK_CUR) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Returns current seek position a of large object
  * @link http://php.net/manual/en/function.pg-lo-tell.php
  * @param resource $large_object <p>
@@ -1343,7 +1400,8 @@ function pg_lo_seek ($large_object, $offset, $whence = PGSQL_SEEK_CUR) {}
 function pg_lo_tell ($large_object) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Escape a string for query
  * @link http://php.net/manual/en/function.pg-escape-string.php
  * @param resource $connection [optional] <p>
@@ -1360,7 +1418,8 @@ function pg_lo_tell ($large_object) {}
 function pg_escape_string ($connection = null, $data) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Escape a string for insertion into a bytea field
  * @link http://php.net/manual/en/function.pg-escape-bytea.php
  * @param resource $connection [optional] <p>
@@ -1378,7 +1437,7 @@ function pg_escape_string ($connection = null, $data) {}
 function pg_escape_bytea ($connection = null, $data) {}
 
 /**
- * (PHP 5 &gt;= 5.4.4)<br/>
+ * @since 5.4.4
  * Escape a identifier for insertion into a text field
  * @link http://php.net/manual/en/function.pg-escape-identifier.php
  * @param resource $connection [optional] <p>
@@ -1395,7 +1454,7 @@ function pg_escape_bytea ($connection = null, $data) {}
 function pg_escape_identifier ($connection = null, $data) {}
 
 /**
- * (PHP 5 &gt;= 5.4.4)<br/>
+ * @since 5.4.4
  * Escape a literal for insertion into a text field
  * @link http://php.net/manual/en/function.pg-escape-literal.php
  * @param resource $connection [optional] <p>
@@ -1412,7 +1471,8 @@ function pg_escape_identifier ($connection = null, $data) {}
 function pg_escape_literal ($connection = null, $data) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Unescape binary for bytea type
  * @link http://php.net/manual/en/function.pg-unescape-bytea.php
  * @param string $data <p>
@@ -1424,7 +1484,7 @@ function pg_escape_literal ($connection = null, $data) {}
 function pg_unescape_bytea ($data) {}
 
 /**
- * (PHP 5 &gt;= 5.1.0)<br/>
+ * @since 5.1.0
  * Determines the verbosity of messages returned by <b>pg_last_error</b> 
 and <b>pg_result_error</b>.
  * @link http://php.net/manual/en/function.pg-set-error-verbosity.php
@@ -1446,7 +1506,8 @@ and <b>pg_result_error</b>.
 function pg_set_error_verbosity ($connection = null, $verbosity) {}
 
 /**
- * (PHP 4 &gt;= 4.0.3, PHP 5)<br/>
+ * @since 4.0.3
+ * @since 5.0
  * Gets the client encoding
  * @link http://php.net/manual/en/function.pg-client-encoding.php
  * @param resource $connection [optional] <p>
@@ -1460,7 +1521,8 @@ function pg_set_error_verbosity ($connection = null, $verbosity) {}
 function pg_client_encoding ($connection = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.3, PHP 5)<br/>
+ * @since 4.0.3
+ * @since 5.0
  * Set the client encoding
  * @link http://php.net/manual/en/function.pg-set-client-encoding.php
  * @param resource $connection [optional] <p>
@@ -1485,7 +1547,8 @@ function pg_client_encoding ($connection = null) {}
 function pg_set_client_encoding ($connection = null, $encoding) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Get meta data for table
  * @link http://php.net/manual/en/function.pg-meta-data.php
  * @param resource $connection <p>
@@ -1499,7 +1562,8 @@ function pg_set_client_encoding ($connection = null, $encoding) {}
 function pg_meta_data ($connection, $table_name) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Convert associative array values into suitable for SQL statement
  * @link http://php.net/manual/en/function.pg-convert.php
  * @param resource $connection <p>
@@ -1521,7 +1585,8 @@ function pg_meta_data ($connection, $table_name) {}
 function pg_convert ($connection, $table_name, array $assoc_array, $options = 0) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Insert array into table
  * @link http://php.net/manual/en/function.pg-insert.php
  * @param resource $connection <p>
@@ -1549,7 +1614,8 @@ function pg_convert ($connection, $table_name, array $assoc_array, $options = 0)
 function pg_insert ($connection, $table_name, array $assoc_array, $options = PGSQL_DML_EXEC) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Update table
  * @link http://php.net/manual/en/function.pg-update.php
  * @param resource $connection <p>
@@ -1579,7 +1645,8 @@ function pg_insert ($connection, $table_name, array $assoc_array, $options = PGS
 function pg_update ($connection, $table_name, array $data, array $condition, $options = PGSQL_DML_EXEC) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Deletes records
  * @link http://php.net/manual/en/function.pg-delete.php
  * @param resource $connection <p>
@@ -1605,7 +1672,8 @@ function pg_update ($connection, $table_name, array $data, array $condition, $op
 function pg_delete ($connection, $table_name, array $assoc_array, $options = PGSQL_DML_EXEC) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Select records
  * @link http://php.net/manual/en/function.pg-select.php
  * @param resource $connection <p>

--- a/posix.php
+++ b/posix.php
@@ -3,7 +3,8 @@
 // Start of posix v.
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Send a signal to a process
  * @link http://php.net/manual/en/function.posix-kill.php
  * @param int $pid <p>
@@ -17,7 +18,8 @@
 function posix_kill ($pid, $sig) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Return the current process identifier
  * @link http://php.net/manual/en/function.posix-getpid.php
  * @return int the identifier, as an integer.
@@ -25,7 +27,8 @@ function posix_kill ($pid, $sig) {}
 function posix_getpid () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Return the parent process identifier
  * @link http://php.net/manual/en/function.posix-getppid.php
  * @return int the identifier, as an integer.
@@ -33,7 +36,8 @@ function posix_getpid () {}
 function posix_getppid () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Return the real user ID of the current process
  * @link http://php.net/manual/en/function.posix-getuid.php
  * @return int the user id, as an integer
@@ -41,7 +45,8 @@ function posix_getppid () {}
 function posix_getuid () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Set the UID of the current process
  * @link http://php.net/manual/en/function.posix-setuid.php
  * @param int $uid <p>
@@ -52,7 +57,8 @@ function posix_getuid () {}
 function posix_setuid ($uid) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Return the effective user ID of the current process
  * @link http://php.net/manual/en/function.posix-geteuid.php
  * @return int the user id, as an integer
@@ -60,7 +66,8 @@ function posix_setuid ($uid) {}
 function posix_geteuid () {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Set the effective UID of the current process
  * @link http://php.net/manual/en/function.posix-seteuid.php
  * @param int $uid <p>
@@ -71,7 +78,8 @@ function posix_geteuid () {}
 function posix_seteuid ($uid) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Return the real group ID of the current process
  * @link http://php.net/manual/en/function.posix-getgid.php
  * @return int the real group id, as an integer.
@@ -79,7 +87,8 @@ function posix_seteuid ($uid) {}
 function posix_getgid () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Set the GID of the current process
  * @link http://php.net/manual/en/function.posix-setgid.php
  * @param int $gid <p>
@@ -90,7 +99,8 @@ function posix_getgid () {}
 function posix_setgid ($gid) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Return the effective group ID of the current process
  * @link http://php.net/manual/en/function.posix-getegid.php
  * @return int an integer of the effective group ID.
@@ -98,7 +108,8 @@ function posix_setgid ($gid) {}
 function posix_getegid () {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Set the effective GID of the current process
  * @link http://php.net/manual/en/function.posix-setegid.php
  * @param int $gid <p>
@@ -109,7 +120,8 @@ function posix_getegid () {}
 function posix_setegid ($gid) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Return the group set of the current process
  * @link http://php.net/manual/en/function.posix-getgroups.php
  * @return array an array of integers containing the numeric group ids of the group
@@ -118,7 +130,8 @@ function posix_setegid ($gid) {}
 function posix_getgroups () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Return login name
  * @link http://php.net/manual/en/function.posix-getlogin.php
  * @return string the login name of the user, as a string.
@@ -126,7 +139,8 @@ function posix_getgroups () {}
 function posix_getlogin () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Return the current process group identifier
  * @link http://php.net/manual/en/function.posix-getpgrp.php
  * @return int the identifier, as an integer.
@@ -134,7 +148,8 @@ function posix_getlogin () {}
 function posix_getpgrp () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Make the current process a session leader
  * @link http://php.net/manual/en/function.posix-setsid.php
  * @return int the session id, or -1 on errors.
@@ -142,7 +157,8 @@ function posix_getpgrp () {}
 function posix_setsid () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Set process group id for job control
  * @link http://php.net/manual/en/function.posix-setpgid.php
  * @param int $pid <p>
@@ -156,7 +172,8 @@ function posix_setsid () {}
 function posix_setpgid ($pid, $pgid) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get process group id for job control
  * @link http://php.net/manual/en/function.posix-getpgid.php
  * @param int $pid <p>
@@ -167,7 +184,8 @@ function posix_setpgid ($pid, $pgid) {}
 function posix_getpgid ($pid) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get the current sid of the process
  * @link http://php.net/manual/en/function.posix-getsid.php
  * @param int $pid <p>
@@ -181,7 +199,8 @@ function posix_getpgid ($pid) {}
 function posix_getsid ($pid) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get system name
  * @link http://php.net/manual/en/function.posix-uname.php
  * @return array a hash of strings with information about the
@@ -202,7 +221,8 @@ function posix_getsid ($pid) {}
 function posix_uname () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get process times
  * @link http://php.net/manual/en/function.posix-times.php
  * @return array a hash of strings with information about the current
@@ -217,7 +237,8 @@ function posix_uname () {}
 function posix_times () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get path name of controlling terminal
  * @link http://php.net/manual/en/function.posix-ctermid.php
  * @return string Upon successful completion, returns string of the pathname to
@@ -227,7 +248,8 @@ function posix_times () {}
 function posix_ctermid () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Determine terminal device name
  * @link http://php.net/manual/en/function.posix-ttyname.php
  * @param int $fd <p>
@@ -239,7 +261,8 @@ function posix_ctermid () {}
 function posix_ttyname ($fd) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Determine if a file descriptor is an interactive terminal
  * @link http://php.net/manual/en/function.posix-isatty.php
  * @param mixed $fd <p>
@@ -254,7 +277,8 @@ function posix_ttyname ($fd) {}
 function posix_isatty ($fd) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Pathname of current directory
  * @link http://php.net/manual/en/function.posix-getcwd.php
  * @return string a string of the absolute pathname on success.
@@ -264,7 +288,8 @@ function posix_isatty ($fd) {}
 function posix_getcwd () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Create a fifo special file (a named pipe)
  * @link http://php.net/manual/en/function.posix-mkfifo.php
  * @param string $pathname <p>
@@ -282,7 +307,7 @@ function posix_getcwd () {}
 function posix_mkfifo ($pathname, $mode) {}
 
 /**
- * (PHP 5 &gt;= 5.1.0)<br/>
+ * @since 5.1.0
  * Create a special or ordinary file (POSIX.1)
  * @link http://php.net/manual/en/function.posix-mknod.php
  * @param string $pathname <p>
@@ -307,7 +332,7 @@ function posix_mkfifo ($pathname, $mode) {}
 function posix_mknod ($pathname, $mode, $major = 0, $minor = 0) {}
 
 /**
- * (PHP 5 &gt;= 5.1.0)<br/>
+ * @since 5.1.0
  * Determine accessibility of a file
  * @link http://php.net/manual/en/function.posix-access.php
  * @param string $file <p>
@@ -330,7 +355,8 @@ function posix_mknod ($pathname, $mode, $major = 0, $minor = 0) {}
 function posix_access ($file, $mode = POSIX_F_OK) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Return info about a group by name
  * @link http://php.net/manual/en/function.posix-getgrnam.php
  * @param string $name <p>The name of the group</p>
@@ -377,7 +403,8 @@ function posix_access ($file, $mode = POSIX_F_OK) {}
 function posix_getgrnam ($name) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Return info about a group by group id
  * @link http://php.net/manual/en/function.posix-getgrgid.php
  * @param int $gid <p>
@@ -426,7 +453,8 @@ function posix_getgrnam ($name) {}
 function posix_getgrgid ($gid) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Return info about a user by username
  * @link http://php.net/manual/en/function.posix-getpwnam.php
  * @param string $username <p>
@@ -503,7 +531,8 @@ function posix_getgrgid ($gid) {}
 function posix_getpwnam ($username) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Return info about a user by user id
  * @link http://php.net/manual/en/function.posix-getpwuid.php
  * @param int $uid <p>
@@ -579,7 +608,8 @@ function posix_getpwnam ($username) {}
 function posix_getpwuid ($uid) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Return info about system resource limits
  * @link http://php.net/manual/en/function.posix-getrlimit.php
  * @return array an associative array of elements for each
@@ -664,7 +694,8 @@ function posix_getpwuid ($uid) {}
 function posix_getrlimit () {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Retrieve the error number set by the last posix function that failed
  * @link http://php.net/manual/en/function.posix-get-last-error.php
  * @return int the errno (error number) set by the last posix function that
@@ -673,14 +704,16 @@ function posix_getrlimit () {}
 function posix_get_last_error () {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Alias of <b>posix_get_last_error</b>
  * @link http://php.net/manual/en/function.posix-errno.php
  */
 function posix_errno () {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Retrieve the system error message associated with the given errno
  * @link http://php.net/manual/en/function.posix-strerror.php
  * @param int $errno <p>
@@ -693,7 +726,7 @@ function posix_errno () {}
 function posix_strerror ($errno) {}
 
 /**
- * (PHP 5 &gt;= 5.2.0)<br/>
+ * @since 5.2.0
  * Calculate the group access list
  * @link http://php.net/manual/en/function.posix-initgroups.php
  * @param string $name <p>

--- a/pspell.php
+++ b/pspell.php
@@ -3,7 +3,8 @@
 // Start of pspell v.
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Load a new dictionary
  * @link http://php.net/manual/en/function.pspell-new.php
  * @param string $language <p>
@@ -38,7 +39,8 @@
 function pspell_new ($language, $spelling = null, $jargon = null, $encoding = null, $mode = 0) {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Load a new dictionary with personal wordlist
  * @link http://php.net/manual/en/function.pspell-new-personal.php
  * @param string $personal <p>
@@ -76,7 +78,8 @@ function pspell_new ($language, $spelling = null, $jargon = null, $encoding = nu
 function pspell_new_personal ($personal, $language, $spelling = null, $jargon = null, $encoding = null, $mode = 0) {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Load a new dictionary with settings based on a given config
  * @link http://php.net/manual/en/function.pspell-new-config.php
  * @param int $config <p>
@@ -88,7 +91,8 @@ function pspell_new_personal ($personal, $language, $spelling = null, $jargon = 
 function pspell_new_config ($config) {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Check a word
  * @link http://php.net/manual/en/function.pspell-check.php
  * @param int $dictionary_link
@@ -100,7 +104,8 @@ function pspell_new_config ($config) {}
 function pspell_check ($dictionary_link, $word) {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Suggest spellings of a word
  * @link http://php.net/manual/en/function.pspell-suggest.php
  * @param int $dictionary_link
@@ -112,7 +117,8 @@ function pspell_check ($dictionary_link, $word) {}
 function pspell_suggest ($dictionary_link, $word) {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Store a replacement pair for a word
  * @link http://php.net/manual/en/function.pspell-store-replacement.php
  * @param int $dictionary_link <p>
@@ -130,7 +136,8 @@ function pspell_suggest ($dictionary_link, $word) {}
 function pspell_store_replacement ($dictionary_link, $misspelled, $correct) {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Add the word to a personal wordlist
  * @link http://php.net/manual/en/function.pspell-add-to-personal.php
  * @param int $dictionary_link
@@ -142,7 +149,8 @@ function pspell_store_replacement ($dictionary_link, $misspelled, $correct) {}
 function pspell_add_to_personal ($dictionary_link, $word) {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Add the word to the wordlist in the current session
  * @link http://php.net/manual/en/function.pspell-add-to-session.php
  * @param int $dictionary_link
@@ -154,7 +162,8 @@ function pspell_add_to_personal ($dictionary_link, $word) {}
 function pspell_add_to_session ($dictionary_link, $word) {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Clear the current session
  * @link http://php.net/manual/en/function.pspell-clear-session.php
  * @param int $dictionary_link
@@ -163,7 +172,8 @@ function pspell_add_to_session ($dictionary_link, $word) {}
 function pspell_clear_session ($dictionary_link) {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Save the personal wordlist to a file
  * @link http://php.net/manual/en/function.pspell-save-wordlist.php
  * @param int $dictionary_link <p>
@@ -175,7 +185,8 @@ function pspell_clear_session ($dictionary_link) {}
 function pspell_save_wordlist ($dictionary_link) {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Create a config used to open a dictionary
  * @link http://php.net/manual/en/function.pspell-config-create.php
  * @param string $language <p>
@@ -205,7 +216,8 @@ function pspell_save_wordlist ($dictionary_link) {}
 function pspell_config_create ($language, $spelling = null, $jargon = null, $encoding = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Consider run-together words as valid compounds
  * @link http://php.net/manual/en/function.pspell-config-runtogether.php
  * @param int $dictionary_link
@@ -218,7 +230,8 @@ function pspell_config_create ($language, $spelling = null, $jargon = null, $enc
 function pspell_config_runtogether ($dictionary_link, $flag) {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Change the mode number of suggestions returned
  * @link http://php.net/manual/en/function.pspell-config-mode.php
  * @param int $dictionary_link
@@ -232,7 +245,8 @@ function pspell_config_runtogether ($dictionary_link, $flag) {}
 function pspell_config_mode ($dictionary_link, $mode) {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Ignore words less than N characters long
  * @link http://php.net/manual/en/function.pspell-config-ignore.php
  * @param int $dictionary_link
@@ -244,7 +258,8 @@ function pspell_config_mode ($dictionary_link, $mode) {}
 function pspell_config_ignore ($dictionary_link, $n) {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Set a file that contains personal wordlist
  * @link http://php.net/manual/en/function.pspell-config-personal.php
  * @param int $dictionary_link
@@ -257,7 +272,7 @@ function pspell_config_ignore ($dictionary_link, $n) {}
 function pspell_config_personal ($dictionary_link, $file) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Location of the main word list
  * @link http://php.net/manual/en/function.pspell-config-dict-dir.php
  * @param int $conf
@@ -267,7 +282,7 @@ function pspell_config_personal ($dictionary_link, $file) {}
 function pspell_config_dict_dir ($conf, $directory) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * location of language data files
  * @link http://php.net/manual/en/function.pspell-config-data-dir.php
  * @param int $conf
@@ -277,7 +292,8 @@ function pspell_config_dict_dir ($conf, $directory) {}
 function pspell_config_data_dir ($conf, $directory) {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Set a file that contains replacement pairs
  * @link http://php.net/manual/en/function.pspell-config-repl.php
  * @param int $dictionary_link
@@ -289,7 +305,8 @@ function pspell_config_data_dir ($conf, $directory) {}
 function pspell_config_repl ($dictionary_link, $file) {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Determine whether to save a replacement pairs list
 along with the wordlist
  * @link http://php.net/manual/en/function.pspell-config-save-repl.php

--- a/pthreads.php
+++ b/pthreads.php
@@ -306,7 +306,7 @@ class Threaded implements Traversable, Countable, ArrayAccess {
 
 
     /**
-     * (PHP 5 &gt;= 5.0.0)<br/>
+     * @since 5.0.0
      * Whether a offset exists
      * @link http://php.net/manual/en/arrayaccess.offsetexists.php
      * @param mixed $offset <p>
@@ -321,7 +321,7 @@ class Threaded implements Traversable, Countable, ArrayAccess {
     }
 
     /**
-     * (PHP 5 &gt;= 5.0.0)<br/>
+     * @since 5.0.0
      * Offset to retrieve
      * @link http://php.net/manual/en/arrayaccess.offsetget.php
      * @param mixed $offset <p>
@@ -333,7 +333,7 @@ class Threaded implements Traversable, Countable, ArrayAccess {
     }
 
     /**
-     * (PHP 5 &gt;= 5.0.0)<br/>
+     * @since 5.0.0
      * Offset to set
      * @link http://php.net/manual/en/arrayaccess.offsetset.php
      * @param mixed $offset <p>
@@ -348,7 +348,7 @@ class Threaded implements Traversable, Countable, ArrayAccess {
     }
 
     /**
-     * (PHP 5 &gt;= 5.0.0)<br/>
+     * @since 5.0.0
      * Offset to unset
      * @link http://php.net/manual/en/arrayaccess.offsetunset.php
      * @param mixed $offset <p>

--- a/readline.php
+++ b/readline.php
@@ -3,7 +3,8 @@
 // Start of readline v.5.5.3-1ubuntu2.1
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Reads a line
  * @link http://php.net/manual/en/function.readline.php
  * @param string $prompt [optional] <p>
@@ -15,7 +16,8 @@
 function readline ($prompt = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Gets/sets various internal readline variables
  * @link http://php.net/manual/en/function.readline-info.php
  * @param string $varname [optional] <p>
@@ -36,7 +38,8 @@ function readline ($prompt = null) {}
 function readline_info ($varname = null, $newvalue = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Adds a line to the history
  * @link http://php.net/manual/en/function.readline-add-history.php
  * @param string $line <p>
@@ -47,7 +50,8 @@ function readline_info ($varname = null, $newvalue = null) {}
 function readline_add_history ($line) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Clears the history
  * @link http://php.net/manual/en/function.readline-clear-history.php
  * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
@@ -55,7 +59,8 @@ function readline_add_history ($line) {}
 function readline_clear_history () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Lists the history
  * @link http://php.net/manual/en/function.readline-list-history.php
  * @return array an array of the entire command line history. The elements are
@@ -64,7 +69,8 @@ function readline_clear_history () {}
 function readline_list_history () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Reads the history
  * @link http://php.net/manual/en/function.readline-read-history.php
  * @param string $filename [optional] <p>
@@ -75,7 +81,8 @@ function readline_list_history () {}
 function readline_read_history ($filename = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Writes the history
  * @link http://php.net/manual/en/function.readline-write-history.php
  * @param string $filename [optional] <p>
@@ -86,7 +93,8 @@ function readline_read_history ($filename = null) {}
 function readline_write_history ($filename = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Registers a completion function
  * @link http://php.net/manual/en/function.readline-completion-function.php
  * @param callable $function <p>
@@ -98,7 +106,7 @@ function readline_write_history ($filename = null) {}
 function readline_completion_function (callable $function) {}
 
 /**
- * (PHP 5 &gt;= 5.1.0)<br/>
+ * @since 5.1.0
  * Initializes the readline callback interface and terminal, prints the prompt and returns immediately
  * @link http://php.net/manual/en/function.readline-callback-handler-install.php
  * @param string $prompt <p>
@@ -113,7 +121,7 @@ function readline_completion_function (callable $function) {}
 function readline_callback_handler_install ($prompt, callable $callback) {}
 
 /**
- * (PHP 5 &gt;= 5.1.0)<br/>
+ * @since 5.1.0
  * Reads a character and informs the readline callback interface when a line is received
  * @link http://php.net/manual/en/function.readline-callback-read-char.php
  * @return void No value is returned.
@@ -121,7 +129,7 @@ function readline_callback_handler_install ($prompt, callable $callback) {}
 function readline_callback_read_char () {}
 
 /**
- * (PHP 5 &gt;= 5.1.0)<br/>
+ * @since 5.1.0
  * Removes a previously installed callback handler and restores terminal settings
  * @link http://php.net/manual/en/function.readline-callback-handler-remove.php
  * @return bool <b>TRUE</b> if a previously installed callback handler was removed, or
@@ -130,7 +138,7 @@ function readline_callback_read_char () {}
 function readline_callback_handler_remove () {}
 
 /**
- * (PHP 5 &gt;= 5.1.0)<br/>
+ * @since 5.1.0
  * Redraws the display
  * @link http://php.net/manual/en/function.readline-redisplay.php
  * @return void No value is returned.
@@ -138,7 +146,7 @@ function readline_callback_handler_remove () {}
 function readline_redisplay () {}
 
 /**
- * (PHP 5 &gt;= 5.1.0)<br/>
+ * @since 5.1.0
  * Inform readline that the cursor has moved to a new line
  * @link http://php.net/manual/en/function.readline-on-new-line.php
  * @return void No value is returned.

--- a/recode.php
+++ b/recode.php
@@ -3,7 +3,8 @@
 // Start of recode v.
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Recode a string according to a recode request
  * @link http://php.net/manual/en/function.recode-string.php
  * @param string $request <p>
@@ -18,7 +19,8 @@
 function recode_string ($request, $string) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Recode from file to file according to recode request
  * @link http://php.net/manual/en/function.recode-file.php
  * @param string $request <p>
@@ -37,7 +39,8 @@ function recode_string ($request, $string) {}
 function recode_file ($request, $input, $output) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Alias of <b>recode_string</b>
  * @link http://php.net/manual/en/function.recode.php
  * @param $request

--- a/session.php
+++ b/session.php
@@ -3,7 +3,8 @@
 // Start of session v.
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get and/or set the current session name
  * @link http://php.net/manual/en/function.session-name.php
  * @param string $name [optional] <p>
@@ -25,7 +26,8 @@
 function session_name ($name = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get and/or set the current session module
  * @link http://php.net/manual/en/function.session-module-name.php
  * @param string $module [optional] <p>
@@ -37,7 +39,8 @@ function session_name ($name = null) {}
 function session_module_name ($module = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get and/or set the current session save path
  * @link http://php.net/manual/en/function.session-save-path.php
  * @param string $path [optional] <p>
@@ -57,7 +60,8 @@ function session_module_name ($module = null) {}
 function session_save_path ($path = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get and/or set the current session id
  * @link http://php.net/manual/en/function.session-id.php
  * @param string $id [optional] <p>
@@ -79,7 +83,8 @@ function session_save_path ($path = null) {}
 function session_id ($id = null) {}
 
 /**
- * (PHP 4 &gt;= 4.3.2, PHP 5)<br/>
+ * @since 4.3.2
+ * @since 5.0
  * Update the current session id with a newly generated one
  * @link http://php.net/manual/en/function.session-regenerate-id.php
  * @param bool $delete_old_session [optional] <p>
@@ -97,7 +102,8 @@ function session_regenerate_id ($delete_old_session = false) {}
 function session_register_shutdown  () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Decodes session data from a string
  * @link http://php.net/manual/en/function.session-decode.php
  * @param string $data <p>
@@ -108,7 +114,8 @@ function session_register_shutdown  () {}
 function session_decode ($data) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Register one or more global variables with the current session
  * @link http://php.net/manual/en/function.session-register.php
  * @param mixed $name <p>
@@ -122,7 +129,8 @@ function session_decode ($data) {}
 function session_register ($name, $_ = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Unregister a global variable from the current session
  * @link http://php.net/manual/en/function.session-unregister.php
  * @param string $name <p>
@@ -134,7 +142,8 @@ function session_register ($name, $_ = null) {}
 function session_unregister ($name) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Find out whether a global variable is registered in a session
  * @link http://php.net/manual/en/function.session-is-registered.php
  * @param string $name <p>
@@ -148,7 +157,8 @@ function session_unregister ($name) {}
 function session_is_registered ($name) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Encodes the current session data as a string
  * @link http://php.net/manual/en/function.session-encode.php
  * @return string the contents of the current session encoded.
@@ -156,7 +166,8 @@ function session_is_registered ($name) {}
 function session_encode () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Initialize session data
  * @link http://php.net/manual/en/function.session-start.php
  * @return bool This function returns true if a session was successfully started,
@@ -165,7 +176,8 @@ function session_encode () {}
 function session_start () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Destroys all data registered to a session
  * @link http://php.net/manual/en/function.session-destroy.php
  * @return bool true on success or false on failure.
@@ -173,7 +185,8 @@ function session_start () {}
 function session_destroy () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Free all session variables
  * @link http://php.net/manual/en/function.session-unset.php
  * @return void
@@ -181,7 +194,8 @@ function session_destroy () {}
 function session_unset () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Sets user-level session storage functions
  * @link http://php.net/manual/en/function.session-set-save-handler.php
  * @param callback $open <p>
@@ -238,7 +252,8 @@ function session_set_save_handler ($open, $close, $read, $write, $destroy, $gc) 
 function session_set_save_handler (SessionHandlerInterface $session_handler, $register_shutdown = true) {}
 
 /**
- * (PHP 4 &gt;= 4.0.3, PHP 5)<br/>
+ * @since 4.0.3
+ * @since 5.0
  * Get and/or set the current cache limiter
  * @link http://php.net/manual/en/function.session-cache-limiter.php
  * @param string $cache_limiter [optional] <p>
@@ -296,7 +311,8 @@ function session_set_save_handler (SessionHandlerInterface $session_handler, $re
 function session_cache_limiter ($cache_limiter = null) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Return current cache expire
  * @link http://php.net/manual/en/function.session-cache-expire.php
  * @param string $new_cache_expire [optional] <p>
@@ -314,7 +330,8 @@ function session_cache_limiter ($cache_limiter = null) {}
 function session_cache_expire ($new_cache_expire = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Set the session cookie parameters
  * @link http://php.net/manual/en/function.session-set-cookie-params.php
  * @param int $lifetime <p>
@@ -345,7 +362,8 @@ function session_cache_expire ($new_cache_expire = null) {}
 function session_set_cookie_params ($lifetime, $path = null, $domain = null, $secure = false, $httponly = false) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get the session cookie parameters
  * @link http://php.net/manual/en/function.session-get-cookie-params.php
  * @return array an array with the current session cookie information, the array
@@ -364,7 +382,8 @@ function session_set_cookie_params ($lifetime, $path = null, $domain = null, $se
 function session_get_cookie_params () {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Write session data and end session
  * @link http://php.net/manual/en/function.session-write-close.php
  * @return void
@@ -372,7 +391,8 @@ function session_get_cookie_params () {}
 function session_write_close () {}
 
 /**
- * (PHP 4 &gt;= 4.4.0, PHP 5)<br/>
+ * @since 4.4.0
+ * @since 5.0
  * Alias of <b>session_write_close</b>
  * @link http://php.net/manual/en/function.session-commit.php
  */

--- a/session.php
+++ b/session.php
@@ -124,7 +124,7 @@ function session_decode ($data) {}
  * </p>
  * @param mixed $_ [optional]
  * @return bool true on success or false on failure.
- * @deprecated This function has been DEPRECATED as of PHP 5.3.0 and REMOVED as of PHP 5.4.0.
+ * @deprecated 5.3.0 This function has been DEPRECATED as of PHP 5.3.0 and REMOVED as of PHP 5.4.0.
  */
 function session_register ($name, $_ = null) {}
 
@@ -137,7 +137,7 @@ function session_register ($name, $_ = null) {}
  * The variable name.
  * </p>
  * @return bool true on success or false on failure.
- * @deprecated This function has been DEPRECATED as of PHP 5.3.0 and REMOVED as of PHP 5.4.0.
+ * @deprecated 5.3.0 This function has been DEPRECATED as of PHP 5.3.0 and REMOVED as of PHP 5.4.0.
  */
 function session_unregister ($name) {}
 
@@ -152,7 +152,7 @@ function session_unregister ($name) {}
  * @return bool <b>session_is_registered</b> returns true if there is a
  * global variable with the name <i>name</i> registered in
  * the current session, false otherwise.
- * @deprecated This function has been DEPRECATED as of PHP 5.3.0 and REMOVED as of PHP 5.4.0.
+ * @deprecated 5.3.0 This function has been DEPRECATED as of PHP 5.3.0 and REMOVED as of PHP 5.4.0.
  */
 function session_is_registered ($name) {}
 

--- a/shmop.php
+++ b/shmop.php
@@ -3,7 +3,8 @@
 // Start of shmop v.
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Create or open shared memory block
  * @link http://php.net/manual/en/function.shmop-open.php
  * @param int $key <p>
@@ -30,7 +31,8 @@
 function shmop_open ($key, $flags, $mode, $size) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Read data from shared memory block
  * @link http://php.net/manual/en/function.shmop-read.php
  * @param int $shmid <p>
@@ -48,7 +50,8 @@ function shmop_open ($key, $flags, $mode, $size) {}
 function shmop_read ($shmid, $start, $count) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Close shared memory block
  * @link http://php.net/manual/en/function.shmop-close.php
  * @param int $shmid <p>
@@ -60,7 +63,8 @@ function shmop_read ($shmid, $start, $count) {}
 function shmop_close ($shmid) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Get size of shared memory block
  * @link http://php.net/manual/en/function.shmop-size.php
  * @param int $shmid <p>
@@ -73,7 +77,8 @@ function shmop_close ($shmid) {}
 function shmop_size ($shmid) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Write data into shared memory block
  * @link http://php.net/manual/en/function.shmop-write.php
  * @param int $shmid <p>
@@ -93,7 +98,8 @@ function shmop_size ($shmid) {}
 function shmop_write ($shmid, $data, $offset) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Delete shared memory block
  * @link http://php.net/manual/en/function.shmop-delete.php
  * @param int $shmid <p>

--- a/snmp.php
+++ b/snmp.php
@@ -87,7 +87,7 @@ class SNMP  {
 
 
 	/**
-	 * (PHP 5 &gt;= 5.4.0)<br/>
+	 * @since 5.4.0
 	 * Creates SNMP instance representing session to remote SNMP agent
 	 * @link http://php.net/manual/en/snmp.construct.php
 	 * @param $version SNMP protocol version:
@@ -129,7 +129,7 @@ class SNMP  {
 	public function __construct ($version, $hostname, $community, $timeout = 1000000, $retries = 5) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.4.0)<br/>
+	 * @since 5.4.0
 	 * Close SNMP session
 	 * @link http://php.net/manual/en/snmp.close.php
 	 * @return mixed <b>TRUE</b> on success or <b>FALSE</b> on failure.
@@ -137,7 +137,7 @@ class SNMP  {
 	public function close () {}
 
     /**
-     * (PHP 5 &gt;= 5.4.0)<br/>
+     * @since 5.4.0
      * Configures security-related SNMPv3 session parameters
      * @link http://php.net/manual/en/snmp.setsecurity.php
      * @param $sec_level string the security level (noAuthNoPriv|authNoPriv|authPriv)
@@ -152,7 +152,7 @@ class SNMP  {
 	public function setSecurity ($sec_level, $auth_protocol, $auth_passphrase, $priv_protocol, $priv_passphrase, $contextName, $contextEngineID) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.4.0)<br/>
+	 * @since 5.4.0
 	 * Fetch an SNMP object
 	 * @link http://php.net/manual/en/snmp.get.php
 	 * @param $object_id mixed The SNMP object (OID) or objects
@@ -163,7 +163,7 @@ class SNMP  {
 	public function get ($object_id, $preserve_keys = FALSE) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.4.0)<br/>
+	 * @since 5.4.0
 	 * Fetch an SNMP object which
      * follows the given object id
 	 * @link http://php.net/manual/en/snmp.getnext.php
@@ -176,7 +176,7 @@ class SNMP  {
 	public function getnext ($object_id) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.4.0)<br/>
+	 * @since 5.4.0
 	 * Fetch SNMP object subtree
 	 * @link http://php.net/manual/en/snmp.walk.php
 	 * @param $object_id string <p>Root of subtree to be fetched</p>
@@ -192,7 +192,7 @@ class SNMP  {
 	public function walk ($object_id, $suffix_as_keys = FALSE, $max_repetitions, $non_repeaters) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.4.0)<br/>
+	 * @since 5.4.0
 	 * Set the value of an SNMP object
 	 * @link http://php.net/manual/en/snmp.set.php
 	 * @param $object_id string <p>The SNMP object id</p>
@@ -265,7 +265,7 @@ class SNMP  {
 	public function set ($object_id, $type, $value) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.4.0)<br/>
+	 * @since 5.4.0
 	 * Get last error code
 	 * @link http://php.net/manual/en/snmp.geterrno.php
 	 * @return int one of SNMP error code values described in constants chapter.
@@ -273,7 +273,7 @@ class SNMP  {
 	public function getErrno () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.4.0)<br/>
+	 * @since 5.4.0
 	 * Get last error message
 	 * @link http://php.net/manual/en/snmp.geterror.php
 	 * @return string String describing error from last SNMP request.
@@ -301,7 +301,8 @@ class SNMPException extends RuntimeException  {
 }
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Fetch an SNMP object
  * @link http://php.net/manual/en/function.snmpget.php
  * @param string $hostname <p>
@@ -324,7 +325,7 @@ class SNMPException extends RuntimeException  {
 function snmpget ($hostname, $community, $object_id, $timeout = 1000000, $retries = 5) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Fetch the SNMP object which follows the given object id
  * @link http://php.net/manual/en/function.snmpgetnext.php
  * @param string $host <p>The hostname of the SNMP agent (server).</p>
@@ -338,7 +339,8 @@ function snmpget ($hostname, $community, $object_id, $timeout = 1000000, $retrie
 function snmpgetnext ($host, $community, $object_id, $timeout = 1000000, $retries = 5) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Fetch all the SNMP objects from an agent
  * @link http://php.net/manual/en/function.snmpwalk.php
  * @param string $hostname <p>
@@ -366,7 +368,8 @@ function snmpgetnext ($host, $community, $object_id, $timeout = 1000000, $retrie
 function snmpwalk ($hostname, $community, $object_id, $timeout = 1000000, $retries = 5) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Return all objects including their respective object ID within the specified one
  * @link http://php.net/manual/en/function.snmprealwalk.php
  * @param string $host <p>The hostname of the SNMP agent (server).</p>
@@ -380,7 +383,8 @@ function snmpwalk ($hostname, $community, $object_id, $timeout = 1000000, $retri
 function snmprealwalk ($host, $community, $object_id, $timeout = 1000000, $retries = 5) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Query for a tree of information about a network entity
  * @link http://php.net/manual/en/function.snmpwalkoid.php
  * @param string $hostname <p>
@@ -411,7 +415,8 @@ function snmprealwalk ($host, $community, $object_id, $timeout = 1000000, $retri
 function snmpwalkoid ($hostname, $community, $object_id, $timeout = 1000000, $retries = 5) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Set the value of an SNMP object
  * @link http://php.net/manual/en/function.snmpset.php
  * @param string $host <p>
@@ -477,7 +482,8 @@ function snmpwalkoid ($hostname, $community, $object_id, $timeout = 1000000, $re
 function snmpset ($host, $community, $object_id, $type, $value, $timeout = 1000000, $retries = 5) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Fetches the current value of the UCD library's quick_print setting
  * @link http://php.net/manual/en/function.snmp-get-quick-print.php
  * @return bool <b>TRUE</b> if quick_print is on, <b>FALSE</b> otherwise.
@@ -485,7 +491,8 @@ function snmpset ($host, $community, $object_id, $type, $value, $timeout = 10000
 function snmp_get_quick_print () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Set the value of <i>quick_print</i> within the UCD SNMP library
  * @link http://php.net/manual/en/function.snmp-set-quick-print.php
  * @param bool $quick_print
@@ -494,7 +501,8 @@ function snmp_get_quick_print () {}
 function snmp_set_quick_print ($quick_print) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Return all values that are enums with their enum value instead of the raw integer
  * @link http://php.net/manual/en/function.snmp-set-enum-print.php
  * @param int $enum_print <p>
@@ -505,7 +513,7 @@ function snmp_set_quick_print ($quick_print) {}
 function snmp_set_enum_print ($enum_print) {}
 
 /**
- * (PHP 5 &gt;= 5.2.0)<br/>
+ * @since 5.2.0
  * Set the OID output format
  * @link http://php.net/manual/en/function.snmp-set-oid-output-format.php
  * @param int $oid_format [optional] <table>
@@ -526,7 +534,8 @@ function snmp_set_enum_print ($enum_print) {}
 function snmp_set_oid_output_format ($oid_format = SNMP_OID_OUTPUT_MODULE) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Return all objects including their respective object id within the specified one
  * @link http://php.net/manual/en/function.snmp-set-oid-numeric-print.php
  * @param int $oid_format
@@ -535,7 +544,7 @@ function snmp_set_oid_output_format ($oid_format = SNMP_OID_OUTPUT_MODULE) {}
 function snmp_set_oid_numeric_print ($oid_format) {}
 
 /**
- * (PHP 5 &gt;= 5.2.0)<br/>
+ * @since 5.2.0
  * Fetch an SNMP object
  * @link http://php.net/manual/en/function.snmp2-get.php
  * @param string $host <p>
@@ -702,7 +711,8 @@ function snmp2_real_walk ($host, $community, $object_id, $timeout = 1000000, $re
 function snmp2_set ($host, $community, $object_id, $type, $value, $timeout = 1000000, $retries = 5) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Fetch an SNMP object
  * @link http://php.net/manual/en/function.snmp3-get.php
  * @param string $host <p>
@@ -740,7 +750,7 @@ function snmp2_set ($host, $community, $object_id, $type, $value, $timeout = 100
 function snmp3_get ($host, $sec_name, $sec_level, $auth_protocol, $auth_passphrase, $priv_protocol, $priv_passphrase, $object_id, $timeout = 1000000, $retries = 5) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Fetch the SNMP object which follows the given object id
  * @link http://php.net/manual/en/function.snmp3-getnext.php
  * @param string $host <p>
@@ -780,7 +790,8 @@ function snmp3_get ($host, $sec_name, $sec_level, $auth_protocol, $auth_passphra
 function snmp3_getnext ($host, $sec_name, $sec_level, $auth_protocol, $auth_passphrase, $priv_protocol, $priv_passphrase, $object_id, $timeout = 1000000, $retries = 5) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Fetch all the SNMP objects from an agent
  * @link http://php.net/manual/en/function.snmp3-walk.php
  * @param string $host <p>
@@ -825,7 +836,8 @@ function snmp3_getnext ($host, $sec_name, $sec_level, $auth_protocol, $auth_pass
 function snmp3_walk ($host, $sec_name, $sec_level, $auth_protocol, $auth_passphrase, $priv_protocol, $priv_passphrase, $object_id, $timeout = 1000000, $retries = 5) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Return all objects including their respective object ID within the specified one
  * @link http://php.net/manual/en/function.snmp3-real-walk.php
  * @param string $host <p>
@@ -866,7 +878,8 @@ function snmp3_walk ($host, $sec_name, $sec_level, $auth_protocol, $auth_passphr
 function snmp3_real_walk ($host, $sec_name, $sec_level, $auth_protocol, $auth_passphrase, $priv_protocol, $priv_passphrase, $object_id, $timeout = null, $retries = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Set the value of an SNMP object
  * @link http://php.net/manual/en/function.snmp3-set.php
  * @param string $host <p>
@@ -947,7 +960,8 @@ function snmp3_real_walk ($host, $sec_name, $sec_level, $auth_protocol, $auth_pa
 function snmp3_set ($host, $sec_name, $sec_level, $auth_protocol, $auth_passphrase, $priv_protocol, $priv_passphrase, $object_id, $type, $value, $timeout = 1000000, $retries = 5) {}
 
 /**
- * (PHP 4 &gt;= 4.3.3, PHP 5)<br/>
+ * @since 4.3.3
+ * @since 5.0
  * Specify the method how the SNMP values will be returned
  * @link http://php.net/manual/en/function.snmp-set-valueretrieval.php
  * @param int $method <table>
@@ -975,7 +989,8 @@ function snmp3_set ($host, $sec_name, $sec_level, $auth_protocol, $auth_passphra
 function snmp_set_valueretrieval ($method) {}
 
 /**
- * (PHP 4 &gt;= 4.3.3, PHP 5)<br/>
+ * @since 4.3.3
+ * @since 5.0
  * Return the method how the SNMP values will be returned
  * @link http://php.net/manual/en/function.snmp-get-valueretrieval.php
  * @return int OR-ed combitantion of constants ( <b>SNMP_VALUE_LIBRARY</b> or
@@ -985,7 +1000,7 @@ function snmp_set_valueretrieval ($method) {}
 function snmp_get_valueretrieval () {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Reads and parses a MIB file into the active MIB tree
  * @link http://php.net/manual/en/function.snmp-read-mib.php
  * @param string $filename <p>The filename of the MIB.</p>

--- a/soap.php
+++ b/soap.php
@@ -10,7 +10,7 @@
 class SoapClient  {
 
 	/**
-	 * (PHP 5 &gt;= 5.0.1)<br/>
+	 * @since 5.0.1
 	 * SoapClient constructor
 	 * @link http://php.net/manual/en/soapclient.soapclient.php
 	 * @param mixed $wsdl <p>
@@ -135,7 +135,7 @@ class SoapClient  {
 	public function SoapClient ($wsdl, array $options = null) {}
 
     /**
-     * (PHP 5 &gt;= 5.0.1)<br/>
+     * @since 5.0.1
      * SoapClient constructor
      * @link http://php.net/manual/en/soapclient.soapclient.php
      * @param mixed $wsdl <p>
@@ -260,7 +260,7 @@ class SoapClient  {
     public function __construct ($wsdl, array $options = null) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.0.1)<br/>
+	 * @since 5.0.1
 	 * Calls a SOAP function (deprecated)
 	 * @link http://php.net/manual/en/soapclient.call.php
 	 * @param string $function_name
@@ -270,7 +270,7 @@ class SoapClient  {
 	public function __call ($function_name, $arguments) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.0.1)<br/>
+	 * @since 5.0.1
 	 * Calls a SOAP function
 	 * @link http://php.net/manual/en/soapclient.soapcall.php
 	 * @param string $function_name <p>
@@ -313,7 +313,7 @@ class SoapClient  {
 	public function __soapCall ($function_name, array $arguments, array $options = null, $input_headers = null, array &$output_headers = null) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.0.1)<br/>
+	 * @since 5.0.1
 	 * Returns last SOAP request
 	 * @link http://php.net/manual/en/soapclient.getlastrequest.php
 	 * @return string The last SOAP request, as an XML string.
@@ -321,7 +321,7 @@ class SoapClient  {
 	public function __getLastRequest () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.0.1)<br/>
+	 * @since 5.0.1
 	 * Returns last SOAP response
 	 * @link http://php.net/manual/en/soapclient.getlastresponse.php
 	 * @return string The last SOAP response, as an XML string.
@@ -329,7 +329,7 @@ class SoapClient  {
 	public function __getLastResponse () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.0.1)<br/>
+	 * @since 5.0.1
 	 * Returns the SOAP headers from the last request
 	 * @link http://php.net/manual/en/soapclient.getlastrequestheaders.php
 	 * @return string The last SOAP request headers.
@@ -337,7 +337,7 @@ class SoapClient  {
 	public function __getLastRequestHeaders () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.0.1)<br/>
+	 * @since 5.0.1
 	 * Returns the SOAP headers from the last response
 	 * @link http://php.net/manual/en/soapclient.getlastresponseheaders.php
 	 * @return string The last SOAP response headers.
@@ -345,7 +345,7 @@ class SoapClient  {
 	public function __getLastResponseHeaders () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.0.1)<br/>
+	 * @since 5.0.1
 	 * Returns list of available SOAP functions
 	 * @link http://php.net/manual/en/soapclient.getfunctions.php
 	 * @return array The array of SOAP function prototypes, detailing the return type,
@@ -354,7 +354,7 @@ class SoapClient  {
 	public function __getFunctions () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.0.1)<br/>
+	 * @since 5.0.1
 	 * Returns a list of SOAP types
 	 * @link http://php.net/manual/en/soapclient.gettypes.php
 	 * @return array The array of SOAP types, detailing all structures and types.
@@ -362,7 +362,7 @@ class SoapClient  {
 	public function __getTypes () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.0.1)<br/>
+	 * @since 5.0.1
 	 * Performs a SOAP request
 	 * @link http://php.net/manual/en/soapclient.dorequest.php
 	 * @param string $request <p>
@@ -386,7 +386,7 @@ class SoapClient  {
 	public function __doRequest ($request, $location, $action, $version, $one_way = 0) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.0.4)<br/>
+	 * @since 5.0.4
 	 * The __setCookie purpose
 	 * @link http://php.net/manual/en/soapclient.setcookie.php
 	 * @param string $name <p>
@@ -400,7 +400,7 @@ class SoapClient  {
 	public function __setCookie ($name, $value = null) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.0.1)<br/>
+	 * @since 5.0.1
 	 * Sets the location of the Web service to use
 	 * @link http://php.net/manual/en/soapclient.setlocation.php
 	 * @param string $new_location [optional] <p>
@@ -411,7 +411,7 @@ class SoapClient  {
 	public function __setLocation ($new_location = null) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.0.5)<br/>
+	 * @since 5.0.5
 	 * Sets SOAP headers for subsequent calls
 	 * @link http://php.net/manual/en/soapclient.setsoapheaders.php
 	 * @param mixed $soapheaders [optional] <p>
@@ -432,7 +432,7 @@ class SoapClient  {
 class SoapVar  {
 
 	/**
-	 * (PHP 5 &gt;= 5.0.1)<br/>
+	 * @since 5.0.1
 	 * SoapVar constructor
 	 * @link http://php.net/manual/en/soapvar.soapvar.php
 	 * @param mixed $data <p>
@@ -465,7 +465,7 @@ class SoapVar  {
 class SoapServer  {
 
 	/**
-	 * (PHP 5 &gt;= 5.0.1)<br/>
+	 * @since 5.0.1
 	 * SoapServer constructor
 	 * @link http://php.net/manual/en/soapserver.soapserver.php
 	 * @param mixed $wsdl <p>
@@ -507,7 +507,7 @@ class SoapServer  {
 	public function SoapServer ($wsdl, array $options = null) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.1.2)<br/>
+	 * @since 5.1.2
 	 * Sets SoapServer persistence mode
 	 * @link http://php.net/manual/en/soapserver.setpersistence.php
 	 * @param int $mode <p>
@@ -529,7 +529,7 @@ class SoapServer  {
 	public function setPersistence ($mode) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.0.1)<br/>
+	 * @since 5.0.1
 	 * Sets the class which handles SOAP requests
 	 * @link http://php.net/manual/en/soapserver.setclass.php
 	 * @param string $class_name <p>
@@ -545,7 +545,7 @@ class SoapServer  {
 	public function setClass ($class_name, $args = null, $_ = null) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.2.0)<br/>
+	 * @since 5.2.0
 	 * Sets the object which will be used to handle SOAP requests
 	 * @link http://php.net/manual/en/soapserver.setobject.php
 	 * @param object $object <p>
@@ -556,7 +556,7 @@ class SoapServer  {
 	public function setObject ($object) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.0.1)<br/>
+	 * @since 5.0.1
 	 * Adds one or more functions to handle SOAP requests
 	 * @link http://php.net/manual/en/soapserver.addfunction.php
 	 * @param mixed $functions <p>
@@ -580,7 +580,7 @@ class SoapServer  {
 	public function addFunction ($functions) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.0.1)<br/>
+	 * @since 5.0.1
 	 * Returns list of defined functions
 	 * @link http://php.net/manual/en/soapserver.getfunctions.php
 	 * @return array An array of the defined functions.
@@ -588,7 +588,7 @@ class SoapServer  {
 	public function getFunctions () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.0.1)<br/>
+	 * @since 5.0.1
 	 * Handles a SOAP request
 	 * @link http://php.net/manual/en/soapserver.handle.php
 	 * @param string $soap_request [optional] <p>
@@ -600,7 +600,7 @@ class SoapServer  {
 	public function handle ($soap_request = null) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.0.1)<br/>
+	 * @since 5.0.1
 	 * Issue SoapServer fault indicating an error
 	 * @link http://php.net/manual/en/soapserver.fault.php
 	 * @param string $code <p>
@@ -623,7 +623,7 @@ class SoapServer  {
 	public function fault ($code, $string, $actor = null, $details = null, $name = null) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.0.1)<br/>
+	 * @since 5.0.1
 	 * Add a SOAP header to the response
 	 * @link http://php.net/manual/en/soapserver.addsoapheader.php
 	 * @param SoapHeader $object <p>
@@ -641,7 +641,7 @@ class SoapServer  {
  */
 class SoapFault extends Exception  {
 	/**
-	 * (PHP 5 &gt;= 5.0.1)<br/>
+	 * @since 5.0.1
 	 * SoapFault constructor
 	 * @link http://php.net/manual/en/soapfault.soapfault.php
 	 * @param string $faultcode <p>
@@ -667,7 +667,7 @@ class SoapFault extends Exception  {
 	public function SoapFault ($faultcode, $faultstring, $faultactor = null, $detail = null, $faultname = null, $headerfault = null) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.0.1)<br/>
+	 * @since 5.0.1
 	 * Obtain a string representation of a SoapFault
 	 * @link http://php.net/manual/en/soapfault.tostring.php
 	 * @return string A string describing the SoapFault.
@@ -684,7 +684,7 @@ class SoapFault extends Exception  {
 class SoapParam  {
 
 	/**
-	 * (PHP 5 &gt;= 5.0.1)<br/>
+	 * @since 5.0.1
 	 * SoapParam constructor
 	 * @link http://php.net/manual/en/soapparam.soapparam.php
 	 * @param mixed $data <p>
@@ -707,7 +707,7 @@ class SoapParam  {
 class SoapHeader  {
 
 	/**
-	 * (PHP 5 &gt;= 5.0.1)<br/>
+	 * @since 5.0.1
 	 * SoapHeader constructor
 	 * @link http://php.net/manual/en/soapheader.soapheader.php
 	 * @param string $namespace <p>
@@ -829,25 +829,25 @@ define ('WSDL_CACHE_MEMORY', 2);
 define ('WSDL_CACHE_BOTH', 3);
 
 /**
- * Since PHP 5.5.0.
+ * @since 5.5.0
  * @link http://php.net/manual/en/soap.constants.php
  */
 define ('SOAP_SSL_METHOD_TLS', 0);
 
 /**
- * Since PHP 5.5.0.
+ * @since 5.5.0
  * @link http://php.net/manual/en/soap.constants.php
  */
 define ('SOAP_SSL_METHOD_SSLv2', 1);
 
 /**
- * Since PHP 5.5.0.
+ * @since 5.5.0
  * @link http://php.net/manual/en/soap.constants.php
  */
 define ('SOAP_SSL_METHOD_SSLv3', 2);
 
 /**
- * Since PHP 5.5.0.
+ * @since 5.5.0
  * @link http://php.net/manual/en/soap.constants.php
  */
 define ('SOAP_SSL_METHOD_SSLv23', 3);

--- a/sockets.php
+++ b/sockets.php
@@ -3,7 +3,8 @@
 // Start of sockets v.
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Runs the select() system call on the given arrays of sockets with a specified timeout
  * @link http://php.net/manual/en/function.socket-select.php
  * @param array $read <p>
@@ -54,7 +55,8 @@
 function socket_select (array &$read, array &$write, array &$except, $tv_sec, $tv_usec = 0) {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Create a socket (endpoint for communication)
  * @link http://php.net/manual/en/function.socket-create.php
  * @param int $domain <p>
@@ -193,7 +195,8 @@ function socket_select (array &$read, array &$write, array &$except, $tv_sec, $t
 function socket_create ($domain, $type, $protocol) {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Opens a socket on port to accept connections
  * @link http://php.net/manual/en/function.socket-create-listen.php
  * @param int $port <p>
@@ -215,7 +218,8 @@ function socket_create ($domain, $type, $protocol) {}
 function socket_create_listen ($port, $backlog = 128) {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Creates a pair of indistinguishable sockets and stores them in an array
  * @link http://php.net/manual/en/function.socket-create-pair.php
  * @param int $domain <p>
@@ -249,7 +253,8 @@ function socket_create_listen ($port, $backlog = 128) {}
 function socket_create_pair ($domain, $type, $protocol, array &$fd) {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Accepts a connection on a socket
  * @link http://php.net/manual/en/function.socket-accept.php
  * @param resource $socket <p>
@@ -264,7 +269,8 @@ function socket_create_pair ($domain, $type, $protocol, array &$fd) {}
 function socket_accept ($socket) {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Sets nonblocking mode for file descriptor fd
  * @link http://php.net/manual/en/function.socket-set-nonblock.php
  * @param resource $socket <p>
@@ -276,7 +282,8 @@ function socket_accept ($socket) {}
 function socket_set_nonblock ($socket) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Sets blocking mode on a socket resource
  * @link http://php.net/manual/en/function.socket-set-block.php
  * @param resource $socket <p>
@@ -288,7 +295,8 @@ function socket_set_nonblock ($socket) {}
 function socket_set_block ($socket) {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Listens for a connection on a socket
  * @link http://php.net/manual/en/function.socket-listen.php
  * @param resource $socket <p>
@@ -318,7 +326,8 @@ function socket_set_block ($socket) {}
 function socket_listen ($socket, $backlog = 0) {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Closes a socket resource
  * @link http://php.net/manual/en/function.socket-close.php
  * @param resource $socket <p>
@@ -339,7 +348,8 @@ function socket_close ($socket) {}
 function socket_cmsg_space ($level , $type ) {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Write to a socket
  * @link http://php.net/manual/en/function.socket-write.php
  * @param resource $socket
@@ -367,7 +377,8 @@ function socket_cmsg_space ($level , $type ) {}
 function socket_write ($socket, $buffer, $length = 0) {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Reads a maximum of length bytes from a socket
  * @link http://php.net/manual/en/function.socket-read.php
  * @param resource $socket <p>
@@ -399,7 +410,8 @@ function socket_write ($socket, $buffer, $length = 0) {}
 function socket_read ($socket, $length, $type = PHP_BINARY_READ) {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Queries the local side of the given socket which may either result in host/port or in a Unix filesystem path, dependent on its type
  * @link http://php.net/manual/en/function.socket-getsockname.php
  * @param resource $socket <p>
@@ -431,7 +443,8 @@ function socket_read ($socket, $length, $type = PHP_BINARY_READ) {}
 function socket_getsockname ($socket, &$addr, &$port = null) {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Queries the remote side of the given socket which may either result in host/port or in a Unix filesystem path, dependent on its type
  * @link http://php.net/manual/en/function.socket-getpeername.php
  * @param resource $socket <p>
@@ -465,7 +478,8 @@ function socket_getsockname ($socket, &$addr, &$port = null) {}
 function socket_getpeername ($socket, &$address, &$port = null) {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Initiates a connection on a socket
  * @link http://php.net/manual/en/function.socket-connect.php
  * @param resource $socket
@@ -496,7 +510,8 @@ function socket_getpeername ($socket, &$address, &$port = null) {}
 function socket_connect ($socket, $address, $port = 0) {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Return a string describing a socket error
  * @link http://php.net/manual/en/function.socket-strerror.php
  * @param int $errno <p>
@@ -509,7 +524,8 @@ function socket_connect ($socket, $address, $port = 0) {}
 function socket_strerror ($errno) {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Binds a name to a socket
  * @link http://php.net/manual/en/function.socket-bind.php
  * @param resource $socket <p>
@@ -540,7 +556,8 @@ function socket_strerror ($errno) {}
 function socket_bind ($socket, $address, $port = 0) {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Receives data from a connected socket
  * @link http://php.net/manual/en/function.socket-recv.php
  * @param resource $socket <p>
@@ -605,7 +622,8 @@ function socket_bind ($socket, $address, $port = 0) {}
 function socket_recv ($socket, &$buf, $len, $flags) {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Sends data to a connected socket
  * @link http://php.net/manual/en/function.socket-send.php
  * @param resource $socket <p>
@@ -669,7 +687,8 @@ function socket_send ($socket, $buf, $len, $flags) {}
 function socket_sendmsg ($socket, array $message, $flags ) {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Receives data from a socket whether or not it is connection-oriented
  * @link http://php.net/manual/en/function.socket-recvfrom.php
  * @param resource $socket <p>
@@ -754,7 +773,8 @@ function socket_recvfrom ($socket, &$buf, $len, $flags, &$name, &$port = null) {
  */
 function socket_recvmsg ($socket , $message, $flags) {}
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Sends a message to a socket, whether it is connected or not
  * @link http://php.net/manual/en/function.socket-sendto.php
  * @param resource $socket <p>
@@ -814,7 +834,8 @@ function socket_recvmsg ($socket , $message, $flags) {}
 function socket_sendto ($socket, $buf, $len, $flags, $addr, $port = 0) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Gets socket options for the socket
  * @link http://php.net/manual/en/function.socket-get-option.php
  * @param resource $socket <p>
@@ -1181,7 +1202,8 @@ function socket_sendto ($socket, $buf, $len, $flags, $addr, $port = 0) {}
 function socket_get_option ($socket, $level, $optname) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Sets socket options for the socket
  * @link http://php.net/manual/en/function.socket-set-option.php
  * @param resource $socket <p>
@@ -1209,7 +1231,8 @@ function socket_get_option ($socket, $level, $optname) {}
 function socket_set_option ($socket, $level, $optname, $optval) {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Shuts down a socket for receiving, sending, or both
  * @link http://php.net/manual/en/function.socket-shutdown.php
  * @param resource $socket <p>
@@ -1244,7 +1267,8 @@ function socket_set_option ($socket, $level, $optname, $optval) {}
 function socket_shutdown ($socket, $how = 2) {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Returns the last error on the socket
  * @link http://php.net/manual/en/function.socket-last-error.php
  * @param resource $socket [optional] <p>
@@ -1255,7 +1279,8 @@ function socket_shutdown ($socket, $how = 2) {}
 function socket_last_error ($socket = null) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Clears the error on the socket or the last error code
  * @link http://php.net/manual/en/function.socket-clear-error.php
  * @param resource $socket [optional] <p>
@@ -1266,7 +1291,7 @@ function socket_last_error ($socket = null) {}
 function socket_clear_error ($socket = null) {}
 
 /**
- * (PHP 5 &gt;= 5.4.0)<br/>
+ * @since 5.4.0
  * Import a stream
  * @link http://php.net/manual/en/function.socket-import-stream.php
  * @param resource $stream <p>
@@ -1277,7 +1302,7 @@ function socket_clear_error ($socket = null) {}
 function socket_import_stream ($stream) {}
 
 /**
- * (PHP 5 &gt;= 5.5.0)<br/>
+ * @since 5.5.0
  * Send a message
  * @link http://php.net/manual/en/function.socket-sendmsg.php
  * @param resource $socket
@@ -1288,7 +1313,7 @@ function socket_import_stream ($stream) {}
 function socket_sendmsg ($socket, array $message, $flags) {}
 
 /**
- * (PHP 5 &gt;= 5.5.0)<br/>
+ * @since 5.5.0
  * Read a message
  * @link http://php.net/manual/en/function.socket-recvmsg.php
  * @param resource $socket
@@ -1299,7 +1324,7 @@ function socket_sendmsg ($socket, array $message, $flags) {}
 function socket_recvmsg ($socket, $message, $flags = null) {}
 
 /**
- * (PHP 5 &gt;= 5.5.0)<br/>
+ * @since 5.5.0
  * Calculate message buffer size
  * @link http://php.net/manual/en/function.socket-cmsg-space.php
  * @param int $level

--- a/sqlite3.php
+++ b/sqlite3.php
@@ -9,7 +9,7 @@
 class SQLite3  {
 
 	/**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
 	 * Opens an SQLite database
 	 * @link http://php.net/manual/en/sqlite3.open.php
 	 * @param string $filename <p>
@@ -31,7 +31,7 @@ class SQLite3  {
 	public function open ($filename, $flags = 'SQLITE3_OPEN_READWRITE | SQLITE3_OPEN_CREATE', $encryption_key = null) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
 	 * Closes the database connection
 	 * @link http://php.net/manual/en/sqlite3.close.php
 	 * @return bool <b>TRUE</b> on success, <b>FALSE</b> on failure.
@@ -39,7 +39,7 @@ class SQLite3  {
 	public function close () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
 	 * Executes a result-less query against a given database
 	 * @link http://php.net/manual/en/sqlite3.exec.php
 	 * @param string $query <p>
@@ -51,7 +51,7 @@ class SQLite3  {
 	public function exec ($query) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
 	 * Returns the SQLite3 library version as a string constant and as a number
 	 * @link http://php.net/manual/en/sqlite3.version.php
 	 * @return array an associative array with the keys "versionString" and
@@ -60,7 +60,7 @@ class SQLite3  {
 	public static function version () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
 	 * Returns the row ID of the most recent INSERT into the database
 	 * @link http://php.net/manual/en/sqlite3.lastinsertrowid.php
 	 * @return int the row ID of the most recent INSERT into the database
@@ -68,7 +68,7 @@ class SQLite3  {
 	public function lastInsertRowID () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
 	 * Returns the numeric result code of the most recent failed SQLite request
 	 * @link http://php.net/manual/en/sqlite3.lasterrorcode.php
 	 * @return int an integer value representing the numeric result code of the most
@@ -77,7 +77,7 @@ class SQLite3  {
 	public function lastErrorCode () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
 	 * Returns English text describing the most recent failed SQLite request
 	 * @link http://php.net/manual/en/sqlite3.lasterrormsg.php
 	 * @return string an English string describing the most recent failed SQLite request.
@@ -85,7 +85,7 @@ class SQLite3  {
 	public function lastErrorMsg () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.3.3)<br/>
+	 * @since 5.3.3
 	 * Sets the busy connection handler
 	 * @link http://php.net/manual/en/sqlite3.busytimeout.php
 	 * @param int $msecs <p>
@@ -97,7 +97,7 @@ class SQLite3  {
 	public function busyTimeout ($msecs) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
 	 * Attempts to load an SQLite extension library
 	 * @link http://php.net/manual/en/sqlite3.loadextension.php
 	 * @param string $shared_library <p>
@@ -109,7 +109,7 @@ class SQLite3  {
 	public function loadExtension ($shared_library) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
 	 * Returns the number of database rows that were changed (or inserted or
 deleted) by the most recent SQL statement
 	 * @link http://php.net/manual/en/sqlite3.changes.php
@@ -120,7 +120,7 @@ deleted) by the most recent SQL statement
 	public function changes () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
 	 * Returns a string that has been properly escaped
 	 * @link http://php.net/manual/en/sqlite3.escapestring.php
 	 * @param string $value <p>
@@ -132,7 +132,7 @@ deleted) by the most recent SQL statement
 	public static function escapeString ($value) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
 	 * Prepares an SQL statement for execution
 	 * @link http://php.net/manual/en/sqlite3.prepare.php
 	 * @param string $query <p>
@@ -143,7 +143,7 @@ deleted) by the most recent SQL statement
 	public function prepare ($query) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
 	 * Executes an SQL query
 	 * @link http://php.net/manual/en/sqlite3.query.php
 	 * @param string $query <p>
@@ -155,7 +155,7 @@ deleted) by the most recent SQL statement
 	public function query ($query) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
 	 * Executes a query and returns a single result
 	 * @link http://php.net/manual/en/sqlite3.querysingle.php
 	 * @param string $query <p>
@@ -181,7 +181,7 @@ deleted) by the most recent SQL statement
 	public function querySingle ($query, $entire_row = false) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
 	 * Registers a PHP function for use as an SQL scalar function
 	 * @link http://php.net/manual/en/sqlite3.createfunction.php
 	 * @param string $name <p>
@@ -201,7 +201,7 @@ deleted) by the most recent SQL statement
 	public function createFunction ($name, $callback, $argument_count = -1) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
 	 * Registers a PHP function for use as an SQL aggregate function
 	 * @link http://php.net/manual/en/sqlite3.createaggregate.php
 	 * @param string $name <p>
@@ -226,7 +226,7 @@ deleted) by the most recent SQL statement
 	public function createAggregate ($name, $step_callback, $final_callback, $argument_count = -1) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.3.11)<br/>
+	 * @since 5.3.11
 	 * Registers a PHP function for use as an SQL collating function
 	 * @link http://php.net/manual/en/sqlite3.createcollation.php
 	 * @param string $name <p>
@@ -257,7 +257,7 @@ deleted) by the most recent SQL statement
 	public function enableExceptions ($enableExceptions) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
 	 * Instantiates an SQLite3 object and opens an SQLite 3 database
 	 * @link http://php.net/manual/en/sqlite3.construct.php
 	 * @param string $filename <p>
@@ -286,7 +286,7 @@ deleted) by the most recent SQL statement
 class SQLite3Stmt  {
 
 	/**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
 	 * Returns the number of parameters within the prepared statement
 	 * @link http://php.net/manual/en/sqlite3stmt.paramcount.php
 	 * @return int the number of parameters within the prepared statement.
@@ -294,7 +294,7 @@ class SQLite3Stmt  {
 	public function paramCount () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
 	 * Closes the prepared statement
 	 * @link http://php.net/manual/en/sqlite3stmt.close.php
 	 * @return bool <b>TRUE</b>
@@ -302,7 +302,7 @@ class SQLite3Stmt  {
 	public function close () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
 	 * Resets the prepared statement
 	 * @link http://php.net/manual/en/sqlite3stmt.reset.php
 	 * @return bool <b>TRUE</b> if the statement is successfully reset, <b>FALSE</b> on failure.
@@ -310,7 +310,7 @@ class SQLite3Stmt  {
 	public function reset () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
 	 * Clears all current bound parameters
 	 * @link http://php.net/manual/en/sqlite3stmt.clear.php
 	 * @return bool <b>TRUE</b> on successful clearing of bound parameters, <b>FALSE</b> on
@@ -319,7 +319,7 @@ class SQLite3Stmt  {
 	public function clear () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
 	 * Executes a prepared statement and returns a result set object
 	 * @link http://php.net/manual/en/sqlite3stmt.execute.php
 	 * @return SQLite3Result an <b>SQLite3Result</b> object on successful execution of the prepared
@@ -328,7 +328,7 @@ class SQLite3Stmt  {
 	public function execute () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
 	 * Binds a parameter to a statement variable
 	 * @link http://php.net/manual/en/sqlite3stmt.bindparam.php
 	 * @param string $sql_param <p>
@@ -351,7 +351,7 @@ class SQLite3Stmt  {
 	public function bindParam ($sql_param, &$param, $type = null) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
 	 * Binds the value of a parameter to a statement variable
 	 * @link http://php.net/manual/en/sqlite3stmt.bindvalue.php
 	 * @param string $sql_param <p>
@@ -389,7 +389,7 @@ class SQLite3Stmt  {
 class SQLite3Result  {
 
 	/**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
 	 * Returns the number of columns in the result set
 	 * @link http://php.net/manual/en/sqlite3result.numcolumns.php
 	 * @return int the number of columns in the result set.
@@ -397,7 +397,7 @@ class SQLite3Result  {
 	public function numColumns () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
 	 * Returns the name of the nth column
 	 * @link http://php.net/manual/en/sqlite3result.columnname.php
 	 * @param int $column_number <p>
@@ -409,7 +409,7 @@ class SQLite3Result  {
 	public function columnName ($column_number) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
 	 * Returns the type of the nth column
 	 * @link http://php.net/manual/en/sqlite3result.columntype.php
 	 * @param int $column_number <p>
@@ -424,7 +424,7 @@ class SQLite3Result  {
 	public function columnType ($column_number) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
 	 * Fetches a result row as an associative or numerically indexed array or both
 	 * @link http://php.net/manual/en/sqlite3result.fetcharray.php
 	 * @param int $mode [optional] <p>
@@ -441,7 +441,7 @@ class SQLite3Result  {
 	public function fetchArray ($mode = 'SQLITE3_BOTH') {}
 
 	/**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
 	 * Resets the result set back to the first row
 	 * @link http://php.net/manual/en/sqlite3result.reset.php
 	 * @return bool <b>TRUE</b> if the result set is successfully reset
@@ -450,7 +450,7 @@ class SQLite3Result  {
 	public function reset () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.3.0)<br/>
+	 * @since 5.3.0
 	 * Closes the result set
 	 * @link http://php.net/manual/en/sqlite3result.finalize.php
 	 * @return bool <b>TRUE</b>.

--- a/standard_0.php
+++ b/standard_0.php
@@ -57,7 +57,8 @@ class Directory  {
 }
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Returns the value of a constant
  * @link http://php.net/manual/en/function.constant.php
  * @param string $name <p>
@@ -69,7 +70,8 @@ class Directory  {
 function constant ($name) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Convert binary data into hexadecimal representation
  * @link http://php.net/manual/en/function.bin2hex.php
  * @param string $str <p>
@@ -80,7 +82,8 @@ function constant ($name) {}
 function bin2hex ($str) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Delay execution
  * @link http://php.net/manual/en/function.sleep.php
  * @param int $seconds <p>
@@ -93,7 +96,8 @@ function bin2hex ($str) {}
 function sleep ($seconds) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Delay execution in microseconds
  * @link http://php.net/manual/en/function.usleep.php
  * @param int $micro_seconds <p>
@@ -105,7 +109,7 @@ function sleep ($seconds) {}
 function usleep ($micro_seconds) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Delay for a number of seconds and nanoseconds
  * @link http://php.net/manual/en/function.time-nanosleep.php
  * @param int $seconds <p>
@@ -127,7 +131,7 @@ function usleep ($micro_seconds) {}
 function time_nanosleep ($seconds, $nanoseconds) {}
 
 /**
- * (PHP 5 &gt;= 5.1.0)<br/>
+ * @since 5.1.0
  * Make the script sleep until the specified time
  * @link http://php.net/manual/en/function.time-sleep-until.php
  * @param float $timestamp <p>
@@ -138,7 +142,7 @@ function time_nanosleep ($seconds, $nanoseconds) {}
 function time_sleep_until ($timestamp) {}
 
 /**
- * (PHP 5 &gt;= 5.1.0)<br/>
+ * @since 5.1.0
  * Parse a time/date generated with <function>strftime</function>
  * @link http://php.net/manual/en/function.strptime.php
  * @param string $date <p>
@@ -203,7 +207,8 @@ function time_sleep_until ($timestamp) {}
 function strptime ($date, $format) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Flush the output buffer
  * @link http://php.net/manual/en/function.flush.php
  * @return void 
@@ -211,7 +216,8 @@ function strptime ($date, $format) {}
 function flush () {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Wraps a string to a given number of characters
  * @link http://php.net/manual/en/function.wordwrap.php
  * @param string $str <p>
@@ -235,7 +241,8 @@ function flush () {}
 function wordwrap ($str, $width = 75, $break = "\n", $cut = false) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Convert special characters to HTML entities
  * @link http://php.net/manual/en/function.htmlspecialchars.php
  * @param string $string <p>
@@ -355,7 +362,8 @@ function wordwrap ($str, $width = 75, $break = "\n", $cut = false) {}
 function htmlspecialchars ($string, $flags = ENT_COMPAT, $encoding = 'UTF-8', $double_encode = true) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Convert all applicable characters to HTML entities
  * @link http://php.net/manual/en/function.htmlentities.php
  * @param string $string <p>
@@ -402,7 +410,8 @@ function htmlspecialchars ($string, $flags = ENT_COMPAT, $encoding = 'UTF-8', $d
 function htmlentities ($string, $quote_style = null, $charset = null, $double_encode = null) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Convert all HTML entities to their applicable characters
  * @link http://php.net/manual/en/function.html-entity-decode.php
  * @param string $string <p>
@@ -444,7 +453,7 @@ function htmlentities ($string, $quote_style = null, $charset = null, $double_en
 function html_entity_decode ($string, $quote_style = null, $charset = null) {}
 
 /**
- * (PHP 5 &gt;= 5.1.0)<br/>
+ * @since 5.1.0
  * Convert special HTML entities back to characters
  * @link http://php.net/manual/en/function.htmlspecialchars-decode.php
  * @param string $string <p>
@@ -478,7 +487,8 @@ function html_entity_decode ($string, $quote_style = null, $charset = null) {}
 function htmlspecialchars_decode ($string, $quote_style = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Returns the translation table used by <function>htmlspecialchars</function> and <function>htmlentities</function>
  * @link http://php.net/manual/en/function.get-html-translation-table.php
  * @param int $table [optional] <p>
@@ -498,7 +508,8 @@ function htmlspecialchars_decode ($string, $quote_style = null) {}
 function get_html_translation_table ($table = null, $quote_style = null) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Calculate the sha1 hash of a string
  * @link http://php.net/manual/en/function.sha1.php
  * @param string $str <p>
@@ -515,7 +526,8 @@ function get_html_translation_table ($table = null, $quote_style = null) {}
 function sha1 ($str, $raw_output = null) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Calculate the sha1 hash of a file
  * @link http://php.net/manual/en/function.sha1-file.php
  * @param string $filename <p>
@@ -530,7 +542,8 @@ function sha1 ($str, $raw_output = null) {}
 function sha1_file ($filename, $raw_output = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Calculate the md5 hash of a string
  * @link http://php.net/manual/en/function.md5.php
  * @param string $str <p>
@@ -546,7 +559,8 @@ function sha1_file ($filename, $raw_output = null) {}
 function md5 ($str, $raw_output = null) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Calculates the md5 hash of a given file
  * @link http://php.net/manual/en/function.md5-file.php
  * @param string $filename <p>
@@ -561,7 +575,8 @@ function md5 ($str, $raw_output = null) {}
 function md5_file ($filename, $raw_output = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.1, PHP 5)<br/>
+ * @since 4.0.1
+ * @since 5.0
  * Calculates the crc32 polynomial of a string
  * @link http://php.net/manual/en/function.crc32.php
  * @param string $str <p>
@@ -572,7 +587,8 @@ function md5_file ($filename, $raw_output = null) {}
 function crc32 ($str) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Parse a binary IPTC block into single tags.
  * @link http://php.net/manual/en/function.iptcparse.php
  * @param string $iptcblock <p>
@@ -584,7 +600,8 @@ function crc32 ($str) {}
 function iptcparse ($iptcblock) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Embeds binary IPTC data into a JPEG image
  * @link http://php.net/manual/en/function.iptcembed.php
  * @param string $iptcdata <p>
@@ -603,7 +620,8 @@ function iptcparse ($iptcblock) {}
 function iptcembed ($iptcdata, $jpeg_file_name, $spool = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get the size of an image
  * @link http://php.net/manual/en/function.getimagesize.php
  * @param string $filename <p>
@@ -679,7 +697,7 @@ function getimagesize ($filename, array &$imageinfo = null) {}
 function imageaffine($image, $affine, $clip = null) {}
 
 /**
- * (PHP 5 &gt;= 5.5.0)<br/>
+ * @since 5.5.0
  * Concat two matrices (as in doing many ops in one go)
  * @link http://www.php.net/manual/en/function.imageaffinematrixconcat.php
  * @param array $m1 <p>Array with keys 0 to 5.</p>
@@ -689,7 +707,7 @@ function imageaffine($image, $affine, $clip = null) {}
 function imageaffinematrixconcat(array $m1, array $m2) {}
 
 /**
- * (PHP 5 &gt;= 5.5.0)<br/>
+ * @since 5.5.0
  * Return an image containing the affine tramsformed src image, using an optional clipping area
  * @link http://www.php.net/manual/en/function.imageaffinematrixget.php
  * @param int $type <p> One of <b>IMG_AFFINE_*</b> constants.
@@ -700,7 +718,7 @@ function imageaffinematrixconcat(array $m1, array $m2) {}
 function imageaffinematrixget ($type, $options = null) {}
 
 /**
- * (PHP 5 &gt;= 5.5.0)<br/>
+ * @since 5.5.0
  * Crop an image using the given coordinates and size, x, y, width and height
  * @link http://www.php.net/manual/en/function.imagecrop.php
  * @param resource $image <p>
@@ -712,7 +730,7 @@ function imageaffinematrixget ($type, $options = null) {}
 function imagecrop ($image, $rect) {}
 
 /**
- * (PHP 5 &gt;= 5.5.0)<br/>
+ * @since 5.5.0
  * Crop an image automatically using one of the available modes
  * @link http://www.php.net/manual/en/function.imagecropauto.php
  * @param resource $image <p>
@@ -733,7 +751,7 @@ function imagecrop ($image, $rect) {}
 function imagecropauto ($image, $mode = -1, $threshold = .5, $color = -1) {}
 
 /**
- * (PHP 5 &gt;= 5.5.0)<br/>
+ * @since 5.5.0
  * Flips an image using a given mode
  * @link http://www.php.net/manual/en/function.imageflip.php
  * @param resource $image <p>
@@ -774,7 +792,7 @@ function imagecropauto ($image, $mode = -1, $threshold = .5, $color = -1) {}
 function imageflip ($image, $mode) {}
 
 /**
- * (PHP 5 &gt;= 5.5.0)<br/>
+ * @since 5.5.0
  * Converts a palette based image to true color
  * @link http://www.php.net/manual/en/function.imagepalettetotruecolor.php
  * @param resource $image <p>
@@ -785,7 +803,7 @@ function imageflip ($image, $mode) {}
 function imagepalettetotruecolor ($image) {}
 
 /**
- *(PHP 5 &gt;= 5.5.0)<br/>
+ *@since 5.5.0
  * Scale an image using the given new width and height
  * @link http://www.php.net/manual/en/function.imagescale.php
  * @param resource $image <p>
@@ -800,7 +818,7 @@ function imagepalettetotruecolor ($image) {}
 function imagescale ($image, $new_width, $new_height = -1, $mode = IMG_BILINEAR_FIXED) {}
 
 /**
- * (PHP 5 &gt;= 5.5.0)<br/>
+ * @since 5.5.0
  * Set the interpolation method
  * @link http://www.php.net/manual/en/function.imagesetinterpolation.php
  * @param resource $image <p>
@@ -879,7 +897,8 @@ function imagescale ($image, $new_width, $new_height = -1, $mode = IMG_BILINEAR_
 function imagesetinterpolation ($image, $method = IMG_BILINEAR_FIXED) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Get Mime-Type for image-type returned by getimagesize,
    exif_read_data, exif_thumbnail, exif_imagetype
  * @link http://php.net/manual/en/function.image-type-to-mime-type.php
@@ -968,7 +987,7 @@ function imagesetinterpolation ($image, $method = IMG_BILINEAR_FIXED) {}
 function image_type_to_mime_type ($imagetype) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Get file extension for image type
  * @link http://php.net/manual/en/function.image-type-to-extension.php
  * @param int $imagetype <p>
@@ -982,7 +1001,8 @@ function image_type_to_mime_type ($imagetype) {}
 function image_type_to_extension ($imagetype, $include_dot = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Outputs lots of PHP information
  * @link http://php.net/manual/en/function.phpinfo.php
  * @param int $what [optional] <p>
@@ -1069,7 +1089,8 @@ function image_type_to_extension ($imagetype, $include_dot = null) {}
 function phpinfo ($what = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Gets the current PHP version
  * @link http://php.net/manual/en/function.phpversion.php
  * @param string $extension [optional] <p>
@@ -1083,7 +1104,8 @@ function phpinfo ($what = null) {}
 function phpversion ($extension = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Prints out the credits for PHP
  * @link http://php.net/manual/en/function.phpcredits.php
  * @param int $flag [optional] <p>
@@ -1179,7 +1201,8 @@ function php_egg_logo_guid () {}
 function zend_logo_guid () {}
 
 /**
- * (PHP 4 &gt;= 4.0.1, PHP 5)<br/>
+ * @since 4.0.1
+ * @since 5.0
  * Returns the type of interface between web server and PHP
  * @link http://php.net/manual/en/function.php-sapi-name.php
  * @return string the interface type, as a lowercase string.
@@ -1199,7 +1222,8 @@ function zend_logo_guid () {}
 function php_sapi_name () {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Returns information about the operating system PHP is running on
  * @link http://php.net/manual/en/function.php-uname.php
  * @param string $mode [optional] <p>
@@ -1212,7 +1236,8 @@ function php_sapi_name () {}
 function php_uname ($mode = null) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Return a list of .ini files parsed from the additional ini dir
  * @link http://php.net/manual/en/function.php-ini-scanned-files.php
  * @return string a comma-separated string of .ini files on success. Each comma is
@@ -1226,7 +1251,7 @@ function php_uname ($mode = null) {}
 function php_ini_scanned_files () {}
 
 /**
- * (PHP 5 &gt;= 5.2.4)<br/>
+ * @since 5.2.4
  * Retrieve a path to the loaded php.ini file
  * @link http://php.net/manual/en/function.php-ini-loaded-file.php
  * @return string The loaded &php.ini; path, or false if one is not loaded.
@@ -1234,7 +1259,8 @@ function php_ini_scanned_files () {}
 function php_ini_loaded_file () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * String comparisons using a "natural order" algorithm
  * @link http://php.net/manual/en/function.strnatcmp.php
  * @param string $str1 <p>
@@ -1251,7 +1277,8 @@ function php_ini_loaded_file () {}
 function strnatcmp ($str1, $str2) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Case insensitive string comparisons using a "natural order" algorithm
  * @link http://php.net/manual/en/function.strnatcasecmp.php
  * @param string $str1 <p>
@@ -1268,7 +1295,8 @@ function strnatcmp ($str1, $str2) {}
 function strnatcasecmp ($str1, $str2) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Count the number of substring occurrences
  * @link http://php.net/manual/en/function.substr-count.php
  * @param string $haystack <p>
@@ -1290,7 +1318,8 @@ function strnatcasecmp ($str1, $str2) {}
 function substr_count ($haystack, $needle, $offset = null, $length = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Finds the length of the first segment of a string consisting
    entirely of characters contained within a given mask.
  * @link http://php.net/manual/en/function.strspn.php
@@ -1343,7 +1372,8 @@ function substr_count ($haystack, $needle, $offset = null, $length = null) {}
 function strspn ($subject, $mask, $start = null, $length = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Find length of initial segment not matching mask
  * @link http://php.net/manual/en/function.strcspn.php
  * @param string $str1 <p>
@@ -1363,7 +1393,8 @@ function strspn ($subject, $mask, $start = null, $length = null) {}
 function strcspn ($str1, $str2, $start = null, $length = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Tokenize string
  * Note that only the first call to strtok uses the string argument.
  * Every subsequent call to strtok only needs the token to use, as it keeps track of where it is in the current string.

--- a/standard_0.php
+++ b/standard_0.php
@@ -1171,32 +1171,36 @@ function phpversion ($extension = null) {}
 function phpcredits ($flag = null) {}
 
 /**
- * (PHP 4, PHP 5 < 5.5)<br/>
+ * @since 4.0
+ * @since 5.0
+ * @deprecated 5.5 Removed in PHP 5.5
  * Gets the logo guid
  * @link http://php.net/manual/en/function.php-logo-guid.php
  * @return string PHPE9568F34-D428-11d2-A769-00AA001ACF42.
- * @deprecated removed in PHP 5.5
  */
 function php_logo_guid () {}
 
 /**
- * (PHP 4, PHP 5 < 5.5)<br/>
- * @deprecated removed in PHP 5.5
+ * @since 4.0
+ * @since 5.0
+ * @deprecated 5.5 Removed in PHP 5.5
  */
 function php_real_logo_guid () {}
 
 /**
- * (PHP 4, PHP 5 < 5.5)<br/>
- * @deprecated removed in PHP 5.5
+ * @since 4.0
+ * @since 5.0
+ * @deprecated 5.5 Removed in PHP 5.5
  */
 function php_egg_logo_guid () {}
 
 /**
- * (PHP 4, PHP 5 < 5.5)<br/>
+ * @since 4.0
+ * @since 5.0
+ * @deprecated 5.5 Removed in PHP 5.5
  * Gets the Zend guid
  * @link http://php.net/manual/en/function.zend-logo-guid.php
  * @return string PHPE9568F35-D428-11d2-A769-00AA001ACF42.
- * @deprecated removed in PHP 5.5
  */
 function zend_logo_guid () {}
 

--- a/standard_1.php
+++ b/standard_1.php
@@ -2,7 +2,8 @@
 
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Make a string uppercase
  * @link http://php.net/manual/en/function.strtoupper.php
  * @param string $string <p>
@@ -13,7 +14,8 @@
 function strtoupper ($string) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Make a string lowercase
  * @link http://php.net/manual/en/function.strtolower.php
  * @param string $str <p>
@@ -24,7 +26,8 @@ function strtoupper ($string) {}
 function strtolower ($str) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Find the position of the first occurrence of a substring in a string
  * @link http://php.net/manual/en/function.strpos.php
  * @param string $haystack <p>
@@ -51,7 +54,7 @@ function strtolower ($str) {}
 function strpos ($haystack, $needle, $offset = 0) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Find position of first occurrence of a case-insensitive string
  * @link http://php.net/manual/en/function.stripos.php
  * @param string $haystack <p>
@@ -77,7 +80,8 @@ function strpos ($haystack, $needle, $offset = 0) {}
 function stripos ($haystack, $needle, $offset = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Find the position of the last occurrence of a substring in a string
  * @link http://php.net/manual/en/function.strrpos.php
  * @param string $haystack <p>
@@ -102,7 +106,7 @@ function stripos ($haystack, $needle, $offset = null) {}
 function strrpos ($haystack, $needle, $offset = 0) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Find position of last occurrence of a case-insensitive string in a string
  * @link http://php.net/manual/en/function.strripos.php
  * @param string $haystack <p>
@@ -131,7 +135,8 @@ function strrpos ($haystack, $needle, $offset = 0) {}
 function strripos ($haystack, $needle, $offset = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Reverse a string
  * @link http://php.net/manual/en/function.strrev.php
  * @param string $string <p>
@@ -142,7 +147,8 @@ function strripos ($haystack, $needle, $offset = null) {}
 function strrev ($string) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Convert logical Hebrew text to visual text
  * @link http://php.net/manual/en/function.hebrev.php
  * @param string $hebrew_text <p>
@@ -157,7 +163,8 @@ function strrev ($string) {}
 function hebrev ($hebrew_text, $max_chars_per_line = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Convert logical Hebrew text to visual text with newline conversion
  * @link http://php.net/manual/en/function.hebrevc.php
  * @param string $hebrew_text <p>
@@ -172,7 +179,8 @@ function hebrev ($hebrew_text, $max_chars_per_line = null) {}
 function hebrevc ($hebrew_text, $max_chars_per_line = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Inserts HTML line breaks before all newlines in a string
  * @link http://php.net/manual/en/function.nl2br.php
  * @param string $string <p>
@@ -186,7 +194,8 @@ function hebrevc ($hebrew_text, $max_chars_per_line = null) {}
 function nl2br ($string, $is_xhtml = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Returns filename component of path
  * @link http://php.net/manual/en/function.basename.php
  * @param string $path <p>
@@ -206,7 +215,8 @@ function nl2br ($string, $is_xhtml = null) {}
 function basename ($path, $suffix = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Returns directory name component of path
  * @link http://php.net/manual/en/function.dirname.php
  * @param string $path <p>
@@ -226,7 +236,8 @@ function basename ($path, $suffix = null) {}
 function dirname ($path) {}
 
 /**
- * (PHP 4 &gt;= 4.0.3, PHP 5)<br/>
+ * @since 4.0.3
+ * @since 5.0
  * Returns information about a file path
  * @link http://php.net/manual/en/function.pathinfo.php
  * @param string $path <p>
@@ -252,7 +263,8 @@ function dirname ($path) {}
 function pathinfo ($path, $options = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Un-quotes a quoted string
  * @link http://php.net/manual/en/function.stripslashes.php
  * @param string $str <p>
@@ -266,7 +278,8 @@ function pathinfo ($path, $options = null) {}
 function stripslashes ($str) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Un-quote string quoted with <function>addcslashes</function>
  * @link http://php.net/manual/en/function.stripcslashes.php
  * @param string $str <p>
@@ -277,7 +290,8 @@ function stripslashes ($str) {}
 function stripcslashes ($str) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Find first occurrence of a string
  * @link http://php.net/manual/en/function.strstr.php
  * @param string $haystack <p>
@@ -298,7 +312,8 @@ function stripcslashes ($str) {}
 function strstr ($haystack, $needle, $before_needle = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Case-insensitive <function>strstr</function>
  * @link http://php.net/manual/en/function.stristr.php
  * @param string $haystack <p>
@@ -319,7 +334,8 @@ function strstr ($haystack, $needle, $before_needle = null) {}
 function stristr ($haystack, $needle, $before_needle = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Find the last occurrence of a character in a string
  * @link http://php.net/manual/en/function.strrchr.php
  * @param string $haystack <p>
@@ -341,7 +357,8 @@ function stristr ($haystack, $needle, $before_needle = null) {}
 function strrchr ($haystack, $needle) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Randomly shuffles a string
  * @link http://php.net/manual/en/function.str-shuffle.php
  * @param string $str <p>
@@ -352,7 +369,8 @@ function strrchr ($haystack, $needle) {}
 function str_shuffle ($str) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Return information about words used in a string
  * @link http://php.net/manual/en/function.str-word-count.php
  * @param string $string <p>
@@ -371,7 +389,7 @@ function str_shuffle ($str) {}
 function str_word_count ($string, $format = null, $charlist = null) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Convert a string to an array
  * @link http://php.net/manual/en/function.str-split.php
  * @param string $string <p>
@@ -394,7 +412,7 @@ function str_word_count ($string, $format = null, $charlist = null) {}
 function str_split ($string, $split_length = 1) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Search a string for any of a set of characters
  * @link http://php.net/manual/en/function.strpbrk.php
  * @param string $haystack <p>
@@ -409,7 +427,7 @@ function str_split ($string, $split_length = 1) {}
 function strpbrk ($haystack, $char_list) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Binary safe comparison of 2 strings from an offset, up to length characters
  * @link http://php.net/manual/en/function.substr-compare.php
  * @param string $main_str <p>
@@ -440,7 +458,8 @@ function strpbrk ($haystack, $char_list) {}
 function substr_compare ($main_str, $str, $offset, $length = null, $case_insensitivity = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.5, PHP 5)<br/>
+ * @since 4.0.5
+ * @since 5.0
  * Locale based string comparison
  * @link http://php.net/manual/en/function.strcoll.php
  * @param string $str1 <p>
@@ -457,7 +476,8 @@ function substr_compare ($main_str, $str, $offset, $length = null, $case_insensi
 function strcoll ($str1, $str2) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Formats a number as a currency string
  * @link http://php.net/manual/en/function.money-format.php
  * @param string $format <p>
@@ -474,7 +494,8 @@ function strcoll ($str1, $str2) {}
 function money_format ($format, $number) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Return part of a string
  * @link http://php.net/manual/en/function.substr.php
  * @param string $string <p>
@@ -527,7 +548,8 @@ function money_format ($format, $number) {}
 function substr ($string, $start, $length = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Replace text within a portion of a string
  * @link http://php.net/manual/en/function.substr-replace.php
  * @param mixed $string <p>
@@ -565,7 +587,8 @@ function substr ($string, $start, $length = null) {}
 function substr_replace ($string, $replacement, $start, $length = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Quote meta characters
  * @link http://php.net/manual/en/function.quotemeta.php
  * @param string $str <p>
@@ -576,7 +599,8 @@ function substr_replace ($string, $replacement, $start, $length = null) {}
 function quotemeta ($str) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Make a string's first character uppercase
  * @link http://php.net/manual/en/function.ucfirst.php
  * @param string $str <p>
@@ -587,7 +611,7 @@ function quotemeta ($str) {}
 function ucfirst ($str) {}
 
 /**
- * (PHP 5 &gt;= 5.3.0)<br/>
+ * @since 5.3.0
  * Make a string's first character lowercase
  * @link http://php.net/manual/en/function.lcfirst.php
  * @param string $str <p>
@@ -598,7 +622,8 @@ function ucfirst ($str) {}
 function lcfirst ($str) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Uppercase the first character of each word in a string
  * @link http://php.net/manual/en/function.ucwords.php
  * @param string $str <p>
@@ -609,7 +634,8 @@ function lcfirst ($str) {}
 function ucwords ($str) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Translate certain characters
  * @link http://php.net/manual/en/function.strtr.php
  * @param string $str <p>
@@ -629,7 +655,8 @@ function ucwords ($str) {}
 function strtr ($str, $from, $to) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Quote string with slashes
  * @link http://php.net/manual/en/function.addslashes.php
  * @param string $str <p>
@@ -640,7 +667,8 @@ function strtr ($str, $from, $to) {}
 function addslashes ($str) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Quote string with slashes in a C style
  * @link http://php.net/manual/en/function.addcslashes.php
  * @param string $str <p>
@@ -679,7 +707,8 @@ function addslashes ($str) {}
 function addcslashes ($str, $charlist) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Strip whitespace (or other characters) from the end of a string.
  * Without the second parameter, rtrim() will strip these characters:
  * <ul>
@@ -705,7 +734,8 @@ function addcslashes ($str, $charlist) {}
 function rtrim ($str, $charlist = " \t\n\r\0\x0B") {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Replace all occurrences of the search string with the replacement string
  * @link http://php.net/manual/en/function.str-replace.php
  * @param mixed $search <p>
@@ -732,7 +762,7 @@ function rtrim ($str, $charlist = " \t\n\r\0\x0B") {}
 function str_replace ($search, $replace, $subject, &$count = null) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Case-insensitive version of <function>str_replace</function>.
  * @link http://php.net/manual/en/function.str-ireplace.php
  * @param mixed $search <p>
@@ -757,7 +787,8 @@ function str_replace ($search, $replace, $subject, &$count = null) {}
 function str_ireplace ($search, $replace, $subject, &$count = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Repeat a string
  * @link http://php.net/manual/en/function.str-repeat.php
  * @param string $input <p>
@@ -777,7 +808,8 @@ function str_ireplace ($search, $replace, $subject, &$count = null) {}
 function str_repeat ($input, $multiplier) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Return information about characters used in a string
  * @link http://php.net/manual/en/function.count-chars.php
  * @param string $string <p>
@@ -800,7 +832,8 @@ function str_repeat ($input, $multiplier) {}
 function count_chars ($string, $mode = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Split a string into smaller chunks
  * @link http://php.net/manual/en/function.chunk-split.php
  * @param string $body <p>
@@ -817,7 +850,8 @@ function count_chars ($string, $mode = null) {}
 function chunk_split ($body, $chunklen = null, $end = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Strip whitespace (or other characters) from the beginning and end of a string
  * @link http://php.net/manual/en/function.trim.php
  * @param string $str <p>
@@ -834,7 +868,8 @@ function chunk_split ($body, $chunklen = null, $end = null) {}
 function trim ($str, $charlist = " \t\n\r\0\x0B") {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Strip whitespace (or other characters) from the beginning of a string
  * @link http://php.net/manual/en/function.ltrim.php
  * @param string $str <p>
@@ -866,7 +901,8 @@ function trim ($str, $charlist = " \t\n\r\0\x0B") {}
 function ltrim ($str, $charlist = " \t\n\r\0\x0B") {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Strip HTML and PHP tags from a string
  * @link http://php.net/manual/en/function.strip-tags.php
  * @param string $str <p>
@@ -885,7 +921,8 @@ function ltrim ($str, $charlist = " \t\n\r\0\x0B") {}
 function strip_tags ($str, $allowable_tags = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Calculate the similarity between two strings
  * @link http://php.net/manual/en/function.similar-text.php
  * @param string $first <p>
@@ -904,7 +941,8 @@ function strip_tags ($str, $allowable_tags = null) {}
 function similar_text ($first, $second, &$percent = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Split a string by string
  * @link http://php.net/manual/en/function.explode.php
  * @param string $delimiter <p>
@@ -936,7 +974,8 @@ function similar_text ($first, $second, &$percent = null) {}
 function explode ($delimiter, $string, $limit = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Join array elements with a string
  * @link http://php.net/manual/en/function.implode.php
  * @param string $glue [optional]<p>
@@ -953,7 +992,8 @@ function explode ($delimiter, $string, $limit = null) {}
 function implode ($glue, array $pieces) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * &Alias; <function>implode</function>
  * @link http://php.net/manual/en/function.join.php
  * @param string $glue <p>
@@ -970,7 +1010,8 @@ function implode ($glue, array $pieces) {}
 function join ($glue, $pieces) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Set locale information
  * @link http://php.net/manual/en/function.setlocale.php
  * @param int $category <p>
@@ -1013,7 +1054,8 @@ function join ($glue, $pieces) {}
 function setlocale ($category, $locale, $_ = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.5, PHP 5)<br/>
+ * @since 4.0.5
+ * @since 5.0
  * Get numeric formatting information
  * @link http://php.net/manual/en/function.localeconv.php
  * @return array localeconv returns data based upon the current locale

--- a/standard_2.php
+++ b/standard_2.php
@@ -1,7 +1,8 @@
 <?php
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Query language and locale information
  * @link http://php.net/manual/en/function.nl-langinfo.php
  * @param int $item <p>
@@ -147,7 +148,8 @@
 function nl_langinfo ($item) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Calculate the soundex key of a string
  * @link http://php.net/manual/en/function.soundex.php
  * @param string $str <p>
@@ -158,7 +160,8 @@ function nl_langinfo ($item) {}
 function soundex ($str) {}
 
 /**
- * (PHP 4 &gt;= 4.0.1, PHP 5)<br/>
+ * @since 4.0.1
+ * @since 5.0
  * Calculate Levenshtein distance between two strings
  * @link http://php.net/manual/en/function.levenshtein.php
  * @param string $str1 <p>
@@ -174,7 +177,8 @@ function soundex ($str) {}
 function levenshtein ($str1, $str2) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Return a specific character
  * @link http://php.net/manual/en/function.chr.php
  * @param int $ascii <p>
@@ -185,7 +189,8 @@ function levenshtein ($str1, $str2) {}
 function chr ($ascii) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Return ASCII value of character
  * @link http://php.net/manual/en/function.ord.php
  * @param string $string <p>
@@ -196,7 +201,8 @@ function chr ($ascii) {}
 function ord ($string) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Parses the string into variables
  * @link http://php.net/manual/en/function.parse-str.php
  * @param string $str <p>
@@ -211,7 +217,7 @@ function ord ($string) {}
 function parse_str ($str, array &$arr = null) {}
 
 /**
- * (PHP 5 &gt;= 5.3.0)<br/>
+ * @since 5.3.0
  * Parse a CSV string into an array
  * @link http://php.net/manual/en/function.str-getcsv.php
  * @param string $input <p>
@@ -232,7 +238,8 @@ function parse_str ($str, array &$arr = null) {}
 function str_getcsv ($input, $delimiter = null, $enclosure = null, $escape = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.1, PHP 5)<br/>
+ * @since 4.0.1
+ * @since 5.0
  * Pad a string to a certain length with another string
  * @link http://php.net/manual/en/function.str-pad.php
  * @param string $input <p>
@@ -260,7 +267,8 @@ function str_getcsv ($input, $delimiter = null, $enclosure = null, $escape = nul
 function str_pad ($input, $pad_length, $pad_string = null, $pad_type = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * &Alias; <function>rtrim</function>
  * @see rtrim()
  * @link http://php.net/manual/en/function.chop.php
@@ -271,7 +279,8 @@ function str_pad ($input, $pad_length, $pad_string = null, $pad_type = null) {}
 function chop ($str, $character_mask) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * &Alias; <function>strstr</function>
  * @link http://php.net/manual/en/function.strchr.php
  * Note: This function is case-sensitive. For case-insensitive searches, use stristr().
@@ -286,7 +295,8 @@ function chop ($str, $character_mask) {}
 function strchr ($haystack, $needle, $part) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Return a formatted string
  * @link http://php.net/manual/en/function.sprintf.php
  * @param string $format <p>
@@ -314,7 +324,8 @@ function strchr ($haystack, $needle, $part) {}
 function sprintf ($format, $args = null, $_ = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Output a formatted string
  * @link http://php.net/manual/en/function.printf.php
  * @param string $format <p>
@@ -329,7 +340,8 @@ function sprintf ($format, $args = null, $_ = null) {}
 function printf ($format, $args = null, $_ = null) {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Output a formatted string
  * @link http://php.net/manual/en/function.vprintf.php
  * @param string $format <p>
@@ -343,7 +355,8 @@ function printf ($format, $args = null, $_ = null) {}
 function vprintf ($format, array $args) {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Return a formatted string
  * @link http://php.net/manual/en/function.vsprintf.php
  * @param string $format <p>
@@ -359,7 +372,7 @@ function vprintf ($format, array $args) {}
 function vsprintf ($format, array $args) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Write a formatted string to a stream
  * @link http://php.net/manual/en/function.fprintf.php
  * @param resource $handle &fs.file.pointer;
@@ -375,7 +388,7 @@ function vsprintf ($format, array $args) {}
 function fprintf ($handle, $format, $args = null, $_ = null) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Write a formatted string to a stream
  * @link http://php.net/manual/en/function.vfprintf.php
  * @param resource $handle <p>
@@ -391,7 +404,8 @@ function fprintf ($handle, $format, $args = null, $_ = null) {}
 function vfprintf ($handle, $format, array $args) {}
 
 /**
- * (PHP 4 &gt;= 4.0.1, PHP 5)<br/>
+ * @since 4.0.1
+ * @since 5.0
  * Parses input from a string according to a format
  * @link http://php.net/manual/en/function.sscanf.php
  * @param string $str <p>
@@ -418,7 +432,8 @@ function vfprintf ($handle, $format, array $args) {}
 function sscanf ($str, $format, &$_ = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.1, PHP 5)<br/>
+ * @since 4.0.1
+ * @since 5.0
  * Parses input from a file according to a format
  * @link http://php.net/manual/en/function.fscanf.php
  * @param resource $handle &fs.file.pointer;
@@ -435,7 +450,8 @@ function sscanf ($str, $format, &$_ = null) {}
 function fscanf ($handle, $format, &$_ = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Parse a URL and return its components
  * @link http://php.net/manual/en/function.parse-url.php
  * @param string $url <p>
@@ -469,7 +485,8 @@ function fscanf ($handle, $format, &$_ = null) {}
 function parse_url ($url, $component = -1) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * URL-encodes string
  * @link http://php.net/manual/en/function.urlencode.php
  * @param string $str <p>
@@ -488,7 +505,8 @@ function parse_url ($url, $component = -1) {}
 function urlencode ($str) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Decodes URL-encoded string
  * @link http://php.net/manual/en/function.urldecode.php
  * @param string $str <p>
@@ -499,7 +517,8 @@ function urlencode ($str) {}
 function urldecode ($str) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * URL-encode according to RFC 1738
  * @link http://php.net/manual/en/function.rawurlencode.php
  * @param string $str <p>
@@ -516,7 +535,8 @@ function urldecode ($str) {}
 function rawurlencode ($str) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Decode URL-encoded strings
  * @link http://php.net/manual/en/function.rawurldecode.php
  * @param string $str <p>
@@ -527,7 +547,7 @@ function rawurlencode ($str) {}
 function rawurldecode ($str) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Generate URL-encoded query string
  * @link http://php.net/manual/en/function.http-build-query.php
  * @param mixed $query_data <p>
@@ -563,7 +583,8 @@ function rawurldecode ($str) {}
 function http_build_query ($query_data, $numeric_prefix = null, $arg_separator = null, $enc_type = PHP_QUERY_RFC1738)
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Returns the target of a symbolic link
  * @link http://php.net/manual/en/function.readlink.php
  * @param string $path <p>
@@ -574,7 +595,8 @@ function http_build_query ($query_data, $numeric_prefix = null, $arg_separator =
 function readlink ($path) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Gets information about a link
  * @link http://php.net/manual/en/function.linkinfo.php
  * @param string $path <p>
@@ -587,7 +609,8 @@ function readlink ($path) {}
 function linkinfo ($path) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Creates a symbolic link
  * @link http://php.net/manual/en/function.symlink.php
  * @param string $target <p>
@@ -601,7 +624,8 @@ function linkinfo ($path) {}
 function symlink ($target, $link) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Create a hard link
  * @link http://php.net/manual/en/function.link.php
  * @param string $from_path <p>
@@ -615,7 +639,8 @@ function symlink ($target, $link) {}
 function link ($from_path, $to_path) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Deletes a file
  * @link http://php.net/manual/en/function.unlink.php
  * @param string $filename <p>
@@ -627,7 +652,8 @@ function link ($from_path, $to_path) {}
 function unlink ($filename, $context = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Execute an external program
  * @link http://php.net/manual/en/function.exec.php
  * @param string $command <p>
@@ -660,7 +686,8 @@ function unlink ($filename, $context = null) {}
 function exec ($command, array &$output = null, &$return_var = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Execute an external program and display the output
  * @link http://php.net/manual/en/function.system.php
  * @param string $command <p>
@@ -677,7 +704,8 @@ function exec ($command, array &$output = null, &$return_var = null) {}
 function system ($command, &$return_var = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Escape shell metacharacters
  * @link http://php.net/manual/en/function.escapeshellcmd.php
  * @param string $command <p>
@@ -688,7 +716,8 @@ function system ($command, &$return_var = null) {}
 function escapeshellcmd ($command) {}
 
 /**
- * (PHP 4 &gt;= 4.0.3, PHP 5)<br/>
+ * @since 4.0.3
+ * @since 5.0
  * Escape a string to be used as a shell argument
  * @link http://php.net/manual/en/function.escapeshellarg.php
  * @param string $arg <p>
@@ -699,7 +728,8 @@ function escapeshellcmd ($command) {}
 function escapeshellarg ($arg) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Execute an external program and display raw output
  * @link http://php.net/manual/en/function.passthru.php
  * @param string $command <p>
@@ -714,7 +744,8 @@ function escapeshellarg ($arg) {}
 function passthru ($command, &$return_var = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Execute command via shell and return the complete output as a string
  * @link http://php.net/manual/en/function.shell-exec.php
  * @param string $cmd <p>
@@ -725,7 +756,8 @@ function passthru ($command, &$return_var = null) {}
 function shell_exec ($cmd) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Execute a command and open file pointers for input/output
  * @link http://php.net/manual/en/function.proc-open.php
  * @param string $cmd <p>
@@ -789,7 +821,8 @@ function shell_exec ($cmd) {}
 function proc_open ($cmd, array $descriptorspec, array &$pipes, $cwd = null, array $env = null, array $other_options = null) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Close a process opened by <function>proc_open</function> and return the exit code of that process
  * @link http://php.net/manual/en/function.proc-close.php
  * @param resource $process <p>
@@ -801,7 +834,7 @@ function proc_open ($cmd, array $descriptorspec, array &$pipes, $cwd = null, arr
 function proc_close ($process) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Kills a process opened by proc_open
  * @link http://php.net/manual/en/function.proc-terminate.php
  * @param resource $process <p>
@@ -819,7 +852,7 @@ function proc_close ($process) {}
 function proc_terminate ($process, $signal = null) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Get information about a process opened by <function>proc_open</function>
  * @link http://php.net/manual/en/function.proc-get-status.php
  * @param resource $process <p>
@@ -897,7 +930,7 @@ function proc_terminate ($process, $signal = null) {}
 function proc_get_status ($process) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Change the priority of the current process
  * @link http://php.net/manual/en/function.proc-nice.php
  * @param int $increment <p>
@@ -910,7 +943,8 @@ function proc_get_status ($process) {}
 function proc_nice ($increment) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Generate a random integer
  * @link http://php.net/manual/en/function.rand.php
  * @param $min [optional]
@@ -921,7 +955,8 @@ function proc_nice ($increment) {}
 function rand ($min, $max) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Seed the random number generator
  * @link http://php.net/manual/en/function.srand.php
  * @param int $seed [optional] <p>
@@ -932,7 +967,8 @@ function rand ($min, $max) {}
 function srand ($seed = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Show largest possible random value
  * @link http://php.net/manual/en/function.getrandmax.php
  * @return int The largest possible random value returned by rand
@@ -940,7 +976,8 @@ function srand ($seed = null) {}
 function getrandmax () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Generate a better random value
  * @link http://php.net/manual/en/function.mt-rand.php
  * @param $min [optional]
@@ -951,7 +988,8 @@ function getrandmax () {}
 function mt_rand ($min, $max) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Seed the better random number generator
  * @link http://php.net/manual/en/function.mt-srand.php
  * @param int $seed [optional] <p>
@@ -962,7 +1000,8 @@ function mt_rand ($min, $max) {}
 function mt_srand ($seed = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Show largest possible random value
  * @link http://php.net/manual/en/function.mt-getrandmax.php
  * @return int the maximum random value returned by mt_rand
@@ -970,7 +1009,8 @@ function mt_srand ($seed = null) {}
 function mt_getrandmax () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get port number associated with an Internet service and protocol
  * @link http://php.net/manual/en/function.getservbyname.php
  * @param string $service <p>
@@ -986,7 +1026,8 @@ function mt_getrandmax () {}
 function getservbyname ($service, $protocol) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get Internet service which corresponds to port and protocol
  * @link http://php.net/manual/en/function.getservbyport.php
  * @param int $port <p>
@@ -1001,7 +1042,8 @@ function getservbyname ($service, $protocol) {}
 function getservbyport ($port, $protocol) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get protocol number associated with protocol name
  * @link http://php.net/manual/en/function.getprotobyname.php
  * @param string $name <p>
@@ -1012,7 +1054,8 @@ function getservbyport ($port, $protocol) {}
 function getprotobyname ($name) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get protocol name associated with protocol number
  * @link http://php.net/manual/en/function.getprotobynumber.php
  * @param int $number <p>
@@ -1023,7 +1066,8 @@ function getprotobyname ($name) {}
 function getprotobynumber ($number) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Gets PHP script owner's UID
  * @link http://php.net/manual/en/function.getmyuid.php
  * @return int the user ID of the current script, or false on error.
@@ -1031,7 +1075,8 @@ function getprotobynumber ($number) {}
 function getmyuid () {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Get PHP script owner's GID
  * @link http://php.net/manual/en/function.getmygid.php
  * @return int the group ID of the current script, or false on error.
@@ -1039,7 +1084,8 @@ function getmyuid () {}
 function getmygid () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Gets PHP's process ID
  * @link http://php.net/manual/en/function.getmypid.php
  * @return int the current PHP process ID, or false on error.
@@ -1047,7 +1093,8 @@ function getmygid () {}
 function getmypid () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Gets the inode of the current script
  * @link http://php.net/manual/en/function.getmyinode.php
  * @return int the current script's inode as an integer, or false on error.

--- a/standard_3.php
+++ b/standard_3.php
@@ -973,7 +973,7 @@ function get_cfg_var ($option) {}
  * @since 5.0
  * &Alias; <function>set_magic_quotes_runtime</function>
  * @link http://php.net/manual/en/function.magic-quotes-runtime.php
- * @deprecated since 5.3.0
+ * @deprecated 5.3.0
  * @param $new_setting
  */
 function magic_quotes_runtime ($new_setting) {}
@@ -983,12 +983,12 @@ function magic_quotes_runtime ($new_setting) {}
  * @since 5.0
  * Sets the current active configuration setting of magic_quotes_runtime
  * @link http://php.net/manual/en/function.set-magic-quotes-runtime.php
- * @deprecated since 5.3.0
+ * @deprecated 5.3.0
  * @param bool $new_setting <p>
  * false for off, true for on.
  * </p>
  * @return bool true on success or false on failure.
- * @deprecated This function has been DEPRECATED as of PHP 5.4.0. Raises an E_CORE_ERROR.
+ * @deprecated 5.4 This function has been DEPRECATED as of PHP 5.4.0. Raises an E_CORE_ERROR.
  */
 function set_magic_quotes_runtime ($new_setting) {}
 
@@ -998,7 +998,7 @@ function set_magic_quotes_runtime ($new_setting) {}
  * Gets the current configuration setting of magic quotes gpc
  * @link http://php.net/manual/en/function.get-magic-quotes-gpc.php
  * @return int 0 if magic quotes gpc are off, 1 otherwise.
- * @deprecated This function has been DEPRECATED as of PHP 5.4.0. Always return false.
+ * @deprecated 5.4 This function has been DEPRECATED as of PHP 5.4.0. Always return false.
  */
 function get_magic_quotes_gpc () {}
 
@@ -1008,12 +1008,13 @@ function get_magic_quotes_gpc () {}
  * Gets the current active configuration setting of magic_quotes_runtime
  * @link http://php.net/manual/en/function.get-magic-quotes-runtime.php
  * @return int 0 if magic quotes runtime is off, 1 otherwise.
- * @deprecated This function has been DEPRECATED as of PHP 5.4.0. Always return false.
+ * @deprecated 5.4 This function has been DEPRECATED as of PHP 5.4.0. Always return false.
  */
 function get_magic_quotes_runtime () {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP %lt;5.4)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Import GET/POST/Cookie variables into the global scope
  * @link http://php.net/manual/en/function.import-request-variables.php
  * @param string $types <p>
@@ -1044,7 +1045,7 @@ function get_magic_quotes_runtime () {}
  * not displayed using the default error reporting level.
  * </p>
  * @return bool true on success or false on failure.
- * @deprecated This function has been DEPRECATED as of PHP 5.3.0 and REMOVED as of PHP 5.4.0.
+ * @deprecated 5.3 This function has been DEPRECATED as of PHP 5.3.0 and REMOVED as of PHP 5.4.0.
  */
 function import_request_variables ($types, $prefix = null) {}
 

--- a/standard_3.php
+++ b/standard_3.php
@@ -1,7 +1,8 @@
 <?php
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Gets time of last page modification
  * @link http://php.net/manual/en/function.getlastmod.php
  * @return int the time of the last modification of the current
@@ -11,7 +12,8 @@
 function getlastmod () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Decodes data encoded with MIME base64
  * @link http://php.net/manual/en/function.base64-decode.php
  * @param string $data <p>
@@ -27,7 +29,8 @@ function getlastmod () {}
 function base64_decode ($data, $strict = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Encodes data with MIME base64
  * @link http://php.net/manual/en/function.base64-encode.php
  * @param string $data <p>
@@ -38,7 +41,7 @@ function base64_decode ($data, $strict = null) {}
 function base64_encode ($data) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Uuencode a string
  * @link http://php.net/manual/en/function.convert-uuencode.php
  * @param string $data <p>
@@ -49,7 +52,7 @@ function base64_encode ($data) {}
 function convert_uuencode ($data) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Decode a uuencoded string
  * @link http://php.net/manual/en/function.convert-uudecode.php
  * @param string $data <p>
@@ -60,7 +63,8 @@ function convert_uuencode ($data) {}
 function convert_uudecode ($data) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Absolute value
  * @link http://php.net/manual/en/function.abs.php
  * @param mixed $number <p>
@@ -75,7 +79,8 @@ function convert_uudecode ($data) {}
 function abs ($number) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Round fractions up
  * @link http://php.net/manual/en/function.ceil.php
  * @param float $value <p>
@@ -90,7 +95,8 @@ function abs ($number) {}
 function ceil ($value) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Round fractions down
  * @link http://php.net/manual/en/function.floor.php
  * @param float $value <p>
@@ -104,7 +110,8 @@ function ceil ($value) {}
 function floor ($value) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Returns the rounded value of val to specified precision (number of digits after the decimal point).
  * precision can also be negative or zero (default).
  * Note: PHP doesn't handle strings like "12,300.2" correctly by default. See converting from strings.
@@ -126,7 +133,8 @@ function floor ($value) {}
 function round ($val, $precision = 0, $mode = PHP_ROUND_HALF_UP) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Sine
  * @link http://php.net/manual/en/function.sin.php
  * @param float $arg <p>
@@ -137,7 +145,8 @@ function round ($val, $precision = 0, $mode = PHP_ROUND_HALF_UP) {}
 function sin ($arg) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Cosine
  * @link http://php.net/manual/en/function.cos.php
  * @param float $arg <p>
@@ -148,7 +157,8 @@ function sin ($arg) {}
 function cos ($arg) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Tangent
  * @link http://php.net/manual/en/function.tan.php
  * @param float $arg <p>
@@ -159,7 +169,8 @@ function cos ($arg) {}
 function tan ($arg) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Arc sine
  * @link http://php.net/manual/en/function.asin.php
  * @param float $arg <p>
@@ -170,7 +181,8 @@ function tan ($arg) {}
 function asin ($arg) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Arc cosine
  * @link http://php.net/manual/en/function.acos.php
  * @param float $arg <p>
@@ -181,7 +193,8 @@ function asin ($arg) {}
 function acos ($arg) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Arc tangent
  * @link http://php.net/manual/en/function.atan.php
  * @param float $arg <p>
@@ -192,7 +205,8 @@ function acos ($arg) {}
 function atan ($arg) {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Inverse hyperbolic tangent
  * @link http://php.net/manual/en/function.atanh.php
  * @param float $arg <p>
@@ -203,7 +217,8 @@ function atan ($arg) {}
 function atanh ($arg) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Arc tangent of two variables
  * @link http://php.net/manual/en/function.atan2.php
  * @param float $y <p>
@@ -218,7 +233,8 @@ function atanh ($arg) {}
 function atan2 ($y, $x) {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Hyperbolic sine
  * @link http://php.net/manual/en/function.sinh.php
  * @param float $arg <p>
@@ -229,7 +245,8 @@ function atan2 ($y, $x) {}
 function sinh ($arg) {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Hyperbolic cosine
  * @link http://php.net/manual/en/function.cosh.php
  * @param float $arg <p>
@@ -240,7 +257,8 @@ function sinh ($arg) {}
 function cosh ($arg) {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Hyperbolic tangent
  * @link http://php.net/manual/en/function.tanh.php
  * @param float $arg <p>
@@ -251,7 +269,8 @@ function cosh ($arg) {}
 function tanh ($arg) {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Inverse hyperbolic sine
  * @link http://php.net/manual/en/function.asinh.php
  * @param float $arg <p>
@@ -262,7 +281,8 @@ function tanh ($arg) {}
 function asinh ($arg) {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Inverse hyperbolic cosine
  * @link http://php.net/manual/en/function.acosh.php
  * @param float $arg <p>
@@ -273,7 +293,8 @@ function asinh ($arg) {}
 function acosh ($arg) {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Returns exp(number) - 1, computed in a way that is accurate even
    when the value of number is close to zero
  * @link http://php.net/manual/en/function.expm1.php
@@ -285,7 +306,8 @@ function acosh ($arg) {}
 function expm1 ($arg) {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Returns log(1 + number), computed in a way that is accurate even when
    the value of number is close to zero
  * @link http://php.net/manual/en/function.log1p.php
@@ -297,7 +319,8 @@ function expm1 ($arg) {}
 function log1p ($number) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get value of pi
  * @link http://php.net/manual/en/function.pi.php
  * @return float The value of pi as float.
@@ -305,7 +328,8 @@ function log1p ($number) {}
 function pi () {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Finds whether a value is a legal finite number
  * @link http://php.net/manual/en/function.is-finite.php
  * @param float $val <p>
@@ -318,7 +342,8 @@ function pi () {}
 function is_finite ($val) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Finds whether a value is not a number
  * @link http://php.net/manual/en/function.is-nan.php
  * @param float $val <p>
@@ -330,7 +355,8 @@ function is_finite ($val) {}
 function is_nan ($val) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Finds whether a value is infinite
  * @link http://php.net/manual/en/function.is-infinite.php
  * @param float $val <p>
@@ -341,7 +367,8 @@ function is_nan ($val) {}
 function is_infinite ($val) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Exponential expression
  * @link http://php.net/manual/en/function.pow.php
  * @param number $base <p>
@@ -358,7 +385,8 @@ function is_infinite ($val) {}
 function pow ($base, $exp) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Calculates the exponent of <constant>e</constant>
  * @link http://php.net/manual/en/function.exp.php
  * @param float $arg <p>
@@ -369,7 +397,8 @@ function pow ($base, $exp) {}
 function exp ($arg) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Natural logarithm
  * @link http://php.net/manual/en/function.log.php
  * @param float $arg <p>
@@ -386,7 +415,8 @@ function exp ($arg) {}
 function log ($arg, $base = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Base-10 logarithm
  * @link http://php.net/manual/en/function.log10.php
  * @param float $arg <p>
@@ -397,7 +427,8 @@ function log ($arg, $base = null) {}
 function log10 ($arg) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Square root
  * @link http://php.net/manual/en/function.sqrt.php
  * @param float $arg <p>
@@ -409,7 +440,8 @@ function log10 ($arg) {}
 function sqrt ($arg) {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Calculate the length of the hypotenuse of a right-angle triangle
  * @link http://php.net/manual/en/function.hypot.php
  * @param float $x <p>
@@ -423,7 +455,8 @@ function sqrt ($arg) {}
 function hypot ($x, $y) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Converts the number in degrees to the radian equivalent
  * @link http://php.net/manual/en/function.deg2rad.php
  * @param float $number <p>
@@ -434,7 +467,8 @@ function hypot ($x, $y) {}
 function deg2rad ($number) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Converts the radian number to the equivalent number in degrees
  * @link http://php.net/manual/en/function.rad2deg.php
  * @param float $number <p>
@@ -445,7 +479,8 @@ function deg2rad ($number) {}
 function rad2deg ($number) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Binary to decimal
  * @link http://php.net/manual/en/function.bindec.php
  * @param string $binary_string <p>
@@ -456,7 +491,8 @@ function rad2deg ($number) {}
 function bindec ($binary_string) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Hexadecimal to decimal
  * @link http://php.net/manual/en/function.hexdec.php
  * @param string $hex_string <p>
@@ -467,7 +503,8 @@ function bindec ($binary_string) {}
 function hexdec ($hex_string) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Octal to decimal
  * @link http://php.net/manual/en/function.octdec.php
  * @param string $octal_string <p>
@@ -478,7 +515,8 @@ function hexdec ($hex_string) {}
 function octdec ($octal_string) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Decimal to binary
  * @link http://php.net/manual/en/function.decbin.php
  * @param int $number <p>
@@ -597,7 +635,8 @@ function octdec ($octal_string) {}
 function decbin ($number) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Decimal to octal
  * @link http://php.net/manual/en/function.decoct.php
  * @param int $number <p>
@@ -608,7 +647,8 @@ function decbin ($number) {}
 function decoct ($number) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Decimal to hexadecimal
  * @link http://php.net/manual/en/function.dechex.php
  * @param int $number <p>
@@ -619,7 +659,8 @@ function decoct ($number) {}
 function dechex ($number) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Convert a number between arbitrary bases
  * @link http://php.net/manual/en/function.base-convert.php
  * @param string $number <p>
@@ -636,7 +677,8 @@ function dechex ($number) {}
 function base_convert ($number, $frombase, $tobase) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Format a number with grouped thousands
  * @link http://php.net/manual/en/function.number-format.php
  * @param float $number <p>
@@ -652,7 +694,8 @@ function base_convert ($number, $frombase, $tobase) {}
 function number_format ($number , $decimals = 0 , $dec_point = '.' , $thousands_sep = ',' ) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Returns the floating point remainder (modulo) of the division
   of the arguments
  * @link http://php.net/manual/en/function.fmod.php
@@ -668,7 +711,7 @@ function number_format ($number , $decimals = 0 , $dec_point = '.' , $thousands_
 function fmod ($x, $y) {}
 
 /**
- * (PHP 5 &gt;= 5.1.0)<br/>
+ * @since 5.1.0
  * Converts a packed internet address to a human readable representation
  * @link http://php.net/manual/en/function.inet-ntop.php
  * @param string $in_addr <p>
@@ -679,7 +722,7 @@ function fmod ($x, $y) {}
 function inet_ntop ($in_addr) {}
 
 /**
- * (PHP 5 &gt;= 5.1.0)<br/>
+ * @since 5.1.0
  * Converts a human readable IP address to its packed in_addr representation
  * @link http://php.net/manual/en/function.inet-pton.php
  * @param string $address <p>
@@ -691,7 +734,8 @@ function inet_ntop ($in_addr) {}
 function inet_pton ($address) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Converts a string containing an (IPv4) Internet Protocol dotted address into a proper address
  * @link http://php.net/manual/en/function.ip2long.php
  * @param string $ip_address <p>
@@ -703,7 +747,8 @@ function inet_pton ($address) {}
 function ip2long ($ip_address) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Converts an (IPv4) Internet network address into a string in Internet standard dotted format
  * @link http://php.net/manual/en/function.long2ip.php
  * @param string $proper_address <p>
@@ -714,7 +759,8 @@ function ip2long ($ip_address) {}
 function long2ip ($proper_address) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Gets the value of an environment variable
  * @link http://php.net/manual/en/function.getenv.php
  * @param string $varname <p>
@@ -726,7 +772,8 @@ function long2ip ($proper_address) {}
 function getenv ($varname) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Sets the value of an environment variable
  * @link http://php.net/manual/en/function.putenv.php
  * @param string $setting <p>
@@ -737,7 +784,8 @@ function getenv ($varname) {}
 function putenv ($setting) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Gets options from the command line argument list
  * @link http://php.net/manual/en/function.getopt.php
  * @param string $options Each character in this string will be used as option characters and
@@ -758,7 +806,7 @@ function putenv ($setting) {}
 function getopt ($options, array $longopts = null) {}
 
 /**
- * (PHP 5 &gt;= 5.1.3)<br/>
+ * @since 5.1.3
  * Gets system load average
  * @link http://php.net/manual/en/function.sys-getloadavg.php
  * @return array an array with three samples (last 1, 5 and 15
@@ -767,7 +815,8 @@ function getopt ($options, array $longopts = null) {}
 function sys_getloadavg () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Return current Unix timestamp with microseconds
  * @link http://php.net/manual/en/function.microtime.php
  * @param bool $get_as_float [optional] <p>
@@ -786,7 +835,8 @@ function sys_getloadavg () {}
 function microtime ($get_as_float = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get current time
  * @link http://php.net/manual/en/function.gettimeofday.php
  * @param bool $return_float [optional] <p>
@@ -805,7 +855,8 @@ function microtime ($get_as_float = null) {}
 function gettimeofday ($return_float = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Gets the current resource usages
  * @link http://php.net/manual/en/function.getrusage.php
  * @param int $who [optional] <p>
@@ -818,7 +869,8 @@ function gettimeofday ($return_float = null) {}
 function getrusage ($who = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Generate a unique ID
  * @link http://php.net/manual/en/function.uniqid.php
  * @param string $prefix [optional] <p>
@@ -841,7 +893,8 @@ function getrusage ($who = null) {}
 function uniqid ($prefix = "", $more_entropy = false) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Convert a quoted-printable string to an 8 bit string
  * @link http://php.net/manual/en/function.quoted-printable-decode.php
  * @param string $str <p>
@@ -852,7 +905,7 @@ function uniqid ($prefix = "", $more_entropy = false) {}
 function quoted_printable_decode ($str) {}
 
 /**
- * (PHP 5 &gt;= 5.3.0)<br/>
+ * @since 5.3.0
  * Convert a 8 bit string to a quoted-printable string
  * @link http://php.net/manual/en/function.quoted-printable-encode.php
  * @param string $str <p>
@@ -863,7 +916,8 @@ function quoted_printable_decode ($str) {}
 function quoted_printable_encode ($str) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Convert from one Cyrillic character set to another
  * @link http://php.net/manual/en/function.convert-cyr-string.php
  * @param string $str <p>
@@ -880,7 +934,8 @@ function quoted_printable_encode ($str) {}
 function convert_cyr_string ($str, $from, $to) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Gets the name of the owner of the current PHP script
  * @link http://php.net/manual/en/function.get-current-user.php
  * @return string the username as a string.
@@ -888,7 +943,8 @@ function convert_cyr_string ($str, $from, $to) {}
 function get_current_user () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Limits the maximum execution time
  * @link http://php.net/manual/en/function.set-time-limit.php
  * @param int $seconds <p>
@@ -900,7 +956,8 @@ function get_current_user () {}
 function set_time_limit ($seconds) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Gets the value of a PHP configuration option
  * @link http://php.net/manual/en/function.get-cfg-var.php
  * @param string $option <p>
@@ -912,7 +969,8 @@ function set_time_limit ($seconds) {}
 function get_cfg_var ($option) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * &Alias; <function>set_magic_quotes_runtime</function>
  * @link http://php.net/manual/en/function.magic-quotes-runtime.php
  * @deprecated since 5.3.0
@@ -921,7 +979,8 @@ function get_cfg_var ($option) {}
 function magic_quotes_runtime ($new_setting) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Sets the current active configuration setting of magic_quotes_runtime
  * @link http://php.net/manual/en/function.set-magic-quotes-runtime.php
  * @deprecated since 5.3.0
@@ -934,7 +993,8 @@ function magic_quotes_runtime ($new_setting) {}
 function set_magic_quotes_runtime ($new_setting) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Gets the current configuration setting of magic quotes gpc
  * @link http://php.net/manual/en/function.get-magic-quotes-gpc.php
  * @return int 0 if magic quotes gpc are off, 1 otherwise.
@@ -943,7 +1003,8 @@ function set_magic_quotes_runtime ($new_setting) {}
 function get_magic_quotes_gpc () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Gets the current active configuration setting of magic_quotes_runtime
  * @link http://php.net/manual/en/function.get-magic-quotes-runtime.php
  * @return int 0 if magic quotes runtime is off, 1 otherwise.
@@ -988,7 +1049,8 @@ function get_magic_quotes_runtime () {}
 function import_request_variables ($types, $prefix = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Send an error message somewhere
  * @link http://php.net/manual/en/function.error-log.php
  * @param string $message <p>

--- a/standard_4.php
+++ b/standard_4.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * (PHP 5 &gt;= 5.2.0)<br/>
+ * @since 5.2.0
  * Get the last occurred error
  * @link http://php.net/manual/en/function.error-get-last.php
  * @return array an associative array describing the last error with keys "type",
@@ -11,7 +11,8 @@
 function error_get_last () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Call a user function given by the first parameter
  * @link http://php.net/manual/en/function.call-user-func.php
  * @param callback $function <p>
@@ -37,7 +38,8 @@ function error_get_last () {}
 function call_user_func ($function, $parameter = null, $_ = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Call a user function given with an array of parameters
  * @link http://php.net/manual/en/function.call-user-func-array.php
  * @param callback $function <p>
@@ -51,7 +53,8 @@ function call_user_func ($function, $parameter = null, $_ = null) {}
 function call_user_func_array ($function, array $param_arr) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Call a user method on an specific object
  * @link http://php.net/manual/en/function.call-user-method.php
  * @deprecated since 5.3.0, use call_user_func() instead
@@ -64,7 +67,8 @@ function call_user_func_array ($function, array $param_arr) {}
 function call_user_method ($method_name, &$obj, $parameter = null, $_ = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.5, PHP 5)<br/>
+ * @since 4.0.5
+ * @since 5.0
  * Call a user method given with an array of parameters
  * @link http://php.net/manual/en/function.call-user-method-array.php
  * @deprecated since 5.3.0, use call_user_func_array() instead
@@ -76,7 +80,7 @@ function call_user_method ($method_name, &$obj, $parameter = null, $_ = null) {}
 function call_user_method_array ($method_name, &$obj, array $params) {}
 
 /**
- * (PHP 5 &gt;= 5.3.0)<br/>
+ * @since 5.3.0
  * Call a static method
  * @link http://php.net/manual/en/function.forward-static-call.php
  * @param callback $function <p>
@@ -93,7 +97,7 @@ function call_user_method_array ($method_name, &$obj, array $params) {}
 function forward_static_call ($function, $parameter = null, $_ = null) {}
 
 /**
- * (PHP 5 &gt;= 5.3.0)<br/>
+ * @since 5.3.0
  * Call a static method and pass the arguments as array
  * @link http://php.net/manual/en/function.forward-static-call-array.php
  * @param callback $function <p>
@@ -107,7 +111,8 @@ function forward_static_call ($function, $parameter = null, $_ = null) {}
 function forward_static_call_array ($function, array $parameters = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Generates a storable representation of a value
  * @link http://php.net/manual/en/function.serialize.php
  * @param mixed $value <p>
@@ -136,7 +141,8 @@ function forward_static_call_array ($function, array $parameters = null) {}
 function serialize ($value) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Creates a PHP value from a stored representation
  * @link http://php.net/manual/en/function.unserialize.php
  * @param string $str <p>
@@ -170,7 +176,8 @@ function serialize ($value) {}
 function unserialize ($str) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Dumps information about a variable
  * @link http://php.net/manual/en/function.var-dump.php
  * @param mixed $expression <p>
@@ -182,7 +189,8 @@ function unserialize ($str) {}
 function var_dump ($expression, $expression = null) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Outputs or returns a parsable string representation of a variable
  * @link http://php.net/manual/en/function.var-export.php
  * @param mixed $expression <p>
@@ -200,7 +208,8 @@ function var_dump ($expression, $expression = null) {}
 function var_export ($expression, $return = null) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Dumps a string representation of an internal zend value to output
  * @link http://php.net/manual/en/function.debug-zval-dump.php
  * @param mixed $variable <p>
@@ -211,7 +220,8 @@ function var_export ($expression, $return = null) {}
 function debug_zval_dump ($variable) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Prints human-readable information about a variable
  * @link http://php.net/manual/en/function.print-r.php
  * @param mixed $expression <p>
@@ -231,7 +241,8 @@ function debug_zval_dump ($variable) {}
 function print_r ($expression, $return = null) {}
 
 /**
- * (PHP 4 &gt;= 4.3.2, PHP 5)<br/>
+ * @since 4.3.2
+ * @since 5.0
  * Returns the amount of memory allocated to PHP
  * @link http://php.net/manual/en/function.memory-get-usage.php
  * @param bool $real_usage [optional] <p>
@@ -244,7 +255,7 @@ function print_r ($expression, $return = null) {}
 function memory_get_usage ($real_usage = null) {}
 
 /**
- * (PHP 5 &gt;= 5.2.0)<br/>
+ * @since 5.2.0
  * Returns the peak of memory allocated by PHP
  * @link http://php.net/manual/en/function.memory-get-peak-usage.php
  * @param bool $real_usage [optional] <p>
@@ -257,7 +268,8 @@ function memory_get_usage ($real_usage = null) {}
 function memory_get_peak_usage ($real_usage = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Register a function for execution on shutdown
  * @link http://php.net/manual/en/function.register-shutdown-function.php
  * @param callback $function <p>
@@ -284,7 +296,8 @@ function memory_get_peak_usage ($real_usage = null) {}
 function register_shutdown_function ($function, $parameter = null, $_ = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.3, PHP 5)<br/>
+ * @since 4.0.3
+ * @since 5.0
  * Register a function for execution on each tick
  * @link http://php.net/manual/en/function.register-tick-function.php
  * @param callback $function <p>
@@ -299,7 +312,8 @@ function register_shutdown_function ($function, $parameter = null, $_ = null) {}
 function register_tick_function ($function, $arg = null, $_ = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.3, PHP 5)<br/>
+ * @since 4.0.3
+ * @since 5.0
  * De-register a function for execution on each tick
  * @link http://php.net/manual/en/function.unregister-tick-function.php
  * @param string $function_name <p>
@@ -310,7 +324,8 @@ function register_tick_function ($function, $arg = null, $_ = null) {}
 function unregister_tick_function ($function_name) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Syntax highlighting of a file
  * @link http://php.net/manual/en/function.highlight-file.php
  * @param string $filename <p>
@@ -327,7 +342,8 @@ function unregister_tick_function ($function_name) {}
 function highlight_file ($filename, $return = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * &Alias; <function>highlight_file</function>
  * @link http://php.net/manual/en/function.show-source.php
  * @param $file_name
@@ -336,7 +352,8 @@ function highlight_file ($filename, $return = null) {}
 function show_source ($file_name, $return) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Syntax highlighting of a string
  * @link http://php.net/manual/en/function.highlight-string.php
  * @param string $str <p>
@@ -353,7 +370,7 @@ function show_source ($file_name, $return) {}
 function highlight_string ($str, $return = null) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Return source with stripped comments and whitespace
  * @link http://php.net/manual/en/function.php-strip-whitespace.php
  * @param string $filename <p>
@@ -371,7 +388,8 @@ function highlight_string ($str, $return = null) {}
 function php_strip_whitespace ($filename) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Gets the value of a configuration option
  * @link http://php.net/manual/en/function.ini-get.php
  * @param string $varname <p>
@@ -383,7 +401,8 @@ function php_strip_whitespace ($filename) {}
 function ini_get ($varname) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Gets all configuration options
  * @link http://php.net/manual/en/function.ini-get-all.php
  * @param string $extension [optional] <p>
@@ -418,7 +437,8 @@ function ini_get ($varname) {}
 function ini_get_all ($extension = null, $details = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Sets the value of a configuration option
  * @link http://php.net/manual/en/function.ini-set.php
  * @param string $varname <p>
@@ -436,7 +456,8 @@ function ini_get_all ($extension = null, $details = null) {}
 function ini_set ($varname, $newvalue) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * &Alias; <function>ini_set</function>
  * @link http://php.net/manual/en/function.ini-alter.php
  * @param $varname
@@ -445,7 +466,8 @@ function ini_set ($varname, $newvalue) {}
 function ini_alter ($varname, $newvalue) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Restores the value of a configuration option
  * @link http://php.net/manual/en/function.ini-restore.php
  * @param string $varname <p>
@@ -456,7 +478,8 @@ function ini_alter ($varname, $newvalue) {}
 function ini_restore ($varname) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Gets the current include_path configuration option
  * @link http://php.net/manual/en/function.get-include-path.php
  * @return string the path, as a string.
@@ -464,7 +487,8 @@ function ini_restore ($varname) {}
 function get_include_path () {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Sets the include_path configuration option
  * @link http://php.net/manual/en/function.set-include-path.php
  * @param string $new_include_path <p>
@@ -476,7 +500,8 @@ function get_include_path () {}
 function set_include_path ($new_include_path) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Restores the value of the include_path configuration option
  * @link http://php.net/manual/en/function.restore-include-path.php
  * @return void 
@@ -484,7 +509,8 @@ function set_include_path ($new_include_path) {}
 function restore_include_path () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Send a cookie
  * @link http://php.net/manual/en/function.setcookie.php
  * @param string $name <p>
@@ -562,7 +588,7 @@ function restore_include_path () {}
 function setcookie ($name, $value = null, $expire = null, $path = null, $domain = null, $secure = null, $httponly = null) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Send a cookie without urlencoding the cookie value
  * @link http://php.net/manual/en/function.setrawcookie.php
  * @param string $name 
@@ -577,7 +603,8 @@ function setcookie ($name, $value = null, $expire = null, $path = null, $domain 
 function setrawcookie ($name, $value = null, $expire = null, $path = null, $domain = null, $secure = null, $httponly = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Send a raw HTTP header
  * @link http://php.net/manual/en/function.header.php
  * @param string $string <p>
@@ -623,7 +650,7 @@ function setrawcookie ($name, $value = null, $expire = null, $path = null, $doma
 function header ($string, $replace = true, $http_response_code = null) {}
 
 /**
- * (PHP 5 &gt;= 5.3.0)<br/>
+ * @since 5.3.0
  * Remove previously set headers
  * @link http://php.net/manual/en/function.header-remove.php
  * @param string $name [optional] <p>
@@ -635,7 +662,8 @@ function header ($string, $replace = true, $http_response_code = null) {}
 function header_remove ($name = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Checks if or where headers have been sent
  * @link http://php.net/manual/en/function.headers-sent.php
  * @param string $file [optional] <p>
@@ -654,7 +682,7 @@ function header_remove ($name = null) {}
 function headers_sent (&$file = null, &$line = null) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Returns a list of response headers sent (or ready to send)
  * @link http://php.net/manual/en/function.headers-list.php
  * @return array a numerically indexed array of headers.
@@ -662,7 +690,8 @@ function headers_sent (&$file = null, &$line = null) {}
 function headers_list () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Check whether client disconnected
  * @link http://php.net/manual/en/function.connection-aborted.php
  * @return int 1 if client disconnected, 0 otherwise.
@@ -670,7 +699,8 @@ function headers_list () {}
 function connection_aborted () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Returns connection status bitfield
  * @link http://php.net/manual/en/function.connection-status.php
  * @return int the connection status bitfield, which can be used against the
@@ -680,7 +710,8 @@ function connection_aborted () {}
 function connection_status () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Set whether a client disconnect should abort script execution
  * @link http://php.net/manual/en/function.ignore-user-abort.php
  * @param string $value [optional] <p>
@@ -693,7 +724,8 @@ function connection_status () {}
 function ignore_user_abort ($value = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Parse a configuration file
  * @link http://php.net/manual/en/function.parse-ini-file.php
  * @param string $filename <p>
@@ -716,7 +748,7 @@ function ignore_user_abort ($value = null) {}
 function parse_ini_file ($filename, $process_sections = null, $scanner_mode = null) {}
 
 /**
- * (PHP 5 &gt;= 5.3.0)<br/>
+ * @since 5.3.0
  * Parse a configuration string
  * @link http://php.net/manual/en/function.parse-ini-string.php
  * @param string $ini <p>
@@ -739,7 +771,8 @@ function parse_ini_file ($filename, $process_sections = null, $scanner_mode = nu
 function parse_ini_string ($ini, $process_sections = null, $scanner_mode = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.3, PHP 5)<br/>
+ * @since 4.0.3
+ * @since 5.0
  * Tells whether the file was uploaded via HTTP POST
  * @link http://php.net/manual/en/function.is-uploaded-file.php
  * @param string $filename <p>
@@ -750,7 +783,8 @@ function parse_ini_string ($ini, $process_sections = null, $scanner_mode = null)
 function is_uploaded_file ($filename) {}
 
 /**
- * (PHP 4 &gt;= 4.0.3, PHP 5)<br/>
+ * @since 4.0.3
+ * @since 5.0
  * Moves an uploaded file to a new location
  * @link http://php.net/manual/en/function.move-uploaded-file.php
  * @param string $filename <p>
@@ -773,7 +807,8 @@ function is_uploaded_file ($filename) {}
 function move_uploaded_file ($filename, $destination) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get the Internet host name corresponding to a given IP address
  * @link http://php.net/manual/en/function.gethostbyaddr.php
  * @param string $ip_address <p>
@@ -785,7 +820,8 @@ function move_uploaded_file ($filename, $destination) {}
 function gethostbyaddr ($ip_address) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get the IPv4 address corresponding to a given Internet host name
  * @link http://php.net/manual/en/function.gethostbyname.php
  * @param string $hostname <p>
@@ -797,7 +833,8 @@ function gethostbyaddr ($ip_address) {}
 function gethostbyname ($hostname) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get a list of IPv4 addresses corresponding to a given Internet host
    name
  * @link http://php.net/manual/en/function.gethostbynamel.php
@@ -819,7 +856,7 @@ function gethostbynamel ($hostname) {}
 function gethostname () {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * &Alias; <function>checkdnsrr</function>
  * @link http://php.net/manual/en/function.dns-check-record.php
  * @param $host <p>
@@ -835,7 +872,8 @@ function gethostname () {}
 function dns_check_record ($host, $type) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Check DNS records corresponding to a given Internet host name or IP address
  * @link http://php.net/manual/en/function.checkdnsrr.php
  * @param string $host <p>
@@ -852,7 +890,7 @@ function dns_check_record ($host, $type) {}
 function checkdnsrr ($host, $type = null) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * &Alias; <function>getmxrr</function>
  * @link http://php.net/manual/en/function.dns-get-mx.php
  * @param $hostname
@@ -862,7 +900,8 @@ function checkdnsrr ($host, $type = null) {}
 function dns_get_mx ($hostname, &$mxhosts, &$weight) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get MX records corresponding to a given Internet host name
  * @link http://php.net/manual/en/function.getmxrr.php
  * @param string $hostname <p>
@@ -882,7 +921,7 @@ function dns_get_mx ($hostname, &$mxhosts, &$weight) {}
 function getmxrr ($hostname, array &$mxhosts, array &$weight = null) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Fetch DNS Resource Records associated with a hostname
  * @link http://php.net/manual/en/function.dns-get-record.php
  * @param string $hostname <p>

--- a/standard_4.php
+++ b/standard_4.php
@@ -57,7 +57,7 @@ function call_user_func_array ($function, array $param_arr) {}
  * @since 5.0
  * Call a user method on an specific object
  * @link http://php.net/manual/en/function.call-user-method.php
- * @deprecated since 5.3.0, use call_user_func() instead
+ * @deprecated 5.3 use call_user_func() instead
  * @param string $method_name
  * @param object $obj 
  * @param mixed $parameter [optional] 
@@ -71,7 +71,7 @@ function call_user_method ($method_name, &$obj, $parameter = null, $_ = null) {}
  * @since 5.0
  * Call a user method given with an array of parameters
  * @link http://php.net/manual/en/function.call-user-method-array.php
- * @deprecated since 5.3.0, use call_user_func_array() instead
+ * @deprecated 5.3 use call_user_func_array() instead
  * @param string $method_name
  * @param object $obj 
  * @param array $params 

--- a/standard_5.php
+++ b/standard_5.php
@@ -9,7 +9,8 @@
 function boolval($var) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get the integer value of a variable
  * @link http://php.net/manual/en/function.intval.php
  * @param mixed $var <p>
@@ -38,7 +39,8 @@ function boolval($var) {}
 function intval ($var, $base = null) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Get float value of a variable
  * @link http://php.net/manual/en/function.floatval.php
  * @param mixed $var May be any scalar type. should not be used on objects, as doing so will emit an E_NOTICE level error and return 1.
@@ -58,7 +60,8 @@ function floatval ($var) {}
 function doubleval ($var) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get string value of a variable
  * @link http://php.net/manual/en/function.strval.php
  * @param mixed $var <p>
@@ -73,7 +76,8 @@ function doubleval ($var) {}
 function strval ($var) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get the type of a variable
  * @link http://php.net/manual/en/function.gettype.php
  * @param mixed $var <p>
@@ -95,7 +99,8 @@ function strval ($var) {}
 function gettype ($var) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Set the type of a variable
  * @link http://php.net/manual/en/function.settype.php
  * @param mixed $var <p>
@@ -132,7 +137,8 @@ function gettype ($var) {}
 function settype (&$var, $type) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Finds whether a variable is &null;
  * @link http://php.net/manual/en/function.is-null.php
  * @param mixed $var <p>
@@ -144,7 +150,8 @@ function settype (&$var, $type) {}
 function is_null ($var) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Finds whether a variable is a resource
  * @link http://php.net/manual/en/function.is-resource.php
  * @param mixed $var <p>
@@ -156,7 +163,8 @@ function is_null ($var) {}
 function is_resource ($var) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Finds out whether a variable is a boolean
  * @link http://php.net/manual/en/function.is-bool.php
  * @param mixed $var <p>
@@ -168,7 +176,8 @@ function is_resource ($var) {}
 function is_bool ($var) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * &Alias; <function>is_int</function>
  * @link http://php.net/manual/en/function.is-long.php
  * @param mixed $var <p>
@@ -180,7 +189,8 @@ function is_bool ($var) {}
 function is_long ($var) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Finds whether the type of a variable is float
  * @link http://php.net/manual/en/function.is-float.php
  * @param mixed $var <p>
@@ -192,7 +202,8 @@ function is_long ($var) {}
 function is_float ($var) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Find whether the type of a variable is integer
  * @link http://php.net/manual/en/function.is-int.php
  * @param mixed $var <p>
@@ -204,7 +215,8 @@ function is_float ($var) {}
 function is_int ($var) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * &Alias; <function>is_int</function>
  * @link http://php.net/manual/en/function.is-integer.php
  * @param mixed $var <p>
@@ -216,7 +228,8 @@ function is_int ($var) {}
 function is_integer ($var) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * &Alias; <function>is_float</function>
  * @link http://php.net/manual/en/function.is-double.php
  * @param mixed $var <p>
@@ -228,7 +241,8 @@ function is_integer ($var) {}
 function is_double ($var) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * &Alias; <function>is_float</function>
  * @link http://php.net/manual/en/function.is-real.php
  * @param mixed $var <p>
@@ -240,7 +254,8 @@ function is_double ($var) {}
 function is_real ($var) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Finds whether a variable is a number or a numeric string
  * @link http://php.net/manual/en/function.is-numeric.php
  * @param mixed $var <p>
@@ -252,7 +267,8 @@ function is_real ($var) {}
 function is_numeric ($var) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Find whether the type of a variable is string
  * @link http://php.net/manual/en/function.is-string.php
  * @param mixed $var <p>
@@ -264,7 +280,8 @@ function is_numeric ($var) {}
 function is_string ($var) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Finds whether a variable is an array
  * @link http://php.net/manual/en/function.is-array.php
  * @param mixed $var <p>
@@ -276,7 +293,8 @@ function is_string ($var) {}
 function is_array ($var) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Finds whether a variable is an object
  * @link http://php.net/manual/en/function.is-object.php
  * @param mixed $var <p>
@@ -288,7 +306,8 @@ function is_array ($var) {}
 function is_object ($var) {}
 
 /**
- * (PHP 4 &gt;= 4.0.5, PHP 5)<br/>
+ * @since 4.0.5
+ * @since 5.0
  * Finds whether a variable is a scalar
  * @link http://php.net/manual/en/function.is-scalar.php
  * @param mixed $var <p>
@@ -300,7 +319,8 @@ function is_object ($var) {}
 function is_scalar ($var) {}
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Verify that the contents of a variable can be called as a function
  * @link http://php.net/manual/en/function.is-callable.php
  * @param callback|callable $name <p>
@@ -328,7 +348,8 @@ function is_scalar ($var) {}
 function is_callable ($name, $syntax_only = null, &$callable_name = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Closes process file pointer
  * @link http://php.net/manual/en/function.pclose.php
  * @param resource $handle <p>
@@ -340,7 +361,8 @@ function is_callable ($name, $syntax_only = null, &$callable_name = null) {}
 function pclose ($handle) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Opens process file pointer
  * @link http://php.net/manual/en/function.popen.php
  * @param string $command <p>
@@ -362,7 +384,8 @@ function pclose ($handle) {}
 function popen ($command, $mode) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Outputs a file
  * @link http://php.net/manual/en/function.readfile.php
  * @param string $filename <p>
@@ -382,7 +405,8 @@ function popen ($command, $mode) {}
 function readfile ($filename, $use_include_path = null, $context = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Rewind the position of a file pointer
  * @link http://php.net/manual/en/function.rewind.php
  * @param resource $handle <p>
@@ -394,7 +418,8 @@ function readfile ($filename, $use_include_path = null, $context = null) {}
 function rewind ($handle) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Removes directory
  * @link http://php.net/manual/en/function.rmdir.php
  * @param string $dirname <p>
@@ -406,7 +431,8 @@ function rewind ($handle) {}
 function rmdir ($dirname, $context = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Changes the current umask
  * @link http://php.net/manual/en/function.umask.php
  * @param int $mask [optional] <p>
@@ -418,7 +444,8 @@ function rmdir ($dirname, $context = null) {}
 function umask ($mask = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Closes an open file pointer
  * @link http://php.net/manual/en/function.fclose.php
  * @param resource $handle <p>
@@ -430,7 +457,8 @@ function umask ($mask = null) {}
 function fclose ($handle) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Tests for end-of-file on a file pointer
  * @link http://php.net/manual/en/function.feof.php
  * @param resource $handle &fs.validfp.all;
@@ -440,7 +468,8 @@ function fclose ($handle) {}
 function feof ($handle) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Gets character from file pointer
  * @link http://php.net/manual/en/function.fgetc.php
  * @param resource $handle &fs.validfp.all;
@@ -450,7 +479,8 @@ function feof ($handle) {}
 function fgetc ($handle) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Gets line from file pointer
  * @link http://php.net/manual/en/function.fgets.php
  * @param resource $handle &fs.validfp.all;
@@ -475,7 +505,8 @@ function fgetc ($handle) {}
 function fgets ($handle, $length = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Gets line from file pointer and strip HTML tags
  * @link http://php.net/manual/en/function.fgetss.php
  * @param resource $handle &fs.validfp.all;
@@ -496,7 +527,8 @@ function fgets ($handle, $length = null) {}
 function fgetss ($handle, $length = null, $allowable_tags = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Binary-safe file read
  * @link http://php.net/manual/en/function.fread.php
  * @param resource $handle &fs.file.pointer;
@@ -508,7 +540,8 @@ function fgetss ($handle, $length = null, $allowable_tags = null) {}
 function fread ($handle, $length) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Opens file or URL
  * @link http://php.net/manual/en/function.fopen.php
  * @param string $filename <p>
@@ -688,7 +721,8 @@ function fread ($handle, $length) {}
 function fopen ($filename, $mode, $use_include_path = null, $context = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Output all remaining data on a file pointer
  * @link http://php.net/manual/en/function.fpassthru.php
  * @param resource $handle &fs.validfp.all;
@@ -700,7 +734,8 @@ function fopen ($filename, $mode, $use_include_path = null, $context = null) {}
 function fpassthru ($handle) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Truncates a file to a given length
  * @link http://php.net/manual/en/function.ftruncate.php
  * @param resource $handle <p>
@@ -725,7 +760,8 @@ function fpassthru ($handle) {}
 function ftruncate ($handle, $size) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Gets information about a file using an open file pointer
  * @link http://php.net/manual/en/function.fstat.php
  * @param resource $handle &fs.file.pointer;
@@ -735,7 +771,8 @@ function ftruncate ($handle, $size) {}
 function fstat ($handle) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Seeks on a file pointer
  * @link http://php.net/manual/en/function.fseek.php
  * @param resource $handle &fs.file.pointer;
@@ -764,7 +801,8 @@ function fstat ($handle) {}
 function fseek ($handle, $offset, $whence = SEEK_SET) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Returns the current position of the file read/write pointer
  * @link http://php.net/manual/en/function.ftell.php
  * @param resource $handle <p>
@@ -782,7 +820,8 @@ function fseek ($handle, $offset, $whence = SEEK_SET) {}
 function ftell ($handle) {}
 
 /**
- * (PHP 4 &gt;= 4.0.1, PHP 5)<br/>
+ * @since 4.0.1
+ * @since 5.0
  * Flushes the output to a file
  * @link http://php.net/manual/en/function.fflush.php
  * @param resource $handle &fs.validfp.all;
@@ -791,7 +830,8 @@ function ftell ($handle) {}
 function fflush ($handle) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Binary-safe file write
  * @link http://php.net/manual/en/function.fwrite.php
  * @param resource $handle &fs.file.pointer;
@@ -815,7 +855,8 @@ function fflush ($handle) {}
 function fwrite ($handle, $string, $length = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * &Alias; <function>fwrite</function>
  * @see fwrite()
  * @link http://php.net/manual/en/function.fputs.php
@@ -841,7 +882,8 @@ function fwrite ($handle, $string, $length = null) {}
 function fputs ($fp, $str, $length) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Attempts to create the directory specified by pathname.
  * @link http://php.net/manual/en/function.mkdir.php
  * @param string $pathname <p>
@@ -870,7 +912,8 @@ function fputs ($fp, $str, $length) {}
 function mkdir ($pathname, $mode = 0777, $recursive = false, $context = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Renames a file or directory
  * @link http://php.net/manual/en/function.rename.php
  * @param string $oldname <p>
@@ -889,7 +932,8 @@ function mkdir ($pathname, $mode = 0777, $recursive = false, $context = null) {}
 function rename ($oldname, $newname, $context = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Copies file
  * @link http://php.net/manual/en/function.copy.php
  * @param string $source <p>
@@ -912,7 +956,8 @@ function rename ($oldname, $newname, $context = null) {}
 function copy ($source, $dest, $context = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Create file with unique file name
  * @link http://php.net/manual/en/function.tempnam.php
  * @param string $dir <p>
@@ -928,7 +973,8 @@ function copy ($source, $dest, $context = null) {}
 function tempnam ($dir, $prefix) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Creates a temporary file
  * @link http://php.net/manual/en/function.tmpfile.php
  * @return resource a file handle, similar to the one returned by
@@ -937,7 +983,8 @@ function tempnam ($dir, $prefix) {}
 function tmpfile () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Reads entire file into an array
  * @link http://php.net/manual/en/function.file.php
  * @param string $filename <p>
@@ -969,7 +1016,8 @@ function tmpfile () {}
 function file ($filename, $flags = null, $context = null) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Reads entire file into a string
  * @link http://php.net/manual/en/function.file-get-contents.php
  * @param string $filename <p>
@@ -1045,7 +1093,7 @@ function file ($filename, $flags = null, $context = null) {}
 function file_get_contents ($filename, $flags = null, $context = null, $offset = null, $maxlen = null) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Write a string to a file
  * @link http://php.net/manual/en/function.file-put-contents.php
  * @param string $filename <p>

--- a/standard_6.php
+++ b/standard_6.php
@@ -1,7 +1,8 @@
 <?php
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Runs the equivalent of the select() system call on the given
    arrays of streams with a timeout specified by tv_sec and tv_usec
  * @link http://php.net/manual/en/function.stream-select.php
@@ -77,7 +78,8 @@
 function stream_select (array &$read, array &$write, array &$except, $tv_sec, $tv_usec = null) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Create a streams context
  * @link http://php.net/manual/en/function.stream-context-create.php
  * @param array $options [optional] <p>
@@ -98,7 +100,8 @@ function stream_select (array &$read, array &$write, array &$except, $tv_sec, $t
 function stream_context_create (array $options = null, array $params = null) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Set parameters for a stream/wrapper/context
  * @link http://php.net/manual/en/function.stream-context-set-params.php
  * @param resource $stream_or_context <p>
@@ -116,7 +119,7 @@ function stream_context_create (array $options = null, array $params = null) {}
 function stream_context_set_params ($stream_or_context, array $params) {}
 
 /**
- * (PHP 5 &gt;= 5.3.0)<br/>
+ * @since 5.3.0
  * Retrieves parameters from a context
  * @link http://php.net/manual/en/function.stream-context-get-params.php
  * @param resource $stream_or_context <p>
@@ -128,7 +131,8 @@ function stream_context_set_params ($stream_or_context, array $params) {}
 function stream_context_get_params ($stream_or_context) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Sets an option for a stream/wrapper/context
  * @link http://php.net/manual/en/function.stream-context-set-option.php
  * @param resource $stream_or_context <p>
@@ -142,7 +146,8 @@ function stream_context_get_params ($stream_or_context) {}
 function stream_context_set_option ($stream_or_context, $wrapper, $option, $value) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Sets an option for a stream/wrapper/context
  * @link http://php.net/manual/en/function.stream-context-set-option.php
  * @param resource $stream_or_context The stream or context resource to apply the options too.
@@ -152,7 +157,8 @@ function stream_context_set_option ($stream_or_context, $wrapper, $option, $valu
 function stream_context_set_option ($stream_or_context, array $options) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Retrieve options for a stream/wrapper/context
  * @link http://php.net/manual/en/function.stream-context-get-options.php
  * @param resource $stream_or_context <p>
@@ -163,7 +169,7 @@ function stream_context_set_option ($stream_or_context, array $options) {}
 function stream_context_get_options ($stream_or_context) {}
 
 /**
- * (PHP 5 &gt;= 5.1.0)<br/>
+ * @since 5.1.0
  * Retreive the default streams context
  * @link http://php.net/manual/en/function.stream-context-get-default.php
  * @param array $options [optional] options must be an associative
@@ -178,7 +184,7 @@ function stream_context_get_options ($stream_or_context) {}
 function stream_context_get_default (array $options = null) {}
 
 /**
- * (PHP 5 &gt;= 5.3.0)<br/>
+ * @since 5.3.0
  * Set the default streams context
  * @link http://php.net/manual/en/function.stream-context-set-default.php
  * @param array $options <p>
@@ -194,7 +200,8 @@ function stream_context_get_default (array $options = null) {}
 function stream_context_set_default (array $options) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Attach a filter to a stream
  * @link http://php.net/manual/en/function.stream-filter-prepend.php
  * @param resource $stream <p>
@@ -230,7 +237,8 @@ function stream_context_set_default (array $options) {}
 function stream_filter_prepend ($stream, $filtername, $read_write = null, $params = null) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Attach a filter to a stream
  * @link http://php.net/manual/en/function.stream-filter-append.php
  * @param resource $stream <p>
@@ -265,7 +273,7 @@ function stream_filter_prepend ($stream, $filtername, $read_write = null, $param
 function stream_filter_append ($stream, $filtername, $read_write = null, $params = null) {}
 
 /**
- * (PHP 5 &gt;= 5.1.0)<br/>
+ * @since 5.1.0
  * Remove a filter from a stream
  * @link http://php.net/manual/en/function.stream-filter-remove.php
  * @param resource $stream_filter <p>
@@ -276,7 +284,7 @@ function stream_filter_append ($stream, $filtername, $read_write = null, $params
 function stream_filter_remove ($stream_filter) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Open Internet or Unix domain socket connection
  * @link http://php.net/manual/en/function.stream-socket-client.php
  * @param string $remote_socket <p>
@@ -319,7 +327,7 @@ function stream_filter_remove ($stream_filter) {}
 function stream_socket_client ($remote_socket, &$errno = null, &$errstr = null, $timeout = null, $flags = null, $context = null) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Create an Internet or Unix domain server socket
  * @link http://php.net/manual/en/function.stream-socket-server.php
  * @param string $local_socket <p>
@@ -370,7 +378,7 @@ function stream_socket_client ($remote_socket, &$errno = null, &$errstr = null, 
 function stream_socket_server ($local_socket, &$errno = null, &$errstr = null, $flags = null, $context = null) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Accept a connection on a socket created by <function>stream_socket_server</function>
  * @link http://php.net/manual/en/function.stream-socket-accept.php
  * @param resource $server_socket 
@@ -391,7 +399,7 @@ function stream_socket_server ($local_socket, &$errno = null, &$errstr = null, $
 function stream_socket_accept ($server_socket, $timeout = null, &$peername = null) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Retrieve the name of the local or remote sockets
  * @link http://php.net/manual/en/function.stream-socket-get-name.php
  * @param resource $handle <p>
@@ -406,7 +414,7 @@ function stream_socket_accept ($server_socket, $timeout = null, &$peername = nul
 function stream_socket_get_name ($handle, $want_peer) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Receives data from a socket, connected or not
  * @link http://php.net/manual/en/function.stream-socket-recvfrom.php
  * @param resource $socket <p>
@@ -446,7 +454,7 @@ function stream_socket_get_name ($handle, $want_peer) {}
 function stream_socket_recvfrom ($socket, $length, $flags = null, &$address = null) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Sends a message to a socket, whether it is connected or not
  * @link http://php.net/manual/en/function.stream-socket-sendto.php
  * @param resource $socket <p>
@@ -480,7 +488,7 @@ function stream_socket_recvfrom ($socket, $length, $flags = null, &$address = nu
 function stream_socket_sendto ($socket, $data, $flags = null, $address = null) {}
 
 /**
- * (PHP 5 &gt;= 5.1.0)<br/>
+ * @since 5.1.0
  * Turns encryption on/off on an already connected socket
  * @link http://php.net/manual/en/function.stream-socket-enable-crypto.php
  * @param resource $stream <p>
@@ -503,7 +511,7 @@ function stream_socket_sendto ($socket, $data, $flags = null, $address = null) {
 function stream_socket_enable_crypto ($stream, $enable, $crypto_type = null, $session_stream = null) {}
 
 /**
- * (PHP 5 &gt;= 5.2.1)<br/>
+ * @since 5.2.1
  * Shutdown a full-duplex connection
  * @link http://php.net/manual/en/function.stream-socket-shutdown.php
  * @param resource $stream <p>
@@ -522,7 +530,7 @@ function stream_socket_enable_crypto ($stream, $enable, $crypto_type = null, $se
 function stream_socket_shutdown ($stream, $how) {}
 
 /**
- * (PHP 5 &gt;= 5.1.0)<br/>
+ * @since 5.1.0
  * Creates a pair of connected, indistinguishable socket streams
  * @link http://php.net/manual/en/function.stream-socket-pair.php
  * @param int $domain <p>
@@ -551,7 +559,7 @@ function stream_socket_shutdown ($stream, $how) {}
 function stream_socket_pair ($domain, $type, $protocol) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Copies data from one stream to another
  * @link http://php.net/manual/en/function.stream-copy-to-stream.php
  * @param resource $source <p>
@@ -571,7 +579,7 @@ function stream_socket_pair ($domain, $type, $protocol) {}
 function stream_copy_to_stream ($source, $dest, $maxlength = null, $offset = null) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Reads remainder of a stream into a string
  * @link http://php.net/manual/en/function.stream-get-contents.php
  * @param resource $handle <p>
@@ -589,7 +597,7 @@ function stream_copy_to_stream ($source, $dest, $maxlength = null, $offset = nul
 function stream_get_contents ($handle, $maxlength = null, $offset = null) {}
 
 /**
- * (PHP 5 &gt;= 5.3.0)<br/>
+ * @since 5.3.0
  * Tells whether the stream supports locking.
  * @link http://php.net/manual/en/function.stream-supports-lock.php
  * @param resource $stream <p>
@@ -600,7 +608,8 @@ function stream_get_contents ($handle, $maxlength = null, $offset = null) {}
 function stream_supports_lock ($stream) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Gets line from file pointer and parse for CSV fields
  * @link http://php.net/manual/en/function.fgetcsv.php
  * @param resource $handle <p>
@@ -640,7 +649,7 @@ function stream_supports_lock ($stream) {}
 function fgetcsv ($handle, $length = null, $delimiter = null, $enclosure = null, $escape = null) {}
 
 /**
- * (PHP 5 &gt;= 5.1.0)<br/>
+ * @since 5.1.0
  * Format line as CSV and write to file pointer
  * @link http://php.net/manual/en/function.fputcsv.php
  * @param resource $handle &fs.validfp.all;
@@ -660,7 +669,8 @@ function fgetcsv ($handle, $length = null, $delimiter = null, $enclosure = null,
 function fputcsv ($handle, array $fields, $delimiter = null, $enclosure = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Portable advisory file locking
  * @link http://php.net/manual/en/function.flock.php
  * @param resource $handle <p>
@@ -678,7 +688,8 @@ function fputcsv ($handle, array $fields, $delimiter = null, $enclosure = null) 
 function flock ($handle, $operation, &$wouldblock = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Extracts all meta tag content attributes from a file and returns an array
  * @link http://php.net/manual/en/function.get-meta-tags.php
  * @param string $filename <p>
@@ -710,7 +721,8 @@ function flock ($handle, $operation, &$wouldblock = null) {}
 function get_meta_tags ($filename, $use_include_path = null) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Sets file buffering on the given stream
  * @link http://php.net/manual/en/function.stream-set-write-buffer.php
  * @param resource $stream <p>
@@ -728,7 +740,8 @@ function get_meta_tags ($filename, $use_include_path = null) {}
 function stream_set_write_buffer ($stream, $buffer) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Sets file buffering on the given stream
  * @link http://php.net/manual/en/function.stream-set-read-buffer.php
  * @param resource $stream <p>
@@ -746,7 +759,8 @@ function stream_set_write_buffer ($stream, $buffer) {}
 function stream_set_read_buffer ($stream, $buffer) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * &Alias; <function>stream_set_write_buffer</function>
  * <p>Sets the buffering for write operations on the given stream to buffer bytes.
  * Output using fwrite() is normally buffered at 8K.
@@ -761,7 +775,8 @@ function stream_set_read_buffer ($stream, $buffer) {}
 function set_file_buffer ($fp, $buffer) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * &Alias; <function>stream_set_blocking</function>
  * <p>Sets blocking or non-blocking mode on a stream.
  * This function works for any stream that supports non-blocking mode (currently, regular files and socket streams).
@@ -776,7 +791,8 @@ function set_file_buffer ($fp, $buffer) {}
 function set_socket_blocking ($socket, $mode) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Set blocking/non-blocking mode on a stream
  * @link http://php.net/manual/en/function.stream-set-blocking.php
  * @param resource $stream <p>
@@ -797,7 +813,8 @@ function set_socket_blocking ($socket, $mode) {}
 function stream_set_blocking ($stream, $mode) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * &Alias; <function>stream_set_blocking</function>
  * @link http://php.net/manual/en/function.socket-set-blocking.php
  * @param resource $socket <p>
@@ -818,7 +835,8 @@ function stream_set_blocking ($stream, $mode) {}
 function socket_set_blocking ($socket, $mode) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Retrieves header/meta data from streams/file pointers
  * @link http://php.net/manual/en/function.stream-get-meta-data.php
  * @param resource $stream <p>
@@ -883,7 +901,7 @@ function socket_set_blocking ($socket, $mode) {}
 function stream_get_meta_data ($stream) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Gets line from stream resource up to a given delimiter
  * @link http://php.net/manual/en/function.stream-get-line.php
  * @param resource $handle <p>
@@ -904,7 +922,8 @@ function stream_get_meta_data ($stream) {}
 function stream_get_line ($handle, $length, $ending = null) {}
 
 /**
- * (PHP 4 &gt;= 4.3.2, PHP 5)<br/>
+ * @since 4.3.2
+ * @since 5.0
  * Register a URL wrapper implemented as a PHP class
  * @link http://php.net/manual/en/function.stream-wrapper-register.php
  * @param string $protocol <p>
@@ -927,7 +946,8 @@ function stream_get_line ($handle, $length, $ending = null) {}
 function stream_wrapper_register ($protocol, $classname, $flags = null) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * &Alias; <function>stream_wrapper_register</function>
  * <p>Register a URL wrapper implemented as a PHP class
  * @link http://php.net/manual/en/function.stream-register-wrapper.php
@@ -951,7 +971,7 @@ function stream_wrapper_register ($protocol, $classname, $flags = null) {}
 function stream_register_wrapper ($protocol, $classname, $flags) {}
 
 /**
- * (PHP 5 &gt;= 5.3.2)<br/>
+ * @since 5.3.2
  * Resolve filename against the include path according to the same rules as fopen()/include().
  * @link http://php.net/manual/en/function.stream-resolve-include-path.php
  * @param string $filename The filename to resolve.<p>
@@ -961,7 +981,7 @@ function stream_register_wrapper ($protocol, $classname, $flags) {}
 function stream_resolve_include_path ($filename) {}
 
 /**
- * (PHP 5 &gt;= 5.1.0)<br/>
+ * @since 5.1.0
  * Unregister a URL wrapper
  * @link http://php.net/manual/en/function.stream-wrapper-unregister.php
  * @param string $protocol <p>
@@ -971,7 +991,7 @@ function stream_resolve_include_path ($filename) {}
 function stream_wrapper_unregister ($protocol) {}
 
 /**
- * (PHP 5 &gt;= 5.1.0)<br/>
+ * @since 5.1.0
  * Restores a previously unregistered built-in wrapper
  * @link http://php.net/manual/en/function.stream-wrapper-restore.php
  * @param string $protocol <p>
@@ -981,7 +1001,7 @@ function stream_wrapper_unregister ($protocol) {}
 function stream_wrapper_restore ($protocol) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Retrieve list of registered streams
  * @link http://php.net/manual/en/function.stream-get-wrappers.php
  * @return array an indexed array containing the name of all stream wrappers
@@ -990,7 +1010,7 @@ function stream_wrapper_restore ($protocol) {}
 function stream_get_wrappers () {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Retrieve list of registered socket transports
  * @link http://php.net/manual/en/function.stream-get-transports.php
  * @return array an indexed array of socket transports names.
@@ -998,7 +1018,7 @@ function stream_get_wrappers () {}
 function stream_get_transports () {}
 
 /**
- * (PHP 5 &gt;= 5.2.4)<br/>
+ * @since 5.2.4
  * Checks if a stream is a local stream
  * @link http://php.net/manual/en/function.stream-is-local.php
  * @param mixed $stream_or_url <p>
@@ -1009,7 +1029,7 @@ function stream_get_transports () {}
 function stream_is_local ($stream_or_url) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Fetches all the headers sent by the server in response to a HTTP request
  * @link http://php.net/manual/en/function.get-headers.php
  * @param string $url <p>
@@ -1026,7 +1046,8 @@ function stream_is_local ($stream_or_url) {}
 function get_headers ($url, $format = null) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Set timeout period on a stream
  * @link http://php.net/manual/en/function.stream-set-timeout.php
  * @param resource $stream <p>
@@ -1043,7 +1064,8 @@ function get_headers ($url, $format = null) {}
 function stream_set_timeout ($stream, $seconds, $microseconds = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * &Alias; <function>stream_set_timeout</function>
  * <p>Set timeout period on a stream
  * @link http://php.net/manual/en/function.socket-set-timeout.php
@@ -1061,7 +1083,8 @@ function stream_set_timeout ($stream, $seconds, $microseconds = null) {}
 function socket_set_timeout ($stream, $seconds, $microseconds = 0) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * &Alias; <function>stream_get_meta_data</function>
  * Retrieves header/meta data from streams/file pointers
  * @link http://php.net/manual/en/function.socket-get-status.php
@@ -1127,7 +1150,8 @@ function socket_set_timeout ($stream, $seconds, $microseconds = 0) {}
 function socket_get_status (resource $stream) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Returns canonicalized absolute pathname
  * @link http://php.net/manual/en/function.realpath.php
  * @param string $path <p>
@@ -1143,7 +1167,8 @@ function socket_get_status (resource $stream) {}
 function realpath ($path) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Match filename against a pattern
  * @link http://php.net/manual/en/function.fnmatch.php
  * @param string $pattern <p>

--- a/standard_6.php
+++ b/standard_6.php
@@ -781,7 +781,7 @@ function set_file_buffer ($fp, $buffer) {}
  * <p>Sets blocking or non-blocking mode on a stream.
  * This function works for any stream that supports non-blocking mode (currently, regular files and socket streams).
  * @link http://php.net/manual/en/function.set-socket-blocking.php
- * @deprecated since 5.3.0, use stream_set_blocking() instead
+ * @deprecated 5.3 use stream_set_blocking() instead
  * @param resource $socket
  * @param int $mode If mode is 0, the given stream will be switched to non-blocking mode, and if 1, it will be switched to blocking mode.
  * This affects calls like fgets() and fread() that read from the stream.

--- a/standard_7.php
+++ b/standard_7.php
@@ -1,7 +1,8 @@
 <?php
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Open Internet or Unix domain socket connection
  * @link http://php.net/manual/en/function.fsockopen.php
  * @param string $hostname <p>
@@ -46,7 +47,8 @@
 function fsockopen ($hostname, $port = null, &$errno = null, &$errstr = null, $timeout = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Open persistent Internet or Unix domain socket connection
  * @link http://php.net/manual/en/function.pfsockopen.php
  * @param string $hostname 
@@ -59,7 +61,8 @@ function fsockopen ($hostname, $port = null, &$errno = null, &$errstr = null, $t
 function pfsockopen ($hostname, $port = null, &$errno = null, &$errstr = null, $timeout = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Pack data into binary string
  * @link http://php.net/manual/en/function.pack.php
  * @param string $format <p>
@@ -167,7 +170,8 @@ function pfsockopen ($hostname, $port = null, &$errno = null, &$errstr = null, $
 function pack ($format, $args = null, $_ = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Unpack data from binary string
  * @link http://php.net/manual/en/function.unpack.php
  * @param string $format <p>
@@ -182,7 +186,8 @@ function pack ($format, $args = null, $_ = null) {}
 function unpack ($format, $data) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Tells what the user's browser is capable of
  * @link http://php.net/manual/en/function.get-browser.php
  * @param string $user_agent [optional] <p>
@@ -212,7 +217,8 @@ function unpack ($format, $data) {}
 function get_browser ($user_agent = null, $return_array = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * One-way string encryption (hashing)
  * @link http://php.net/manual/en/function.crypt.php
  * @param string $str <p>
@@ -233,7 +239,8 @@ function get_browser ($user_agent = null, $return_array = null) {}
 function crypt ($str, $salt = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Open directory handle
  * @link http://php.net/manual/en/function.opendir.php
  * @param string $path <p>
@@ -260,7 +267,8 @@ function crypt ($str, $salt = null) {}
 function opendir ($path, $context = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Close directory handle
  * @link http://php.net/manual/en/function.closedir.php
  * @param resource $dir_handle [optional] <p>
@@ -274,7 +282,8 @@ function opendir ($path, $context = null) {}
 function closedir ($dir_handle = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Change directory
  * @link http://php.net/manual/en/function.chdir.php
  * @param string $directory <p>
@@ -285,7 +294,8 @@ function closedir ($dir_handle = null) {}
 function chdir ($directory) {}
 
 /**
- * (PHP 4 &gt;= 4.0.5, PHP 5)<br/>
+ * @since 4.0.5
+ * @since 5.0
  * Change the root directory
  * @link http://php.net/manual/en/function.chroot.php
  * @param string $directory <p>
@@ -296,7 +306,8 @@ function chdir ($directory) {}
 function chroot ($directory) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Gets the current working directory
  * @link http://php.net/manual/en/function.getcwd.php
  * @return string the current working directory on success, or false on
@@ -312,7 +323,8 @@ function chroot ($directory) {}
 function getcwd () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Rewind directory handle
  * @link http://php.net/manual/en/function.rewinddir.php
  * @param resource $dir_handle [optional] <p>
@@ -326,7 +338,8 @@ function getcwd () {}
 function rewinddir ($dir_handle = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Read entry from directory handle
  * @link http://php.net/manual/en/function.readdir.php
  * @param resource $dir_handle [optional] <p>
@@ -340,7 +353,8 @@ function rewinddir ($dir_handle = null) {}
 function readdir ($dir_handle = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Return an instance of the Directory class
  * @link http://php.net/manual/en/class.dir.php
  * @param $directory
@@ -350,7 +364,7 @@ function readdir ($dir_handle = null) {}
 function dir ($directory, $context) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * List files and directories inside the specified path
  * @link http://php.net/manual/en/function.scandir.php
  * @param string $directory <p>
@@ -374,7 +388,8 @@ function dir ($directory, $context) {}
 function scandir ($directory, $sorting_order = null, $context = null) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Find pathnames matching a pattern
  * @link http://php.net/manual/en/function.glob.php
  * @param string $pattern <p>
@@ -393,7 +408,8 @@ function scandir ($directory, $sorting_order = null, $context = null) {}
 function glob ($pattern, $flags = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Gets last access time of file
  * @link http://php.net/manual/en/function.fileatime.php
  * @param string $filename <p>
@@ -405,7 +421,8 @@ function glob ($pattern, $flags = null) {}
 function fileatime ($filename) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Gets inode change time of file
  * @link http://php.net/manual/en/function.filectime.php
  * @param string $filename <p>
@@ -417,7 +434,8 @@ function fileatime ($filename) {}
 function filectime ($filename) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Gets file group
  * @link http://php.net/manual/en/function.filegroup.php
  * @param string $filename <p>
@@ -431,7 +449,8 @@ function filectime ($filename) {}
 function filegroup ($filename) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Gets file inode
  * @link http://php.net/manual/en/function.fileinode.php
  * @param string $filename <p>
@@ -442,7 +461,8 @@ function filegroup ($filename) {}
 function fileinode ($filename) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Gets file modification time
  * @link http://php.net/manual/en/function.filemtime.php
  * @param string $filename <p>
@@ -455,7 +475,8 @@ function fileinode ($filename) {}
 function filemtime ($filename) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Gets file owner
  * @link http://php.net/manual/en/function.fileowner.php
  * @param string $filename <p>
@@ -468,7 +489,8 @@ function filemtime ($filename) {}
 function fileowner ($filename) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Gets file permissions
  * @link http://php.net/manual/en/function.fileperms.php
  * @param string $filename <p>
@@ -479,7 +501,8 @@ function fileowner ($filename) {}
 function fileperms ($filename) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Gets file size
  * @link http://php.net/manual/en/function.filesize.php
  * @param string $filename <p>
@@ -491,7 +514,8 @@ function fileperms ($filename) {}
 function filesize ($filename) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Gets file type
  * @link http://php.net/manual/en/function.filetype.php
  * @param string $filename <p>
@@ -508,7 +532,8 @@ function filesize ($filename) {}
 function filetype ($filename) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Checks whether a file or directory exists
  * @link http://php.net/manual/en/function.file-exists.php
  * @param string $filename <p>
@@ -537,7 +562,8 @@ function filetype ($filename) {}
 function file_exists ($filename) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Tells whether the filename is writable
  * @link http://php.net/manual/en/function.is-writable.php
  * @param string $filename <p>
@@ -549,7 +575,8 @@ function file_exists ($filename) {}
 function is_writable ($filename) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * &Alias; <function>is_writable</function>
  * @link http://php.net/manual/en/function.is-writeable.php
  * @param string $filename <p>
@@ -561,7 +588,8 @@ function is_writable ($filename) {}
 function is_writeable ($filename) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Tells whether a file exists and is readable
  * @link http://php.net/manual/en/function.is-readable.php
  * @param string $filename <p>
@@ -573,7 +601,8 @@ function is_writeable ($filename) {}
 function is_readable ($filename) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Tells whether the filename is executable
  * @link http://php.net/manual/en/function.is-executable.php
  * @param string $filename <p>
@@ -585,7 +614,8 @@ function is_readable ($filename) {}
 function is_executable ($filename) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Tells whether the filename is a regular file
  * @link http://php.net/manual/en/function.is-file.php
  * @param string $filename <p>
@@ -597,7 +627,8 @@ function is_executable ($filename) {}
 function is_file ($filename) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Tells whether the filename is a directory
  * @link http://php.net/manual/en/function.is-dir.php
  * @param string $filename <p>
@@ -612,7 +643,8 @@ function is_file ($filename) {}
 function is_dir ($filename) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Tells whether the filename is a symbolic link
  * @link http://php.net/manual/en/function.is-link.php
  * @param string $filename <p>
@@ -624,7 +656,8 @@ function is_dir ($filename) {}
 function is_link ($filename) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Gives information about a file
  * @link http://php.net/manual/en/function.stat.php
  * @param string $filename <p>
@@ -716,7 +749,8 @@ function is_link ($filename) {}
 function stat ($filename) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Gives information about a file or symbolic link
  * @link http://php.net/manual/en/function.lstat.php
  * @param string $filename <p>
@@ -732,7 +766,8 @@ function stat ($filename) {}
 function lstat ($filename) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Changes file owner
  * @link http://php.net/manual/en/function.chown.php
  * @param string $filename <p>
@@ -746,7 +781,8 @@ function lstat ($filename) {}
 function chown ($filename, $user) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Changes file group
  * @link http://php.net/manual/en/function.chgrp.php
  * @param string $filename <p>
@@ -760,7 +796,7 @@ function chown ($filename, $user) {}
 function chgrp ($filename, $group) {}
 
 /**
- * (PHP 5 &gt;= 5.1.2)<br/>
+ * @since 5.1.2
  * Changes user ownership of symlink
  * @link http://php.net/manual/en/function.lchown.php
  * @param string $filename <p>
@@ -774,7 +810,7 @@ function chgrp ($filename, $group) {}
 function lchown ($filename, $user) {}
 
 /**
- * (PHP 5 &gt;= 5.1.2)<br/>
+ * @since 5.1.2
  * Changes group ownership of symlink
  * @link http://php.net/manual/en/function.lchgrp.php
  * @param string $filename <p>
@@ -788,7 +824,8 @@ function lchown ($filename, $user) {}
 function lchgrp ($filename, $group) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Changes file mode
  * @link http://php.net/manual/en/function.chmod.php
  * @param string $filename <p>
@@ -821,7 +858,8 @@ function lchgrp ($filename, $group) {}
 function chmod ($filename, $mode) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Sets access and modification time of file
  * @link http://php.net/manual/en/function.touch.php
  * @param string $filename <p>
@@ -841,7 +879,8 @@ function chmod ($filename, $mode) {}
 function touch ($filename, $time = null, $atime = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Clears file status cache
  * @link http://php.net/manual/en/function.clearstatcache.php
  * @param bool $clear_realpath_cache [optional] <p>
@@ -856,7 +895,8 @@ function touch ($filename, $time = null, $atime = null) {}
 function clearstatcache ($clear_realpath_cache = null, $filename = null) {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Returns the total size of a directory
  * @link http://php.net/manual/en/function.disk-total-space.php
  * @param string $directory <p>
@@ -868,7 +908,8 @@ function clearstatcache ($clear_realpath_cache = null, $filename = null) {}
 function disk_total_space ($directory) {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Returns available space in directory
  * @link http://php.net/manual/en/function.disk-free-space.php
  * @param string $directory <p>
@@ -885,7 +926,8 @@ function disk_total_space ($directory) {}
 function disk_free_space ($directory) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * &Alias; <function>disk_free_space</function>
  * @link http://php.net/manual/en/function.diskfreespace.php
  * @param $path
@@ -893,7 +935,8 @@ function disk_free_space ($directory) {}
 function diskfreespace ($path) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Send mail
  * @link http://php.net/manual/en/function.mail.php
  * @param string $to <p>
@@ -976,7 +1019,8 @@ function diskfreespace ($path) {}
 function mail ($to, $subject, $message, $additional_headers = null, $additional_parameters = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Calculate the hash value needed by EZMLM
  * @link http://php.net/manual/en/function.ezmlm-hash.php
  * @param string $addr <p>
@@ -987,7 +1031,8 @@ function mail ($to, $subject, $message, $additional_headers = null, $additional_
 function ezmlm_hash ($addr) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Open connection to system logger
  * @link http://php.net/manual/en/function.openlog.php
  * @param string $ident <p>

--- a/standard_8.php
+++ b/standard_8.php
@@ -2,7 +2,8 @@
 
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Generate a system log message
  * @link http://php.net/manual/en/function.syslog.php
  * @param int $priority <p>
@@ -59,7 +60,8 @@
 function syslog ($priority, $message) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Close connection to system logger
  * @link http://php.net/manual/en/function.closelog.php
  * @return bool true on success or false on failure.
@@ -67,7 +69,8 @@ function syslog ($priority, $message) {}
 function closelog () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Registers a function that will be called when PHP starts sending output.
  * The callback is executed just after PHP prepares all headers to be sent,<br>
  * and before any other output is sent, creating a window to manipulate the outgoing headers before being sent.
@@ -118,7 +121,8 @@ function stream_set_chunk_size ($fp , $chunk_size) {}
 function socket_import_stream ($stream) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Initializes all syslog related variables
  * @link http://php.net/manual/en/function.define-syslog-variables.php
  * @deprecated since 5.3.0
@@ -127,7 +131,8 @@ function socket_import_stream ($stream) {}
 function define_syslog_variables () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Combined linear congruential generator
  * @link http://php.net/manual/en/function.lcg-value.php
  * @return float A pseudo random float value in the range of (0, 1)
@@ -135,7 +140,8 @@ function define_syslog_variables () {}
 function lcg_value () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Calculate the metaphone key of a string
  * @link http://php.net/manual/en/function.metaphone.php
  * @param string $str <p>
@@ -148,7 +154,8 @@ function lcg_value () {}
 function metaphone ($str, $phones = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Turn on output buffering
  * @link http://php.net/manual/en/function.ob-start.php
  * @param callback $output_callback [optional] <p>
@@ -217,7 +224,8 @@ function metaphone ($str, $phones = null) {}
 function ob_start ($output_callback = null, $chunk_size = null, $erase = null) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Flush (send) the output buffer
  * @link http://php.net/manual/en/function.ob-flush.php
  * @return void 
@@ -225,7 +233,8 @@ function ob_start ($output_callback = null, $chunk_size = null, $erase = null) {
 function ob_flush () {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Clean (erase) the output buffer
  * @link http://php.net/manual/en/function.ob-clean.php
  * @return void 
@@ -233,7 +242,8 @@ function ob_flush () {}
 function ob_clean () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Flush (send) the output buffer and turn off output buffering
  * @link http://php.net/manual/en/function.ob-end-flush.php
  * @return bool true on success or false on failure. Reasons for failure are first that you called the
@@ -243,7 +253,8 @@ function ob_clean () {}
 function ob_end_flush () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Clean (erase) the output buffer and turn off output buffering
  * @link http://php.net/manual/en/function.ob-end-clean.php
  * @return bool true on success or false on failure. Reasons for failure are first that you called the
@@ -253,7 +264,8 @@ function ob_end_flush () {}
 function ob_end_clean () {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Flush the output buffer, return it as a string and turn off output buffering
  * @link http://php.net/manual/en/function.ob-get-flush.php
  * @return string the output buffer or false if no buffering is active.
@@ -261,7 +273,8 @@ function ob_end_clean () {}
 function ob_get_flush () {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Get current buffer contents and delete current output buffer
  * @link http://php.net/manual/en/function.ob-get-clean.php
  * @return string the contents of the output buffer and end output buffering.
@@ -270,7 +283,8 @@ function ob_get_flush () {}
 function ob_get_clean () {}
 
 /**
- * (PHP 4 &gt;= 4.0.2, PHP 5)<br/>
+ * @since 4.0.2
+ * @since 5.0
  * Return the length of the output buffer
  * @link http://php.net/manual/en/function.ob-get-length.php
  * @return int the length of the output buffer contents or false if no
@@ -279,7 +293,8 @@ function ob_get_clean () {}
 function ob_get_length () {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Return the nesting level of the output buffering mechanism
  * @link http://php.net/manual/en/function.ob-get-level.php
  * @return int the level of nested output buffering handlers or zero if output
@@ -288,7 +303,8 @@ function ob_get_length () {}
 function ob_get_level () {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Get status of output buffers
  * @link http://php.net/manual/en/function.ob-get-status.php
  * @param bool $full_status [optional] <p>
@@ -354,7 +370,8 @@ function ob_get_level () {}
 function ob_get_status ($full_status = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Return the contents of the output buffer
  * @link http://php.net/manual/en/function.ob-get-contents.php
  * @return string This will return the contents of the output buffer or false, if output
@@ -363,7 +380,8 @@ function ob_get_status ($full_status = null) {}
 function ob_get_contents () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Turn implicit flush on/off
  * @link http://php.net/manual/en/function.ob-implicit-flush.php
  * @param int $flag [optional] <p>
@@ -374,7 +392,8 @@ function ob_get_contents () {}
 function ob_implicit_flush ($flag = null) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * List all output handlers in use
  * @link http://php.net/manual/en/function.ob-list-handlers.php
  * @return array This will return an array with the output handlers in use (if any). If
@@ -386,7 +405,8 @@ function ob_implicit_flush ($flag = null) {}
 function ob_list_handlers () {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Sort an array by key
  * @link http://php.net/manual/en/function.ksort.php
  * @param array $array <p>
@@ -402,7 +422,8 @@ function ob_list_handlers () {}
 function ksort (array &$array, $sort_flags = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Sort an array by key in reverse order
  * @link http://php.net/manual/en/function.krsort.php
  * @param array $array <p>
@@ -418,7 +439,8 @@ function ksort (array &$array, $sort_flags = null) {}
 function krsort (array &$array, $sort_flags = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Sort an array using a "natural order" algorithm
  * @link http://php.net/manual/en/function.natsort.php
  * @param array $array <p>
@@ -429,7 +451,8 @@ function krsort (array &$array, $sort_flags = null) {}
 function natsort (array &$array) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Sort an array using a case insensitive "natural order" algorithm
  * @link http://php.net/manual/en/function.natcasesort.php
  * @param array $array <p>
@@ -440,7 +463,8 @@ function natsort (array &$array) {}
 function natcasesort (array &$array) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Sort an array and maintain index association
  * @link http://php.net/manual/en/function.asort.php
  * @param array $array <p>
@@ -456,7 +480,8 @@ function natcasesort (array &$array) {}
 function asort (array &$array, $sort_flags = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Sort an array in reverse order and maintain index association
  * @link http://php.net/manual/en/function.arsort.php
  * @param array $array <p>
@@ -472,7 +497,8 @@ function asort (array &$array, $sort_flags = null) {}
 function arsort (array &$array, $sort_flags = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Sort an array
  * @link http://php.net/manual/en/function.sort.php
  * @param array $array <p>
@@ -491,7 +517,8 @@ function arsort (array &$array, $sort_flags = null) {}
 function sort (array &$array, $sort_flags = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Sort an array in reverse order
  * @link http://php.net/manual/en/function.rsort.php
  * @param array $array <p>
@@ -507,7 +534,8 @@ function sort (array &$array, $sort_flags = null) {}
 function rsort (array &$array, $sort_flags = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Sort an array by values using a user-defined comparison function
  * @link http://php.net/manual/en/function.usort.php
  * @param array $array <p>
@@ -523,7 +551,8 @@ function rsort (array &$array, $sort_flags = null) {}
 function usort (array &$array, $cmp_function) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Sort an array with a user-defined comparison function and maintain index association
  * @link http://php.net/manual/en/function.uasort.php
  * @param array $array <p>
@@ -538,7 +567,8 @@ function usort (array &$array, $cmp_function) {}
 function uasort (array &$array, $cmp_function) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Sort an array by keys using a user-defined comparison function
  * @link http://php.net/manual/en/function.uksort.php
  * @param array $array <p>
@@ -560,7 +590,8 @@ function uasort (array &$array, $cmp_function) {}
 function uksort (array &$array, $cmp_function) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Shuffle an array
  * @link http://php.net/manual/en/function.shuffle.php
  * @param array $array <p>
@@ -571,7 +602,8 @@ function uksort (array &$array, $cmp_function) {}
 function shuffle (array &$array) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Apply a user function to every member of an array
  * @link http://php.net/manual/en/function.array-walk.php
  * @param array $array <p>
@@ -606,7 +638,7 @@ function shuffle (array &$array) {}
 function array_walk (array &$array, $funcname, $userdata = null) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Apply a user function recursively to every member of an array
  * @link http://php.net/manual/en/function.array-walk-recursive.php
  * @param array $input <p>
@@ -635,7 +667,8 @@ function array_walk (array &$array, $funcname, $userdata = null) {}
 function array_walk_recursive (array &$input, $funcname, $userdata = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Counts all elements in an array, or something in an object.
  * <p>For objects, if you have SPL installed, you can hook into count() by implementing interface {@see Countable}.
  * The interface has exactly one method, {@see Countable::count()}, which returns the return value for the count() function.
@@ -665,7 +698,8 @@ function array_walk_recursive (array &$input, $funcname, $userdata = null) {}
 function count ($var, $mode = COUNT_NORMAL) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Set the internal pointer of an array to its last element
  * @link http://php.net/manual/en/function.end.php
  * @param array $array <p>
@@ -679,7 +713,8 @@ function count ($var, $mode = COUNT_NORMAL) {}
 function end (array &$array) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Rewind the internal array pointer
  * @link http://php.net/manual/en/function.prev.php
  * @param array $array <p>
@@ -692,7 +727,8 @@ function end (array &$array) {}
 function prev (array &$array) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Advance the internal array pointer of an array
  * @link http://php.net/manual/en/function.next.php
  * @param array $array <p>
@@ -704,7 +740,8 @@ function prev (array &$array) {}
 function next (array &$array) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Set the internal pointer of an array to its first element
  * @link http://php.net/manual/en/function.reset.php
  * @param array $array <p>
@@ -716,7 +753,8 @@ function next (array &$array) {}
 function reset (array &$array) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Return the current element in an array
  * @link http://php.net/manual/en/function.current.php
  * @param array $array <p>
@@ -731,7 +769,8 @@ function reset (array &$array) {}
 function current (array &$array) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Fetch a key from an array
  * @link http://php.net/manual/en/function.key.php
  * @param array $array <p>
@@ -746,7 +785,8 @@ function current (array &$array) {}
 function key (array &$array) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Find lowest value
  * @link http://php.net/manual/en/function.min.php
  * @param array|mixed $value1 Array to look through or first value to compare
@@ -759,7 +799,8 @@ function key (array &$array) {}
 function min (array $value1, $value2 = null, ...$values) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Find highest value
  * @link http://php.net/manual/en/function.max.php
  * @param array|mixed $value1 Array to look through or first value to compare
@@ -772,7 +813,8 @@ function min (array $value1, $value2 = null, ...$values) {}
 function max (array $value1, $value2 = null, ...$values) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Checks if a value exists in an array
  * @link http://php.net/manual/en/function.in-array.php
  * @param mixed $needle <p>
@@ -797,7 +839,8 @@ function max (array $value1, $value2 = null, ...$values) {}
 function in_array ($needle, array $haystack, $strict = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.5, PHP 5)<br/>
+ * @since 4.0.5
+ * @since 5.0
  * Searches the array for a given value and returns the corresponding key if successful
  * @link http://php.net/manual/en/function.array-search.php
  * @param mixed $needle <p>
@@ -828,7 +871,8 @@ function in_array ($needle, array $haystack, $strict = null) {}
 function array_search ($needle, array $haystack, $strict = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Import variables into the current symbol table from an array
  * @link http://php.net/manual/en/function.extract.php
  * @param array array $var_<p>
@@ -857,7 +901,8 @@ function array_search ($needle, array $haystack, $strict = null) {}
 function extract (array $var_array, $extract_type = null, $prefix = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Create array containing variables and their values
  * @link http://php.net/manual/en/function.compact.php
  * @param mixed $varname <p>
@@ -873,7 +918,8 @@ function extract (array $var_array, $extract_type = null, $prefix = null) {}
 function compact ($varname, $_ = null) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Fill an array with values
  * @link http://php.net/manual/en/function.array-fill.php
  * @param int $start_index <p>
@@ -891,7 +937,7 @@ function compact ($varname, $_ = null) {}
 function array_fill ($start_index, $num, $value) {}
 
 /**
- * (PHP 5 &gt;= 5.2.0)<br/>
+ * @since 5.2.0
  * Fill an array with values, specifying keys
  * @link http://php.net/manual/en/function.array-fill-keys.php
  * @param array $keys <p>
@@ -906,7 +952,8 @@ function array_fill ($start_index, $num, $value) {}
 function array_fill_keys (array $keys, $value) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Create an array containing a range of elements
  * @link http://php.net/manual/en/function.range.php
  * @param mixed $low <p>
@@ -928,7 +975,8 @@ function array_fill_keys (array $keys, $value) {}
 function range ($low, $high, $step = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Sort multiple or multi-dimensional arrays
  * @link http://php.net/manual/en/function.array-multisort.php
  * @param array $arr <p>
@@ -950,7 +998,8 @@ function range ($low, $high, $step = null) {}
 function array_multisort (array &$arr, $arg = null, $arg = null, $_ = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Push one or more elements onto the end of array
  * @link http://php.net/manual/en/function.array-push.php
  * @param array $array <p>
@@ -965,7 +1014,8 @@ function array_multisort (array &$arr, $arg = null, $arg = null, $_ = null) {}
 function array_push (array &$array, $var, $_ = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Pop the element off the end of array
  * @link http://php.net/manual/en/function.array-pop.php
  * @param array $array <p>
@@ -978,7 +1028,8 @@ function array_push (array &$array, $var, $_ = null) {}
 function array_pop (array &$array) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Shift an element off the beginning of array
  * @link http://php.net/manual/en/function.array-shift.php
  * @param array $array <p>
@@ -990,7 +1041,8 @@ function array_pop (array &$array) {}
 function array_shift (array &$array) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Prepend one or more elements to the beginning of an array
  * @link http://php.net/manual/en/function.array-unshift.php
  * @param array $array <p>
@@ -1005,7 +1057,8 @@ function array_shift (array &$array) {}
 function array_unshift (array &$array, $var, $_ = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Remove a portion of the array and replace it with something else
  * @link http://php.net/manual/en/function.array-splice.php
  * @param array $input <p>
@@ -1052,7 +1105,8 @@ function array_unshift (array &$array, $var, $_ = null) {}
 function array_splice (array &$input, $offset, $length = null, $replacement = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Extract a slice of the array
  * @link http://php.net/manual/en/function.array-slice.php
  * @param array $array <p>
@@ -1083,7 +1137,8 @@ function array_splice (array &$input, $offset, $length = null, $replacement = nu
 function array_slice (array $array, $offset, $length = null, $preserve_keys = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Merge one or more arrays
  * @link http://php.net/manual/en/function.array-merge.php
  * @param array $array1 <p>

--- a/standard_8.php
+++ b/standard_8.php
@@ -125,7 +125,7 @@ function socket_import_stream ($stream) {}
  * @since 5.0
  * Initializes all syslog related variables
  * @link http://php.net/manual/en/function.define-syslog-variables.php
- * @deprecated since 5.3.0
+ * @deprecated 5.3
  * @return void
  */
 function define_syslog_variables () {}

--- a/standard_9.php
+++ b/standard_9.php
@@ -742,7 +742,8 @@ function pos(&$arg) { }
 function sizeof($var, $mode) { }
 
 /**
- * (PHP 4 < 4.0.6)<br/>
+ * @since 4.0.7
+ * @since 5.0
  * Checks if the given key or index exists in the array. The name of this function is array_key_exists() in PHP > 4.0.6.
  * @link http://php.net/manual/en/function.array-key-exists.php
  * @param mixed $key <p>

--- a/standard_9.php
+++ b/standard_9.php
@@ -6,7 +6,8 @@ define ("ARRAY_FILTER_USE_KEY", 2);
 
 
 /**
- * (PHP 4 &gt;= 4.0.1, PHP 5)<br/>
+ * @since 4.0.1
+ * @since 5.0
  * Merge two or more arrays recursively
  * @link http://php.net/manual/en/function.array-merge-recursive.php
  * @param array $array1 <p>
@@ -18,7 +19,7 @@ define ("ARRAY_FILTER_USE_KEY", 2);
 function array_merge_recursive(array $array1, array $_ = null) { }
 
 /**
- * (PHP 5 &gt;= 5.3.0)<br/>
+ * @since 5.3.0
  * array_replace() replaces the values of the first array with the same values from all the following arrays.
  * If a key from the first array exists in the second array, its value will be replaced by the value from the second array.
  * If the key exists in the second array, and not the first, it will be created in the first array.
@@ -39,7 +40,7 @@ function array_merge_recursive(array $array1, array $_ = null) { }
 function array_replace(array $array, array $array1, array $array2 = null, array $_ = null) { }
 
 /**
- * (PHP 5 &gt;= 5.3.0)<br/>
+ * @since 5.3.0
  * Replaces elements from passed arrays into the first array recursively
  * @link http://php.net/manual/en/function.array-replace-recursive.php
  * @param array $array <p>
@@ -55,7 +56,8 @@ function array_replace(array $array, array $array1, array $array2 = null, array 
 function array_replace_recursive(array $array, array $array1, array $array2 = null, array $_ = null) { }
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Return all the keys of an array
  * @link http://php.net/manual/en/function.array-keys.php
  * @param array $input <p>
@@ -72,7 +74,8 @@ function array_replace_recursive(array $array, array $array1, array $array2 = nu
 function array_keys(array $input, $search_value = null, $strict = null) { }
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Return all the values of an array
  * @link http://php.net/manual/en/function.array-values.php
  * @param array $input <p>
@@ -83,7 +86,8 @@ function array_keys(array $input, $search_value = null, $strict = null) { }
 function array_values(array $input) { }
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Counts all the values of an array
  * @link http://php.net/manual/en/function.array-count-values.php
  * @param array $input <p>
@@ -106,7 +110,8 @@ function array_count_values(array $input) { }
 function array_column(array $array, $column, $index_key = null) { }
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Return an array with elements in reverse order
  * @link http://php.net/manual/en/function.array-reverse.php
  * @param array $array <p>
@@ -120,7 +125,8 @@ function array_column(array $array, $column, $index_key = null) { }
 function array_reverse(array $array, $preserve_keys = null) { }
 
 /**
- * (PHP 4 &gt;= 4.0.5, PHP 5)<br/>
+ * @since 4.0.5
+ * @since 5.0
  * Iteratively reduce the array to a single value using a callback function
  * @link http://php.net/manual/en/function.array-reduce.php
  * @param array $input <p>
@@ -143,7 +149,8 @@ function array_reverse(array $array, $preserve_keys = null) { }
 function array_reduce(array $input, $function, $initial = null) { }
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Pad array to the specified length with a value
  * @link http://php.net/manual/en/function.array-pad.php
  * @param array $input <p>
@@ -166,7 +173,8 @@ function array_reduce(array $input, $function, $initial = null) { }
 function array_pad(array $input, $pad_size, $pad_value) { }
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Exchanges all keys with their associated values in an array
  * @link http://php.net/manual/en/function.array-flip.php
  * @param array $trans <p>
@@ -177,7 +185,8 @@ function array_pad(array $input, $pad_size, $pad_value) { }
 function array_flip(array $trans) { }
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Changes all keys in an array
  * @link http://php.net/manual/en/function.array-change-key-case.php
  * @param array $input <p>
@@ -193,7 +202,8 @@ function array_flip(array $trans) { }
 function array_change_key_case(array $input, $case = null) { }
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Pick one or more random entries out of an array
  * @link http://php.net/manual/en/function.array-rand.php
  * @param array $input <p>
@@ -210,7 +220,8 @@ function array_change_key_case(array $input, $case = null) { }
 function array_rand(array $input, $num_req = null) { }
 
 /**
- * (PHP 4 &gt;= 4.0.1, PHP 5)<br/>
+ * @since 4.0.1
+ * @since 5.0
  * Removes duplicate values from an array
  * @link http://php.net/manual/en/function.array-unique.php
  * @param array $array <p>
@@ -229,7 +240,8 @@ function array_rand(array $input, $num_req = null) { }
 function array_unique(array $array, $sort_flags = null) { }
 
 /**
- * (PHP 4 &gt;= 4.0.1, PHP 5)<br/>
+ * @since 4.0.1
+ * @since 5.0
  * Computes the intersection of arrays
  * @link http://php.net/manual/en/function.array-intersect.php
  * @param array $array1 <p>
@@ -245,7 +257,7 @@ function array_unique(array $array, $sort_flags = null) { }
 function array_intersect(array $array1, array $array2, array $_ = null) { }
 
 /**
- * (PHP 5 &gt;= 5.1.0)<br/>
+ * @since 5.1.0
  * Computes the intersection of arrays using keys for comparison
  * @link http://php.net/manual/en/function.array-intersect-key.php
  * @param array $array1 <p>
@@ -262,7 +274,7 @@ function array_intersect(array $array1, array $array2, array $_ = null) { }
 function array_intersect_key(array $array1, array $array2, array $_ = null) { }
 
 /**
- * (PHP 5 &gt;= 5.1.0)<br/>
+ * @since 5.1.0
  * Computes the intersection of arrays using a callback function on the keys for comparison
  * @link http://php.net/manual/en/function.array-intersect-ukey.php
  * @param array $array1 <p>
@@ -281,7 +293,7 @@ function array_intersect_key(array $array1, array $array2, array $_ = null) { }
 function array_intersect_ukey(array $array1, array $array2, array $_ = null, $key_compare_func) { }
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Computes the intersection of arrays, compares data by a callback function
  * @link http://php.net/manual/en/function.array-uintersect.php
  * @param array $array1 <p>
@@ -306,7 +318,8 @@ function array_intersect_ukey(array $array1, array $array2, array $_ = null, $ke
 function array_uintersect(array $array1, array $array2, array $_ = null, $data_compare_func) { }
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Computes the intersection of arrays with additional index check
  * @link http://php.net/manual/en/function.array-intersect-assoc.php
  * @param array $array1 <p>
@@ -322,7 +335,7 @@ function array_uintersect(array $array1, array $array2, array $_ = null, $data_c
 function array_intersect_assoc(array $array1, array $array2, array $_ = null) { }
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Computes the intersection of arrays with additional index check, compares data by a callback function
  * @link http://php.net/manual/en/function.array-uintersect-assoc.php
  * @param array $array1 <p>
@@ -345,7 +358,7 @@ function array_intersect_assoc(array $array1, array $array2, array $_ = null) { 
 function array_uintersect_assoc(array $array1, array $array2, array $_ = null, $data_compare_func) { }
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Computes the intersection of arrays with additional index check, compares indexes by a callback function
  * @link http://php.net/manual/en/function.array-intersect-uassoc.php
  * @param array $array1 <p>
@@ -364,7 +377,7 @@ function array_uintersect_assoc(array $array1, array $array2, array $_ = null, $
 function array_intersect_uassoc(array $array1, array $array2, array $_ = null, $key_compare_func) { }
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Computes the intersection of arrays with additional index check, compares data and indexes by a callback functions
  * @link http://php.net/manual/en/function.array-uintersect-uassoc.php
  * @param array $array1 <p>
@@ -390,7 +403,8 @@ function array_intersect_uassoc(array $array1, array $array2, array $_ = null, $
 function array_uintersect_uassoc(array $array1, array $array2, array $_ = null, $data_compare_func, $key_compare_func) { }
 
 /**
- * (PHP 4 &gt;= 4.0.1, PHP 5)<br/>
+ * @since 4.0.1
+ * @since 5.0
  * Computes the difference of arrays
  * @link http://php.net/manual/en/function.array-diff.php
  * @param array $array1 <p>
@@ -406,7 +420,7 @@ function array_uintersect_uassoc(array $array1, array $array2, array $_ = null, 
 function array_diff(array $array1, array $array2, array $_ = null) { }
 
 /**
- * (PHP 5 &gt;= 5.1.0)<br/>
+ * @since 5.1.0
  * Computes the difference of arrays using keys for comparison
  * @link http://php.net/manual/en/function.array-diff-key.php
  * @param array $array1 <p>
@@ -423,7 +437,7 @@ function array_diff(array $array1, array $array2, array $_ = null) { }
 function array_diff_key(array $array1, array $array2, array $_ = null) { }
 
 /**
- * (PHP 5 &gt;= 5.1.0)<br/>
+ * @since 5.1.0
  * Computes the difference of arrays using a callback function on the keys for comparison
  * @link http://php.net/manual/en/function.array-diff-ukey.php
  * @param array $array1 <p>
@@ -445,7 +459,7 @@ function array_diff_key(array $array1, array $array2, array $_ = null) { }
 function array_diff_ukey(array $array1, array $array2, array $_ = null, $key_compare_func) { }
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Computes the difference of arrays by using a callback function for data comparison
  * @link http://php.net/manual/en/function.array-udiff.php
  * @param array $array1 <p>
@@ -470,7 +484,8 @@ function array_diff_ukey(array $array1, array $array2, array $_ = null, $key_com
 function array_udiff(array $array1, array $array2, array $_ = null, $data_compare_func) { }
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Computes the difference of arrays with additional index check
  * @link http://php.net/manual/en/function.array-diff-assoc.php
  * @param array $array1 <p>
@@ -486,7 +501,7 @@ function array_udiff(array $array1, array $array2, array $_ = null, $data_compar
 function array_diff_assoc(array $array1, array $array2, array $_ = null) { }
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Computes the difference of arrays with additional index check, compares data by a callback function
  * @link http://php.net/manual/en/function.array-udiff-assoc.php
  * @param array $array1 <p>
@@ -518,7 +533,7 @@ function array_diff_assoc(array $array1, array $array2, array $_ = null) { }
 function array_udiff_assoc(array $array1, array $array2, array $_ = null, $data_compare_func) { }
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Computes the difference of arrays with additional index check which is performed by a user supplied callback function
  * @link http://php.net/manual/en/function.array-diff-uassoc.php
  * @param array $array1 <p>
@@ -540,7 +555,7 @@ function array_udiff_assoc(array $array1, array $array2, array $_ = null, $data_
 function array_diff_uassoc(array $array1, array $array2, array $_ = null, $key_compare_func) { }
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Computes the difference of arrays with additional index check, compares data and indexes by a callback function
  * @link http://php.net/manual/en/function.array-udiff-uassoc.php
  * @param array $array1 <p>
@@ -579,7 +594,8 @@ function array_diff_uassoc(array $array1, array $array2, array $_ = null, $key_c
 function array_udiff_uassoc(array $array1, array $array2, array $_ = null, $data_compare_func, $key_compare_func) { }
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Calculate the sum of values in an array
  * @link http://php.net/manual/en/function.array-sum.php
  * @param array $array <p>
@@ -590,7 +606,7 @@ function array_udiff_uassoc(array $array1, array $array2, array $_ = null, $data
 function array_sum(array $array) { }
 
 /**
- * (PHP 5 &gt;= 5.1.0)<br/>
+ * @since 5.1.0
  * Calculate the product of values in an array
  * @link http://php.net/manual/en/function.array-product.php
  * @param array $array <p>
@@ -601,7 +617,8 @@ function array_sum(array $array) { }
 function array_product(array $array) { }
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Iterates over each value in the <b>array</b>
  * passing them to the <b>callback</b> function.
  * If the <b>callback</b> function returns true, the
@@ -637,7 +654,8 @@ function array_product(array $array) { }
 function array_filter(array $input, $callback = null, $flag = 0) { }
 
 /**
- * (PHP 4 &gt;= 4.0.6, PHP 5)<br/>
+ * @since 4.0.6
+ * @since 5.0
  * Applies the callback to the elements of the given arrays
  * @link http://php.net/manual/en/function.array-map.php
  * @param callback $callback <p>
@@ -653,7 +671,8 @@ function array_filter(array $input, $callback = null, $flag = 0) { }
 function array_map($callback, array $arr1, array $_ = null) { }
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Split an array into chunks
  * @link http://php.net/manual/en/function.array-chunk.php
  * @param array $input <p>
@@ -672,7 +691,7 @@ function array_map($callback, array $arr1, array $_ = null) { }
 function array_chunk(array $input, $size, $preserve_keys = null) { }
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Creates an array by using one array for keys and another for its values
  * @link http://php.net/manual/en/function.array-combine.php
  * @param array $keys <p>
@@ -688,7 +707,8 @@ function array_chunk(array $input, $size, $preserve_keys = null) { }
 function array_combine(array $keys, array $values) { }
 
 /**
- * (PHP 4 &gt;= 4.0.7, PHP 5)<br/>
+ * @since 4.0.7
+ * @since 5.0
  * Checks if the given key or index exists in the array
  * @link http://php.net/manual/en/function.array-key-exists.php
  * @param mixed $key <p>
@@ -702,7 +722,8 @@ function array_combine(array $keys, array $values) { }
 function array_key_exists($key, array $search) { }
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * &Alias; <function>current</function>
  * @link http://php.net/manual/en/function.pos.php
  * @param $arg
@@ -710,7 +731,8 @@ function array_key_exists($key, array $search) { }
 function pos(&$arg) { }
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * &Alias; <function>count</function>
  * @link http://php.net/manual/en/function.sizeof.php
  * @param $var
@@ -735,7 +757,8 @@ function sizeof($var, $mode) { }
 function key_exists($key, $search) { }
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Checks if assertion is &false;
  * @link http://php.net/manual/en/function.assert.php
  * @param mixed $assertion <p>
@@ -764,7 +787,8 @@ function cli_get_process_title() { }
 function cli_set_process_title($title) { }
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Set/get the various assert flags
  * @link http://php.net/manual/en/function.assert-options.php
  * @param int $what <p>
@@ -819,7 +843,8 @@ function cli_set_process_title($title) { }
 function assert_options($what, $value = null) { }
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Compares two "PHP-standardized" version number strings
  * @link http://php.net/manual/en/function.version-compare.php
  * @param string $version1 <p>
@@ -856,7 +881,8 @@ function assert_options($what, $value = null) { }
 function version_compare($version1, $version2, $operator = null) { }
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Convert a pathname and a project identifier to a System V IPC key
  * @link http://php.net/manual/en/function.ftok.php
  * @param string $pathname <p>
@@ -871,7 +897,8 @@ function version_compare($version1, $version2, $operator = null) { }
 function ftok($pathname, $proj) { }
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Perform the rot13 transform on a string
  * @link http://php.net/manual/en/function.str-rot13.php
  * @param string $str <p>
@@ -882,7 +909,7 @@ function ftok($pathname, $proj) { }
 function str_rot13($str) { }
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Retrieve list of registered filters
  * @link http://php.net/manual/en/function.stream-get-filters.php
  * @return array an indexed array containing the name of all stream filters
@@ -891,7 +918,7 @@ function str_rot13($str) { }
 function stream_get_filters() { }
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Register a user defined stream filter
  * @link http://php.net/manual/en/function.stream-filter-register.php
  * @param string $filtername <p>
@@ -1008,7 +1035,7 @@ function stream_get_filters() { }
 function stream_filter_register($filtername, $classname) { }
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Return a bucket object from the brigade for operating on
  * @link http://php.net/manual/en/function.stream-bucket-make-writeable.php
  * @param resource $brigade
@@ -1017,7 +1044,7 @@ function stream_filter_register($filtername, $classname) { }
 function stream_bucket_make_writeable($brigade) { }
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Prepend bucket to brigade
  * @link http://php.net/manual/en/function.stream-bucket-prepend.php
  * @param resource $brigade
@@ -1027,7 +1054,7 @@ function stream_bucket_make_writeable($brigade) { }
 function stream_bucket_prepend($brigade, $bucket) { }
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Append bucket to brigade
  * @link http://php.net/manual/en/function.stream-bucket-append.php
  * @param resource $brigade
@@ -1037,7 +1064,7 @@ function stream_bucket_prepend($brigade, $bucket) { }
 function stream_bucket_append($brigade, $bucket) { }
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * Create a new bucket for use on the current stream
  * @link http://php.net/manual/en/function.stream-bucket-new.php
  * @param resource $stream
@@ -1047,7 +1074,8 @@ function stream_bucket_append($brigade, $bucket) { }
 function stream_bucket_new($stream, $buffer) { }
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Add URL rewriter values
  * @link http://php.net/manual/en/function.output-add-rewrite-var.php
  * @param string $name <p>
@@ -1061,7 +1089,8 @@ function stream_bucket_new($stream, $buffer) { }
 function output_add_rewrite_var($name, $value) { }
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Reset URL rewriter values
  * @link http://php.net/manual/en/function.output-reset-rewrite-vars.php
  * @return bool true on success or false on failure.
@@ -1069,7 +1098,7 @@ function output_add_rewrite_var($name, $value) { }
 function output_reset_rewrite_vars() { }
 
 /**
- * (PHP 5 &gt;= 5.2.1)<br/>
+ * @since 5.2.1
  * Returns directory path used for temporary files
  * @link http://php.net/manual/en/function.sys-get-temp-dir.php
  * @return string the path of the temporary directory.

--- a/standard_defines.php
+++ b/standard_defines.php
@@ -249,7 +249,7 @@ define ('ENT_COMPAT', 2);
 define ('ENT_QUOTES', 3);
 define ('ENT_NOQUOTES', 0);
 /**
- * (PHP 5 &gt;= 5.3.0)<br/>
+ * @since 5.3.0
  */
 define ('ENT_IGNORE', 4);
 define ('STR_PAD_LEFT', 0);
@@ -260,7 +260,7 @@ define ('PATHINFO_BASENAME', 2);
 define ('PATHINFO_EXTENSION', 4);
 
 /**
- * Since PHP 5.2.0.
+ * @since 5.2.0
  * @link http://php.net/manual/en/filesystem.constants.php
  */
 define ('PATHINFO_FILENAME', 8);
@@ -565,24 +565,20 @@ define ('FILE_NO_DEFAULT_CONTEXT', 16);
 
 /**
  * <p>
- * Text mode (since PHP 5.2.7).
- * <p>
  * This constant has no effect prior to PHP 6. It is only available for 
  * forward compatibility.
  * </p>
- * </p>
+ * @since 5.2.7
  * @link http://php.net/manual/en/filesystem.constants.php
  */
 define ('FILE_TEXT', 0);
 
 /**
  * <p>
- * Binary mode (since PHP 5.2.7).
- * <p>
  * This constant has no effect prior to PHP 6. It is only available for 
  * forward compatibility.
  * </p>
- * </p>
+ * @since 5.2.7
  * @link http://php.net/manual/en/filesystem.constants.php
  */
 define ('FILE_BINARY', 0);
@@ -1172,17 +1168,20 @@ define('FILTER_SANITIZE_FULL_SPECIAL_CHARS', 515);
  */
 define('SID', "name=ID");
 /**
- * Return value of session_status() if sessions are disabled. Since PHP 5.4.0.
+ * Return value of session_status() if sessions are disabled.
+ * @since 5.4.0
  * @link http://php.net/manual/en/function.session-status.php
  */
 define('PHP_SESSION_DISABLED', 0);
 /**
- * Return value of session_status() if sessions are enabled, but no session exists. Since PHP 5.4.0.
+ * Return value of session_status() if sessions are enabled, but no session exists.
+ * @since 5.4.0
  * @link http://php.net/manual/en/function.session-status.php
  */
 define('PHP_SESSION_NONE', 1);
 /**
- * Return value of session_status() if sessions are enabled, and a session exists. Since PHP 5.4.0.
+ * Return value of session_status() if sessions are enabled, and a session exists.
+ * @since 5.4.0
  * @link http://php.net/manual/en/function.session-status.php
  */
 define('PHP_SESSION_ACTIVE', 2);
@@ -1269,14 +1268,14 @@ define('IPPROTO_IPV6', 41);
 
 
 /**
- * (PHP 5 &gt;= 5.4.0)<br/>
+ * @since 5.4.0
  * Replace invalid code unit sequences with a Unicode Replacement Character
  * U+FFFD (UTF-8) or &#FFFD; (otherwise) instead of returning an empty string.
  * @link http://php.net/manual/en/function.htmlspecialchars.php
  */
 define('ENT_SUBSTITUTE', 8);
 /**
- * (PHP 5 &gt;= 5.4.0)<br/>
+ * @since 5.4.0
  * Replace invalid code points for the given document type with
  * a Unicode Replacement Character U+FFFD (UTF-8) or &#FFFD;
  * (otherwise) instead of leaving them as is. This may be useful,
@@ -1286,25 +1285,25 @@ define('ENT_SUBSTITUTE', 8);
  */
 define('ENT_DISALLOWED', 128);
 /**
- * (PHP 5 &gt;= 5.4.0)<br/>
+ * @since 5.4.0
  * Handle code as HTML 4.01.
  * @link http://php.net/manual/en/function.htmlspecialchars.php
  */
 define('ENT_HTML401', 0);
 /**
- * (PHP 5 &gt;= 5.4.0)<br/>
+ * @since 5.4.0
  * Handle code as XML 1.
  * @link http://php.net/manual/en/function.htmlspecialchars.php
  */
 define('ENT_XML1', 16);
 /**
- * (PHP 5 &gt;= 5.4.0)<br/>
+ * @since 5.4.0
  * Handle code as XHTML.
  * @link http://php.net/manual/en/function.htmlspecialchars.php
  */
 define('ENT_XHTML', 32);
 /**
- * (PHP 5 &gt;= 5.4.0)<br/>
+ * @since 5.4.0
  * Handle code as HTML 5.
  * @link http://php.net/manual/en/function.htmlspecialchars.php
  */

--- a/sysvmsg.php
+++ b/sysvmsg.php
@@ -3,7 +3,8 @@
 // Start of sysvmsg v.
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Create or attach to a message queue
  * @link http://php.net/manual/en/function.msg-get-queue.php
  * @param int $key <p>
@@ -18,7 +19,8 @@
 function msg_get_queue ($key, $perms = 0666) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Send a message to a message queue
  * @link http://php.net/manual/en/function.msg-send.php
  * @param resource $queue
@@ -57,7 +59,8 @@ function msg_get_queue ($key, $perms = 0666) {}
 function msg_send ($queue, $msgtype, $message, $serialize = true, $blocking = true, &$errorcode = null) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Receive a message from a message queue
  * @link http://php.net/manual/en/function.msg-receive.php
  * @param resource $queue
@@ -145,7 +148,8 @@ function msg_send ($queue, $msgtype, $message, $serialize = true, $blocking = tr
 function msg_receive ($queue, $desiredmsgtype, &$msgtype, $maxsize, &$message, $unserialize = true, $flags = 0, &$errorcode = null) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Destroy a message queue
  * @link http://php.net/manual/en/function.msg-remove-queue.php
  * @param resource $queue <p>
@@ -156,7 +160,8 @@ function msg_receive ($queue, $desiredmsgtype, &$msgtype, $maxsize, &$message, $
 function msg_remove_queue ($queue) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Returns information from the message queue data structure
  * @link http://php.net/manual/en/function.msg-stat-queue.php
  * @param resource $queue <p>
@@ -233,7 +238,8 @@ function msg_remove_queue ($queue) {}
 function msg_stat_queue ($queue) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Set information in the message queue data structure
  * @link http://php.net/manual/en/function.msg-set-queue.php
  * @param resource $queue <p>
@@ -248,7 +254,7 @@ function msg_stat_queue ($queue) {}
 function msg_set_queue ($queue, array $data) {}
 
 /**
- * (PHP 5 &gt;= 5.3.0)<br/>
+ * @since 5.3.0
  * Check whether a message queue exists
  * @link http://php.net/manual/en/function.msg-queue-exists.php
  * @param int $key <p>

--- a/sysvsem.php
+++ b/sysvsem.php
@@ -3,7 +3,8 @@
 // Start of sysvsem v.
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get a semaphore id
  * @link http://php.net/manual/en/function.sem-get.php
  * @param int $key
@@ -26,7 +27,8 @@
 function sem_get ($key, $max_acquire = 1, $perm = 0666, $auto_release = 1) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Acquire a semaphore
  * @link http://php.net/manual/en/function.sem-acquire.php
  * @param resource $sem_identifier <p>
@@ -38,7 +40,8 @@ function sem_get ($key, $max_acquire = 1, $perm = 0666, $auto_release = 1) {}
 function sem_acquire ($sem_identifier) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Release a semaphore
  * @link http://php.net/manual/en/function.sem-release.php
  * @param resource $sem_identifier <p>
@@ -50,7 +53,8 @@ function sem_acquire ($sem_identifier) {}
 function sem_release ($sem_identifier) {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Remove a semaphore
  * @link http://php.net/manual/en/function.sem-remove.php
  * @param resource $sem_identifier <p>

--- a/sysvshm.php
+++ b/sysvshm.php
@@ -3,7 +3,8 @@
 // Start of sysvshm v.
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Creates or open a shared memory segment
  * @link http://php.net/manual/en/function.shm-attach.php
  * @param int $key <p>
@@ -22,7 +23,8 @@
 function shm_attach ($key, $memsize = null, $perm = 0666) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Removes shared memory from Unix systems
  * @link http://php.net/manual/en/function.shm-remove.php
  * @param resource $shm_identifier <p>
@@ -34,7 +36,8 @@ function shm_attach ($key, $memsize = null, $perm = 0666) {}
 function shm_remove ($shm_identifier) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Disconnects from shared memory segment
  * @link http://php.net/manual/en/function.shm-detach.php
  * @param resource $shm_identifier <p>
@@ -46,7 +49,8 @@ function shm_remove ($shm_identifier) {}
 function shm_detach ($shm_identifier) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Inserts or updates a variable in shared memory
  * @link http://php.net/manual/en/function.shm-put-var.php
  * @param resource $shm_identifier <p>
@@ -67,7 +71,7 @@ function shm_detach ($shm_identifier) {}
 function shm_put_var ($shm_identifier, $variable_key, $variable) {}
 
 /**
- * (PHP 5 &gt;= 5.3.0)<br/>
+ * @since 5.3.0
  * Check whether a specific entry exists
  * @link http://php.net/manual/en/function.shm-has-var.php
  * @param resource $shm_identifier <p>
@@ -81,7 +85,8 @@ function shm_put_var ($shm_identifier, $variable_key, $variable) {}
 function shm_has_var ($shm_identifier, $variable_key) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Returns a variable from shared memory
  * @link http://php.net/manual/en/function.shm-get-var.php
  * @param resource $shm_identifier <p>
@@ -95,7 +100,8 @@ function shm_has_var ($shm_identifier, $variable_key) {}
 function shm_get_var ($shm_identifier, $variable_key) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Removes a variable from shared memory
  * @link http://php.net/manual/en/function.shm-remove-var.php
  * @param resource $shm_identifier <p>

--- a/tidy.php
+++ b/tidy.php
@@ -210,7 +210,7 @@ class tidy  {
 	public function getHtmlVer () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.1.0)<br/>
+	 * @since 5.1.0
 	 * Returns the documentation for the given option name
 	 * @link http://php.net/manual/en/tidy.getoptdoc.php
 	 * @param string $optname <p>
@@ -375,7 +375,7 @@ final class tidyNode  {
 
 
 	/**
-	 * (PHP 5 &gt;= 5.0.1)<br/>
+	 * @since 5.0.1
 	 * Checks if a node has children
 	 * @link http://php.net/manual/en/tidynode.haschildren.php
 	 * @return bool <b>TRUE</b> if the node has children, <b>FALSE</b> otherwise.
@@ -383,7 +383,7 @@ final class tidyNode  {
 	public function hasChildren () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.0.1)<br/>
+	 * @since 5.0.1
 	 * Checks if a node has siblings
 	 * @link http://php.net/manual/en/tidynode.hassiblings.php
 	 * @return bool <b>TRUE</b> if the node has siblings, <b>FALSE</b> otherwise.
@@ -391,7 +391,7 @@ final class tidyNode  {
 	public function hasSiblings () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.0.1)<br/>
+	 * @since 5.0.1
 	 * Checks if a node represents a comment
 	 * @link http://php.net/manual/en/tidynode.iscomment.php
 	 * @return bool <b>TRUE</b> if the node is a comment, <b>FALSE</b> otherwise.
@@ -399,7 +399,7 @@ final class tidyNode  {
 	public function isComment () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.0.1)<br/>
+	 * @since 5.0.1
 	 * Checks if a node is part of a HTML document
 	 * @link http://php.net/manual/en/tidynode.ishtml.php
 	 * @return bool <b>TRUE</b> if the node is part of a HTML document, <b>FALSE</b> otherwise.
@@ -407,7 +407,7 @@ final class tidyNode  {
 	public function isHtml () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.0.1)<br/>
+	 * @since 5.0.1
 	 * Checks if a node represents text (no markup)
 	 * @link http://php.net/manual/en/tidynode.istext.php
 	 * @return bool <b>TRUE</b> if the node represent a text, <b>FALSE</b> otherwise.
@@ -415,7 +415,7 @@ final class tidyNode  {
 	public function isText () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.0.1)<br/>
+	 * @since 5.0.1
 	 * Checks if this node is JSTE
 	 * @link http://php.net/manual/en/tidynode.isjste.php
 	 * @return bool <b>TRUE</b> if the node is JSTE, <b>FALSE</b> otherwise.
@@ -423,7 +423,7 @@ final class tidyNode  {
 	public function isJste () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.0.1)<br/>
+	 * @since 5.0.1
 	 * Checks if this node is ASP
 	 * @link http://php.net/manual/en/tidynode.isasp.php
 	 * @return bool <b>TRUE</b> if the node is ASP, <b>FALSE</b> otherwise.
@@ -431,7 +431,7 @@ final class tidyNode  {
 	public function isAsp () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.0.1)<br/>
+	 * @since 5.0.1
 	 * Checks if a node is PHP
 	 * @link http://php.net/manual/en/tidynode.isphp.php
 	 * @return bool <b>TRUE</b> if the current node is PHP code, <b>FALSE</b> otherwise.
@@ -439,7 +439,7 @@ final class tidyNode  {
 	public function isPhp () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.2.2)<br/>
+	 * @since 5.2.2
 	 * Returns the parent node of the current node
 	 * @link http://php.net/manual/en/tidynode.getparent.php
 	 * @return tidyNode a tidyNode if the node has a parent, or <b>NULL</b>
@@ -738,7 +738,7 @@ function tidy_access_count (tidy $object) {}
 function tidy_config_count (tidy $object) {}
 
 /**
- * (PHP 5 &gt;= 5.1.0)<br/>
+ * @since 5.1.0
  * Returns the documentation for the given option name
  * @link http://php.net/manual/en/tidy.getoptdoc.php
  * @param string $optname <p>
@@ -784,7 +784,7 @@ function tidy_get_html () {}
 function tidy_get_body ($tidy) {}
 
 /**
- * (PHP 5)<br/>
+ * @since 5.0
  * ob_start callback function to repair the buffer
  * @link http://php.net/manual/en/function.ob-tidyhandler.php
  * @param string $input <p>

--- a/tokenizer.php
+++ b/tokenizer.php
@@ -3,7 +3,8 @@
 // Start of tokenizer v.0.1
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Split given source into PHP tokens
  * @link http://php.net/manual/en/function.token-get-all.php
  * @param string $source <p>
@@ -18,7 +19,8 @@
 function token_get_all ($source) {}
 
 /**
- * (PHP 4 &gt;= 4.2.0, PHP 5)<br/>
+ * @since 4.2.0
+ * @since 5.0
  * Get the symbolic name of a given PHP token
  * @link http://php.net/manual/en/function.token-name.php
  * @param int $token <p>

--- a/wddx.php
+++ b/wddx.php
@@ -3,7 +3,8 @@
 // Start of wddx v.
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Serialize a single value into a WDDX packet
  * @link http://php.net/manual/en/function.wddx-serialize-value.php
  * @param mixed $var <p>
@@ -17,7 +18,8 @@
 function wddx_serialize_value ($var, $comment = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Serialize variables into a WDDX packet
  * @link http://php.net/manual/en/function.wddx-serialize-vars.php
  * @param mixed $var_name <p>
@@ -30,7 +32,8 @@ function wddx_serialize_value ($var, $comment = null) {}
 function wddx_serialize_vars ($var_name, $_ = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Starts a new WDDX packet with structure inside it
  * @link http://php.net/manual/en/function.wddx-packet-start.php
  * @param string $comment [optional] <p>
@@ -41,7 +44,8 @@ function wddx_serialize_vars ($var_name, $_ = null) {}
 function wddx_packet_start ($comment = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Ends a WDDX packet with the specified ID
  * @link http://php.net/manual/en/function.wddx-packet-end.php
  * @param resource $packet_id <p>
@@ -52,7 +56,8 @@ function wddx_packet_start ($comment = null) {}
 function wddx_packet_end ($packet_id) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Add variables to a WDDX packet with the specified ID
  * @link http://php.net/manual/en/function.wddx-add-vars.php
  * @param resource $packet_id <p>
@@ -68,7 +73,8 @@ function wddx_packet_end ($packet_id) {}
 function wddx_add_vars ($packet_id, $var_name, $_ = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Unserializes a WDDX packet
  * @link http://php.net/manual/en/function.wddx-deserialize.php
  * @param string $packet <p>

--- a/xml.php
+++ b/xml.php
@@ -3,7 +3,8 @@
 // Start of xml v.
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Create an XML parser
  * @link http://php.net/manual/en/function.xml-parser-create.php
  * @param string $encoding [optional] <p>
@@ -24,7 +25,8 @@
 function xml_parser_create ($encoding = null) {}
 
 /**
- * (PHP 4 &gt;= 4.0.5, PHP 5)<br/>
+ * @since 4.0.5
+ * @since 5.0
  * Create an XML parser with namespace support
  * @link http://php.net/manual/en/function.xml-parser-create-ns.php
  * @param string $encoding [optional] <p>
@@ -48,7 +50,8 @@ function xml_parser_create ($encoding = null) {}
 function xml_parser_create_ns ($encoding = null, $separator = ':') {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Use XML Parser within an object
  * @link http://php.net/manual/en/function.xml-set-object.php
  * @param resource $parser <p>
@@ -62,7 +65,8 @@ function xml_parser_create_ns ($encoding = null, $separator = ':') {}
 function xml_set_object ($parser, &$object) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Set up start and end element handlers
  * @link http://php.net/manual/en/function.xml-set-element-handler.php
  * @param resource $parser <p>
@@ -92,7 +96,8 @@ function xml_set_object ($parser, &$object) {}
 function xml_set_element_handler ($parser, callable $start_element_handler, callable $end_element_handler) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Set up character data handler
  * @link http://php.net/manual/en/function.xml-set-character-data-handler.php
  * @param resource $parser <p>
@@ -117,7 +122,8 @@ function xml_set_element_handler ($parser, callable $start_element_handler, call
 function xml_set_character_data_handler ($parser, callable $handler) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Set up processing instruction (PI) handler
  * @link http://php.net/manual/en/function.xml-set-processing-instruction-handler.php
  * @param resource $parser <p>
@@ -143,7 +149,8 @@ function xml_set_character_data_handler ($parser, callable $handler) {}
 function xml_set_processing_instruction_handler ($parser, callable $handler) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Set up default handler
  * @link http://php.net/manual/en/function.xml-set-default-handler.php
  * @param resource $parser <p>
@@ -168,7 +175,8 @@ function xml_set_processing_instruction_handler ($parser, callable $handler) {}
 function xml_set_default_handler ($parser, callable $handler) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Set up unparsed entity declaration handler
  * @link http://php.net/manual/en/function.xml-set-unparsed-entity-decl-handler.php
  * @param resource $parser <p>
@@ -198,7 +206,8 @@ function xml_set_default_handler ($parser, callable $handler) {}
 function xml_set_unparsed_entity_decl_handler ($parser, callable $handler) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Set up notation declaration handler
  * @link http://php.net/manual/en/function.xml-set-notation-decl-handler.php
  * @param resource $parser <p>
@@ -226,7 +235,8 @@ function xml_set_unparsed_entity_decl_handler ($parser, callable $handler) {}
 function xml_set_notation_decl_handler ($parser, callable $handler) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Set up external entity reference handler
  * @link http://php.net/manual/en/function.xml-set-external-entity-ref-handler.php
  * @param resource $parser <p>
@@ -258,7 +268,8 @@ function xml_set_notation_decl_handler ($parser, callable $handler) {}
 function xml_set_external_entity_ref_handler ($parser, callable $handler) {}
 
 /**
- * (PHP 4 &gt;= 4.0.5, PHP 5)<br/>
+ * @since 4.0.5
+ * @since 5.0
  * Set up start namespace declaration handler
  * @link http://php.net/manual/en/function.xml-set-start-namespace-decl-handler.php
  * @param resource $parser <p>
@@ -288,7 +299,8 @@ function xml_set_external_entity_ref_handler ($parser, callable $handler) {}
 function xml_set_start_namespace_decl_handler ($parser, callable $handler) {}
 
 /**
- * (PHP 4 &gt;= 4.0.5, PHP 5)<br/>
+ * @since 4.0.5
+ * @since 5.0
  * Set up end namespace declaration handler
  * @link http://php.net/manual/en/function.xml-set-end-namespace-decl-handler.php
  * @param resource $parser <p>
@@ -317,7 +329,8 @@ function xml_set_start_namespace_decl_handler ($parser, callable $handler) {}
 function xml_set_end_namespace_decl_handler ($parser, callable $handler) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Start parsing an XML document
  * @link http://php.net/manual/en/function.xml-parse.php
  * @param resource $parser <p>
@@ -350,7 +363,8 @@ function xml_set_end_namespace_decl_handler ($parser, callable $handler) {}
 function xml_parse ($parser, $data, $is_final = false) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Parse XML data into an array structure
  * @link http://php.net/manual/en/function.xml-parse-into-struct.php
  * @param resource $parser <p>
@@ -372,7 +386,8 @@ function xml_parse ($parser, $data, $is_final = false) {}
 function xml_parse_into_struct ($parser, $data, array &$values, array &$index = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get XML parser error code
  * @link http://php.net/manual/en/function.xml-get-error-code.php
  * @param resource $parser <p>
@@ -386,7 +401,8 @@ function xml_parse_into_struct ($parser, $data, array &$values, array &$index = 
 function xml_get_error_code ($parser) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get XML parser error string
  * @link http://php.net/manual/en/function.xml-error-string.php
  * @param int $code <p>
@@ -398,7 +414,8 @@ function xml_get_error_code ($parser) {}
 function xml_error_string ($code) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get current line number for an XML parser
  * @link http://php.net/manual/en/function.xml-get-current-line-number.php
  * @param resource $parser <p>
@@ -411,7 +428,8 @@ function xml_error_string ($code) {}
 function xml_get_current_line_number ($parser) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get current column number for an XML parser
  * @link http://php.net/manual/en/function.xml-get-current-column-number.php
  * @param resource $parser <p>
@@ -426,7 +444,8 @@ function xml_get_current_line_number ($parser) {}
 function xml_get_current_column_number ($parser) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get current byte index for an XML parser
  * @link http://php.net/manual/en/function.xml-get-current-byte-index.php
  * @param resource $parser <p>
@@ -439,7 +458,8 @@ function xml_get_current_column_number ($parser) {}
 function xml_get_current_byte_index ($parser) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Free an XML parser
  * @link http://php.net/manual/en/function.xml-parser-free.php
  * @param resource $parser A reference to the XML parser to free.
@@ -449,7 +469,8 @@ function xml_get_current_byte_index ($parser) {}
 function xml_parser_free ($parser) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Set options in an XML parser
  * @link http://php.net/manual/en/function.xml-parser-set-option.php
  * @param resource $parser <p>
@@ -513,7 +534,8 @@ function xml_parser_free ($parser) {}
 function xml_parser_set_option ($parser, $option, $value) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get options from an XML parser
  * @link http://php.net/manual/en/function.xml-parser-get-option.php
  * @param resource $parser A reference to the XML parser to get an option from.
@@ -528,7 +550,8 @@ function xml_parser_set_option ($parser, $option, $value) {}
 function xml_parser_get_option ($parser, $option) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Encodes an ISO-8859-1 string to UTF-8
  * @link http://php.net/manual/en/function.utf8-encode.php
  * @param string $data <p>
@@ -539,7 +562,8 @@ function xml_parser_get_option ($parser, $option) {}
 function utf8_encode ($data) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Converts a string with ISO-8859-1 characters encoded with UTF-8
 to single-byte ISO-8859-1
  * @link http://php.net/manual/en/function.utf8-decode.php

--- a/xmlreader.php
+++ b/xmlreader.php
@@ -115,7 +115,7 @@ class XMLReader  {
 
 
 	/**
-	 * (PHP 5 &gt;= 5.1.2)<br/>
+	 * @since 5.1.2
 	 * Close the XMLReader input
 	 * @link http://php.net/manual/en/xmlreader.close.php
 	 * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
@@ -123,7 +123,7 @@ class XMLReader  {
 	public function close () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.1.2)<br/>
+	 * @since 5.1.2
 	 * Get the value of a named attribute
 	 * @link http://php.net/manual/en/xmlreader.getattribute.php
 	 * @param string $name <p>
@@ -135,7 +135,7 @@ class XMLReader  {
 	public function getAttribute ($name) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.1.2)<br/>
+	 * @since 5.1.2
 	 * Get the value of an attribute by index
 	 * @link http://php.net/manual/en/xmlreader.getattributeno.php
 	 * @param int $index <p>
@@ -147,7 +147,7 @@ class XMLReader  {
 	public function getAttributeNo ($index) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.1.2)<br/>
+	 * @since 5.1.2
 	 * Get the value of an attribute by localname and URI
 	 * @link http://php.net/manual/en/xmlreader.getattributens.php
 	 * @param string $localName <p>
@@ -163,7 +163,7 @@ class XMLReader  {
 	public function getAttributeNs ($localName, $namespaceURI) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.1.2)<br/>
+	 * @since 5.1.2
 	 * Indicates if specified property has been set
 	 * @link http://php.net/manual/en/xmlreader.getparserproperty.php
 	 * @param int $property <p>
@@ -175,7 +175,7 @@ class XMLReader  {
 	public function getParserProperty ($property) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.1.2)<br/>
+	 * @since 5.1.2
 	 * Indicates if the parsed document is valid
 	 * @link http://php.net/manual/en/xmlreader.isvalid.php
 	 * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
@@ -183,7 +183,7 @@ class XMLReader  {
 	public function isValid () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.1.2)<br/>
+	 * @since 5.1.2
 	 * Lookup namespace for a prefix
 	 * @link http://php.net/manual/en/xmlreader.lookupnamespace.php
 	 * @param string $prefix <p>
@@ -194,7 +194,7 @@ class XMLReader  {
 	public function lookupNamespace ($prefix) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.1.2)<br/>
+	 * @since 5.1.2
 	 * Move cursor to an attribute by index
 	 * @link http://php.net/manual/en/xmlreader.movetoattributeno.php
 	 * @param int $index <p>
@@ -205,7 +205,7 @@ class XMLReader  {
 	public function moveToAttributeNo ($index) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.1.2)<br/>
+	 * @since 5.1.2
 	 * Move cursor to a named attribute
 	 * @link http://php.net/manual/en/xmlreader.movetoattribute.php
 	 * @param string $name <p>
@@ -216,7 +216,7 @@ class XMLReader  {
 	public function moveToAttribute ($name) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.1.2)<br/>
+	 * @since 5.1.2
 	 * Move cursor to a named attribute
 	 * @link http://php.net/manual/en/xmlreader.movetoattributens.php
 	 * @param string $localName <p>
@@ -230,7 +230,7 @@ class XMLReader  {
 	public function moveToAttributeNs ($localName, $namespaceURI) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.1.2)<br/>
+	 * @since 5.1.2
 	 * Position cursor on the parent Element of current Attribute
 	 * @link http://php.net/manual/en/xmlreader.movetoelement.php
 	 * @return bool <b>TRUE</b> if successful and <b>FALSE</b> if it fails or not positioned on
@@ -239,7 +239,7 @@ class XMLReader  {
 	public function moveToElement () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.1.2)<br/>
+	 * @since 5.1.2
 	 * Position cursor on the first Attribute
 	 * @link http://php.net/manual/en/xmlreader.movetofirstattribute.php
 	 * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
@@ -247,7 +247,7 @@ class XMLReader  {
 	public function moveToFirstAttribute () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.1.2)<br/>
+	 * @since 5.1.2
 	 * Position cursor on the next Attribute
 	 * @link http://php.net/manual/en/xmlreader.movetonextattribute.php
 	 * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
@@ -255,7 +255,7 @@ class XMLReader  {
 	public function moveToNextAttribute () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.1.2)<br/>
+	 * @since 5.1.2
 	 * Set the URI containing the XML to parse
 	 * @link http://php.net/manual/en/xmlreader.open.php
 	 * @param string $URI <p>
@@ -274,7 +274,7 @@ class XMLReader  {
 	public function open ($URI, $encoding = null, $options = 0) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.1.2)<br/>
+	 * @since 5.1.2
 	 * Move to next node in document
 	 * @link http://php.net/manual/en/xmlreader.read.php
 	 * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
@@ -282,7 +282,7 @@ class XMLReader  {
 	public function read () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.1.2)<br/>
+	 * @since 5.1.2
 	 * Move cursor to next node skipping all subtrees
 	 * @link http://php.net/manual/en/xmlreader.next.php
 	 * @param string $localname [optional] <p>
@@ -293,7 +293,7 @@ class XMLReader  {
 	public function next ($localname = null) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.2.0)<br/>
+	 * @since 5.2.0
 	 * Retrieve XML from current node
 	 * @link http://php.net/manual/en/xmlreader.readinnerxml.php
 	 * @return string the contents of the current node as a string. Empty string on failure.
@@ -301,7 +301,7 @@ class XMLReader  {
 	public function readInnerXml () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.2.0)<br/>
+	 * @since 5.2.0
 	 * Retrieve XML from current node, including it self
 	 * @link http://php.net/manual/en/xmlreader.readouterxml.php
 	 * @return string the contents of current node, including itself, as a string. Empty string on failure.
@@ -309,7 +309,7 @@ class XMLReader  {
 	public function readOuterXml () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.2.0)<br/>
+	 * @since 5.2.0
 	 * Reads the contents of the current node as a string
 	 * @link http://php.net/manual/en/xmlreader.readstring.php
 	 * @return string the content of the current node as a string. Empty string on
@@ -318,7 +318,7 @@ class XMLReader  {
 	public function readString () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.2.0)<br/>
+	 * @since 5.2.0
 	 * Validate document against XSD
 	 * @link http://php.net/manual/en/xmlreader.setschema.php
 	 * @param string $filename <p>
@@ -329,7 +329,7 @@ class XMLReader  {
 	public function setSchema ($filename) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.1.2)<br/>
+	 * @since 5.1.2
 	 * Set parser options
 	 * @link http://php.net/manual/en/xmlreader.setparserproperty.php
 	 * @param int $property <p>
@@ -345,7 +345,7 @@ class XMLReader  {
 	public function setParserProperty ($property, $value) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.2.0)<br/>
+	 * @since 5.2.0
 	 * Set the filename or URI for a RelaxNG Schema
 	 * @link http://php.net/manual/en/xmlreader.setrelaxngschema.php
 	 * @param string $filename <p>
@@ -356,7 +356,7 @@ class XMLReader  {
 	public function setRelaxNGSchema ($filename) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.1.2)<br/>
+	 * @since 5.1.2
 	 * Set the data containing a RelaxNG Schema
 	 * @link http://php.net/manual/en/xmlreader.setrelaxngschemasource.php
 	 * @param string $source <p>
@@ -367,7 +367,7 @@ class XMLReader  {
 	public function setRelaxNGSchemaSource ($source) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.1.2)<br/>
+	 * @since 5.1.2
 	 * Set the data containing the XML to parse
 	 * @link http://php.net/manual/en/xmlreader.xml.php
 	 * @param string $source <p>
@@ -386,7 +386,7 @@ class XMLReader  {
 	public function XML ($source, $encoding = null, $options = 0) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.1.2)<br/>
+	 * @since 5.1.2
 	 * Returns a copy of the current node as a DOM object
 	 * @link http://php.net/manual/en/xmlreader.expand.php
 	 * @param DOMNode $basenode [optional]

--- a/xmlrpc.php
+++ b/xmlrpc.php
@@ -3,7 +3,8 @@
 // Start of xmlrpc v.0.51
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Generates XML for a PHP value
  * @link http://php.net/manual/en/function.xmlrpc-encode.php
  * @param mixed $value
@@ -12,7 +13,8 @@
 function xmlrpc_encode ($value) {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Decodes XML into native PHP types
  * @link http://php.net/manual/en/function.xmlrpc-decode.php
  * @param string $xml <p>
@@ -27,7 +29,8 @@ function xmlrpc_encode ($value) {}
 function xmlrpc_decode ($xml, $encoding = "iso-8859-1") {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Decodes XML into native PHP types
  * @link http://php.net/manual/en/function.xmlrpc-decode-request.php
  * @param string $xml
@@ -38,7 +41,8 @@ function xmlrpc_decode ($xml, $encoding = "iso-8859-1") {}
 function xmlrpc_decode_request ($xml, &$method, $encoding = null) {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Generates XML for a method request
  * @link http://php.net/manual/en/function.xmlrpc-encode-request.php
  * @param string $method <p>
@@ -56,7 +60,8 @@ function xmlrpc_decode_request ($xml, &$method, $encoding = null) {}
 function xmlrpc_encode_request ($method, $params, array $output_options = null) {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Gets xmlrpc type for a PHP value
  * @link http://php.net/manual/en/function.xmlrpc-get-type.php
  * @param mixed $value <p>
@@ -67,7 +72,8 @@ function xmlrpc_encode_request ($method, $params, array $output_options = null) 
 function xmlrpc_get_type ($value) {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Sets xmlrpc type, base64 or datetime, for a PHP string value
  * @link http://php.net/manual/en/function.xmlrpc-set-type.php
  * @param string $value <p>
@@ -82,7 +88,8 @@ function xmlrpc_get_type ($value) {}
 function xmlrpc_set_type (&$value, $type) {}
 
 /**
- * (PHP 4 &gt;= 4.3.0, PHP 5)<br/>
+ * @since 4.3.0
+ * @since 5.0
  * Determines if an array value represents an XMLRPC fault
  * @link http://php.net/manual/en/function.xmlrpc-is-fault.php
  * @param array $arg <p>
@@ -95,7 +102,8 @@ function xmlrpc_set_type (&$value, $type) {}
 function xmlrpc_is_fault (array $arg) {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Creates an xmlrpc server
  * @link http://php.net/manual/en/function.xmlrpc-server-create.php
  * @return resource
@@ -103,7 +111,8 @@ function xmlrpc_is_fault (array $arg) {}
 function xmlrpc_server_create () {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Destroys server resources
  * @link http://php.net/manual/en/function.xmlrpc-server-destroy.php
  * @param resource $server
@@ -112,7 +121,8 @@ function xmlrpc_server_create () {}
 function xmlrpc_server_destroy ($server) {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Register a PHP function to resource method matching method_name
  * @link http://php.net/manual/en/function.xmlrpc-server-register-method.php
  * @param resource $server
@@ -123,7 +133,8 @@ function xmlrpc_server_destroy ($server) {}
 function xmlrpc_server_register_method ($server, $method_name, $function) {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Parses XML requests and call methods
  * @link http://php.net/manual/en/function.xmlrpc-server-call-method.php
  * @param resource $server
@@ -135,7 +146,8 @@ function xmlrpc_server_register_method ($server, $method_name, $function) {}
 function xmlrpc_server_call_method ($server, $xml, $user_data, array $output_options = null) {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Decodes XML into a list of method descriptions
  * @link http://php.net/manual/en/function.xmlrpc-parse-method-descriptions.php
  * @param string $xml
@@ -144,7 +156,8 @@ function xmlrpc_server_call_method ($server, $xml, $user_data, array $output_opt
 function xmlrpc_parse_method_descriptions ($xml) {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Adds introspection documentation
  * @link http://php.net/manual/en/function.xmlrpc-server-add-introspection-data.php
  * @param resource $server
@@ -154,7 +167,8 @@ function xmlrpc_parse_method_descriptions ($xml) {}
 function xmlrpc_server_add_introspection_data ($server, array $desc) {}
 
 /**
- * (PHP 4 &gt;= 4.1.0, PHP 5)<br/>
+ * @since 4.1.0
+ * @since 5.0
  * Register a PHP function to generate documentation
  * @link http://php.net/manual/en/function.xmlrpc-server-register-introspection-callback.php
  * @param resource $server

--- a/xsl.php
+++ b/xsl.php
@@ -8,7 +8,7 @@
 class XSLTProcessor  {
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Import stylesheet
 	 * @link http://php.net/manual/en/xsltprocessor.importstylesheet.php
 	 * @param object $stylesheet <p>
@@ -20,7 +20,7 @@ class XSLTProcessor  {
 	public function importStylesheet ($stylesheet) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Transform to a DOMDocument
 	 * @link http://php.net/manual/en/xsltprocessor.transformtodoc.php
 	 * @param DOMNode $doc <p>
@@ -31,7 +31,7 @@ class XSLTProcessor  {
 	public function transformToDoc (DOMNode $doc) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Transform to URI
 	 * @link http://php.net/manual/en/xsltprocessor.transformtouri.php
 	 * @param DOMDocument|SimpleXMLElement $doc <p>
@@ -45,7 +45,7 @@ class XSLTProcessor  {
 	public function transformToUri ($doc, $uri) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Transform to XML
 	 * @link http://php.net/manual/en/xsltprocessor.transformtoxml.php
 	 * @param DOMDocument|SimpleXMLElement $doc <p>
@@ -56,7 +56,7 @@ class XSLTProcessor  {
 	public function transformToXml ($doc) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Set value for a parameter
 	 * @link http://php.net/manual/en/xsltprocessor.setparameter.php
 	 * @param string $namespace <p>
@@ -73,7 +73,7 @@ class XSLTProcessor  {
 	public function setParameter ($namespace, $name, $value) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Get value of a parameter
 	 * @link http://php.net/manual/en/xsltprocessor.getparameter.php
 	 * @param string $namespaceURI <p>
@@ -87,7 +87,7 @@ class XSLTProcessor  {
 	public function getParameter ($namespaceURI, $localName) {}
 
 	/**
-	 * (PHP 5)<br/>
+	 * @since 5.0
 	 * Remove parameter
 	 * @link http://php.net/manual/en/xsltprocessor.removeparameter.php
 	 * @param string $namespaceURI <p>
@@ -101,7 +101,7 @@ class XSLTProcessor  {
 	public function removeParameter ($namespaceURI, $localName) {}
 
 	/**
-	 * (PHP 5 &gt;= 5.0.4)<br/>
+	 * @since 5.0.4
 	 * Determine if PHP has EXSLT support
 	 * @link http://php.net/manual/en/xsltprocessor.hasexsltsupport.php
 	 * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
@@ -109,7 +109,7 @@ class XSLTProcessor  {
 	public function hasExsltSupport () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.0.4)<br/>
+	 * @since 5.0.4
 	 * Enables the ability to use PHP functions as XSLT functions
 	 * @link http://php.net/manual/en/xsltprocessor.registerphpfunctions.php
 	 * @param mixed $restrict [optional] <p>

--- a/zip.php
+++ b/zip.php
@@ -386,7 +386,7 @@ class ZipArchive  {
 	public function close () {}
 
 	/**
-	 * (PHP 5 &gt;= 5.2.7)<br/>
+	 * @since 5.2.7
 	 * Returns the status error message, system and/or zip messages
 	 * @link http://php.net/manual/en/ziparchive.getstatusstring.php
 	 * @return string a string with the status message on success or <b>FALSE</b> on failure.

--- a/zlib.php
+++ b/zlib.php
@@ -3,7 +3,8 @@
 // Start of zlib v.2.0
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Output a gz-file
  * @link http://php.net/manual/en/function.readgzfile.php
  * @param string $filename <p>
@@ -22,7 +23,8 @@
 function readgzfile ($filename, $use_include_path = 0) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Rewind the position of a gz-file pointer
  * @link http://php.net/manual/en/function.gzrewind.php
  * @param resource $zp <p>
@@ -34,7 +36,8 @@ function readgzfile ($filename, $use_include_path = 0) {}
 function gzrewind ($zp) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Close an open gz-file pointer
  * @link http://php.net/manual/en/function.gzclose.php
  * @param resource $zp <p>
@@ -46,7 +49,8 @@ function gzrewind ($zp) {}
 function gzclose ($zp) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Test for EOF on a gz-file pointer
  * @link http://php.net/manual/en/function.gzeof.php
  * @param resource $zp <p>
@@ -59,7 +63,8 @@ function gzclose ($zp) {}
 function gzeof ($zp) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get character from gz-file pointer
  * @link http://php.net/manual/en/function.gzgetc.php
  * @param resource $zp <p>
@@ -71,7 +76,8 @@ function gzeof ($zp) {}
 function gzgetc ($zp) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get line from file pointer
  * @link http://php.net/manual/en/function.gzgets.php
  * @param resource $zp <p>
@@ -86,7 +92,8 @@ function gzgetc ($zp) {}
 function gzgets ($zp, $length) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Get line from gz-file pointer and strip HTML tags
  * @link http://php.net/manual/en/function.gzgetss.php
  * @param resource $zp <p>
@@ -105,7 +112,8 @@ function gzgets ($zp, $length) {}
 function gzgetss ($zp, $length, $allowable_tags = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Binary-safe gz-file read
  * @link http://php.net/manual/en/function.gzread.php
  * @param resource $zp <p>
@@ -120,7 +128,8 @@ function gzgetss ($zp, $length, $allowable_tags = null) {}
 function gzread ($zp, $length) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Open gz-file
  * @link http://php.net/manual/en/function.gzopen.php
  * @param string $filename <p>
@@ -150,7 +159,8 @@ function gzread ($zp, $length) {}
 function gzopen ($filename, $mode, $use_include_path = 0) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Output all remaining data on a gz-file pointer
  * @link http://php.net/manual/en/function.gzpassthru.php
  * @param resource $zp <p>
@@ -163,7 +173,8 @@ function gzopen ($filename, $mode, $use_include_path = 0) {}
 function gzpassthru ($zp) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Seek on a gz-file pointer
  * @link http://php.net/manual/en/function.gzseek.php
  * @param resource $zp <p>
@@ -188,7 +199,8 @@ function gzpassthru ($zp) {}
 function gzseek ($zp, $offset, $whence = SEEK_SET) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Tell gz-file pointer read/write position
  * @link http://php.net/manual/en/function.gztell.php
  * @param resource $zp <p>
@@ -200,7 +212,8 @@ function gzseek ($zp, $offset, $whence = SEEK_SET) {}
 function gztell ($zp) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Binary-safe gz-file write
  * @link http://php.net/manual/en/function.gzwrite.php
  * @param resource $zp <p>
@@ -228,7 +241,8 @@ function gztell ($zp) {}
 function gzwrite ($zp, $string, $length = null) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Alias of <b>gzwrite</b>
  * @link http://php.net/manual/en/function.gzputs.php
  * @param $fp
@@ -238,7 +252,8 @@ function gzwrite ($zp, $string, $length = null) {}
 function gzputs ($fp, $str, $length) {}
 
 /**
- * (PHP 4, PHP 5)<br/>
+ * @since 4.0
+ * @since 5.0
  * Read entire gz-file into an array
  * @link http://php.net/manual/en/function.gzfile.php
  * @param string $filename <p>
@@ -253,7 +268,8 @@ function gzputs ($fp, $str, $length) {}
 function gzfile ($filename, $use_include_path = 0) {}
 
 /**
- * (PHP 4 &gt;= 4.0.1, PHP 5)<br/>
+ * @since 4.0.1
+ * @since 5.0
  * Compress a string
  * @link http://php.net/manual/en/function.gzcompress.php
  * @param string $data <p>
@@ -274,7 +290,8 @@ function gzfile ($filename, $use_include_path = 0) {}
 function gzcompress ($data, $level = -1, $encoding = ZLIB_ENCODING_DEFLATE) {}
 
 /**
- * (PHP 4 &gt;= 4.0.1, PHP 5)<br/>
+ * @since 4.0.1
+ * @since 5.0
  * Uncompress a compressed string
  * @link http://php.net/manual/en/function.gzuncompress.php
  * @param string $data <p>
@@ -293,7 +310,8 @@ function gzcompress ($data, $level = -1, $encoding = ZLIB_ENCODING_DEFLATE) {}
 function gzuncompress ($data, $length = 0) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Deflate a string
  * @link http://php.net/manual/en/function.gzdeflate.php
  * @param string $data <p>
@@ -312,7 +330,8 @@ function gzuncompress ($data, $length = 0) {}
 function gzdeflate ($data, $level = -1, $encoding = ZLIB_ENCODING_RAW) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Inflate a deflated string
  * @link http://php.net/manual/en/function.gzinflate.php
  * @param string $data <p>
@@ -331,7 +350,8 @@ function gzdeflate ($data, $level = -1, $encoding = ZLIB_ENCODING_RAW) {}
 function gzinflate ($data, $length = 0) {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * Create a gzip compressed string
  * @link http://php.net/manual/en/function.gzencode.php
  * @param string $data <p>
@@ -361,7 +381,7 @@ function gzinflate ($data, $length = 0) {}
 function gzencode ($data, $level = -1, $encoding_mode = FORCE_GZIP) {}
 
 /**
- * (PHP 5 &gt;= 5.4.0)<br/>
+ * @since 5.4.0
  * Decodes a gzip compressed string
  * @link http://php.net/manual/en/function.gzdecode.php
  * @param string $data <p>
@@ -375,7 +395,7 @@ function gzencode ($data, $level = -1, $encoding_mode = FORCE_GZIP) {}
 function gzdecode ($data, $length = null) {}
 
 /**
- * (PHP 5 &gt;= 5.4.0)<br/>
+ * @since 5.4.0
  * Compress data with the specified encoding
  * @link http://php.net/manual/en/function.zlib-encode.php
  * @param string $data <p>
@@ -389,7 +409,7 @@ function gzdecode ($data, $length = null) {}
 function zlib_encode ($data, $encoding, $level = -1) {}
 
 /**
- * (PHP 5 &gt;= 5.4.0)<br/>
+ * @since 5.4.0
  * Uncompress any raw/gzip/zlib encoded data
  * @link http://php.net/manual/en/function.zlib-decode.php
  * @param string $data <p>
@@ -401,7 +421,8 @@ function zlib_encode ($data, $encoding, $level = -1) {}
 function zlib_decode ($data, $max_decoded_len = null) {}
 
 /**
- * (PHP 4 &gt;= 4.3.2, PHP 5)<br/>
+ * @since 4.3.2
+ * @since 5.0
  * Returns the coding type used for output compression
  * @link http://php.net/manual/en/function.zlib-get-coding-type.php
  * @return string Possible return values are gzip, deflate,
@@ -410,7 +431,8 @@ function zlib_decode ($data, $max_decoded_len = null) {}
 function zlib_get_coding_type () {}
 
 /**
- * (PHP 4 &gt;= 4.0.4, PHP 5)<br/>
+ * @since 4.0.4
+ * @since 5.0
  * ob_start callback function to gzip output buffer
  * @link http://php.net/manual/en/function.ob-gzhandler.php
  * @param string $buffer


### PR DESCRIPTION
This PR adds the [`@since`](http://www.phpdoc.org/docs/latest/references/phpdoc/tags/since.html) to the constant, function, define, class, variable, method where the information was already availible.

This PR relates to the comments made in [WI-16509](https://youtrack.jetbrains.com/issue/WI-16509)

The following regex and searches where used:
```
\* Available since PHP ([0-9\.]+)
\* Since PHP ([0-9\.]+)
\* PHP >= ([0-9\.]+)<br\/>
\* \(PHP [0-9] &gt;= ([0-9\.]+)\)<br\/>
``` 
(`* @since $1`)
`\* \(PHP 4 &gt;= 4\.([0-9\.]+), PHP 5\)<br\/>` (`* @since 4.$1, 5.0`)
`* (PHP 4, PHP 5)<br/>` (`* @since 4.0, 5.0`)
`* (PHP 5)<br/>` (`* @since 5.0`)
`(\s*\*\s*)@since ([0-9\.]+), ([0-9\.])` (`$1@since $2$1@since $3`)