### PR TITLE
htmlentities double_encode not null

### DIFF
--- a/standard_0.php
+++ b/standard_0.php
@@ -407,7 +407,7 @@ function htmlspecialchars ($string, $flags = ENT_COMPAT, $encoding = 'UTF-8', $d
  * @since 4.0
  * @since 5.0
  */
-function htmlentities ($string, $quote_style = null, $charset = null, $double_encode = null) {}
+function htmlentities ($string, $quote_style = null, $charset = null, $double_encode = true) {}
 
 /**
  * Convert all HTML entities to their applicable characters


### PR DESCRIPTION
Fix the php >= 5.2.3 double_encode argument for `htmlentities` default as null when it is defined as true like `htmlspecialchars`
Reference: http://php.net/manual/en/function.htmlentities.php