### PR TITLE
Adding UUID_RFC4122 constant to MongoBinData

### DIFF
--- a/mongo.php
+++ b/mongo.php
@@ -2071,6 +2071,11 @@ class MongoBinData {
      * @link http://php.net/manual/en/class.mongobindata.php#mongobindata.constants.uuid
      */
     const UUID = 3;
+    
+    /**
+     * @link http://php.net/manual/en/class.mongobindata.php#mongobindata.constants.uuid_rfc4122
+     */ 
+    const UUID_RFC4122 = 4;
 
      /**
      * @link http://php.net/manual/en/class.mongobindata.php#mongobindata.constants.md5


### PR DESCRIPTION
Constant UUID_RFC4122 representing UUID in RFC 4122 format.