### PR TITLE
The key_exists function has never been deprecated

### DIFF
--- a/standard_9.php
+++ b/standard_9.php
@@ -751,7 +751,6 @@ function sizeof($var, $mode) { }
  * An array with keys to check.
  * </p>
  * @return bool true on success or false on failure.
- * @deprecated
  * @since 4.0.7
  * @since 5.0
  */


### PR DESCRIPTION
 The key_exists function has never been deprecated. Detail https://bugs.php.net/bug.php?id=71174