### PR TITLE
Specify function scope in jsonSerialise interface.

### DIFF
--- a/json.php
+++ b/json.php
@@ -17,7 +17,7 @@ interface JsonSerializable  {
 	 * which is a value of any type other than a resource.
 	 * @since 5.4.0
 	 */
-    function jsonSerialize ();
+    public function jsonSerialize ();
 
 }
 


### PR DESCRIPTION
This makes the method stub autogeneration to add a function scope which is the expected behaviour.

I have signed the Contributor License Agreement.