### PR TITLE
Added missing docblock for autocompletion

### DIFF
--- a/Reflection.php
+++ b/Reflection.php
@@ -153,6 +153,13 @@ abstract class ReflectionFunctionAbstract implements Reflector {
 	 */
 	public function getClosureThis () {}
 
+	/**
+	 * Returns the scope associated to the closure
+	 * @link http://php.net/manual/en/reflectionfunctionabstract.getclosurescopeclass.php
+	 * @return ReflectionClass Returns the class on success.
+	 * Returns <b>NULL</b> on failure.
+	 * @since 5.4.0
+	 */
 	public function getClosureScopeClass () {}
 
 	/**


### PR DESCRIPTION
### Added

- Missing docblock for `ReflectionFunctionAbstract::getClosureScopeClass`