### PR TITLE
Fix 'var' param description for the 'strval' function

### DIFF
--- a/standard_5.php
+++ b/standard_5.php
@@ -66,8 +66,10 @@ function doubleval ($var) {}
  * The variable that is being converted to a string.
  * </p>
  * <p>
- * var may be any scalar type. You cannot use
- * strval on arrays or objects.
+ * var may be any scalar type or an object that 
+ * implements the __toString() method. You cannot 
+ * use strval() on arrays or on objects that do not 
+ * implement the __toString() method. 
  * </p>
  * @return string The string value of var.
  * @since 4.0


### PR DESCRIPTION
This code is intended to fix a bug, WI-30108. See https://youtrack.jetbrains.com/issue/WI-30108 for details.