### PR TITLE
add \MongoDB\Driver\Manager::getReadConcern()

### DIFF
--- a/standard/mongodb.php
+++ b/standard/mongodb.php
@@ -99,6 +99,13 @@ namespace MongoDB {
             }
 
             /**
+             * @return ReadConcern
+             */
+            final public function getReadConcern()
+            {
+            }
+
+            /**
              * @return ReadPreference
              */
             final public function getReadPreference()


### PR DESCRIPTION
The method `\MongoDB\Driver\Manager::getReadConcern()` is missing.
Unfortunately it is not documented on [php.net](http://php.net/manual/en/class.mongodb-driver-manager.php) at the moment, but we can see it in [the source code](https://github.com/mongodb/mongo-php-driver/blob/5076fb026f642ec3ced6da85c6759a8175459b32/src/MongoDB/Manager.c#L198).