### PR TITLE
Add all supported arguments to PDOStatement::setFetchMode stub

### DIFF
--- a/PDO.php
+++ b/PDO.php
@@ -1316,9 +1316,24 @@ class PDOStatement implements Traversable {
 	 * @param int $mode <p>
 	 * The fetch mode must be one of the PDO::FETCH_* constants.
 	 * </p>
+	 * @param int|string|object $arg2 <p>
+     * If $mode is PDO::FETCH_COLUMN, the integer column index to fetch.
+	 * </p>
+     * <p>
+     * If $mode is PDO::FETCH_CLASS, the name of the class to instantiate with
+     * row data.
+     * </p>
+     * <p>
+     * If $mode is PDO::FETCH_INTO, an object whose members to update with the
+     * result set from fetching.
+     * </p>
+     * @param array $ctorargs <p>
+     * If $mode is PDO::FETCH_CLASS, the list of arguments to send the
+     * requested class's constructor.
+     * </p>
 	 * @return bool 1 on success or <b>FALSE</b> on failure.
 	 */
-	public function setFetchMode ($mode) {}
+	public function setFetchMode ($mode, $arg2 = null, $ctorargs = null) {}
 
 	/**
 	 * (PHP 5 &gt;= 5.1.0, PECL pdo &gt;= 0.2.0)<br/>


### PR DESCRIPTION
**Note: I'm not going to sign a contract in order to submit this pull request. Use my contribution or don't. Credit me or don't. I don't care what you do with this code, or the knowledge that this bug exists in your software. I fixed it just because it annoyed me. If you had an issues section, I'd have used that. You don't, so instead you get code.**

This adds a second and third optional argument to PDOStatement::setFetchMode to support this method's multi-call nature:

>public bool PDOStatement::setFetchMode ( int $mode )
>public bool PDOStatement::setFetchMode ( int $PDO::FETCH_COLUMN , int $colno )
>public bool PDOStatement::setFetchMode ( int $PDO::FETCH_CLASS , string $classname , array $ctorargs )
>public bool PDOStatement::setFetchMode ( int $PDO::FETCH_INTO , object $object )

Source: http://php.net/manual/en/pdostatement.setfetchmode.php

This fixes false-positives coming up when running code inspections on perfectly legal usages.

Example of false positive:

Code:

    $statement->setFetchMode(PDO::FETCH_CLASS, $class);

Inspection results:

>Problem synopsis
>    Method call uses 2 parameters, but method signature uses 1 parameters (at line XXX)