### PR TITLE
Remove syntatically invalid return type hint in apache.php

### DIFF
--- a/apache.php
+++ b/apache.php
@@ -104,7 +104,7 @@ function apache_reset_timeout () {}
  * @since 4.3.0
  * @since 5.0
  */
-array function apache_response_headers () {}
+function apache_response_headers () {}
 
 /**
  * Sets the value of the Apache environment variable specified by variable.


### PR DESCRIPTION
I have signed the contributor agreement @sekjun9878 Michael Yoo <michael@yoo.id.au>