### PR TITLE
Fixed typo (ObjectId constructor may not take a first parameter).

### DIFF
--- a/mongodb.php
+++ b/mongodb.php
@@ -879,7 +879,7 @@ namespace MongoDB {
              * @link http://php.net/manual/en/mongodb-bson-objectid.construct.php
              * @param string $id
              */
-            public function __construct($id)
+            public function __construct($id = null)
             {
             }
 


### PR DESCRIPTION
Please note, first example:
http://php.net/manual/en/mongodb-bson-objectid.construct.php
```php
var_dump(new MongoDB\BSON\ObjectId()); //nothing arguments
```