### PR TITLE
Usage in other projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ IDE needs them for completion, code inspection, type inference, doc popups, etc.
 TBD: Have a full copy of .git repo within IDE and add it as an external library "PHP Runtime" to the project. It should then be easilly updatable both way via normal git methods.
 
 ### License
-[Apache 2]
+[ISC]
 
 [PHPDOC]:https://github.com/phpDocumentor/fig-standards/blob/master/proposed/phpdoc.md
-[Apache 2]:https://www.apache.org/licenses/LICENSE-2.0
+[ISC]:https://opensource.org/licenses/ISC
 [Relevant open issues]:https://youtrack.jetbrains.com/issues/WI?q=%23Unresolved+Subsystem%3A+%7BPHP+lib+stubs%7D+order+by%3A+votes+


### PR DESCRIPTION
Hi, I would open an issue, but since you don't allow issues I will propose this through a PR.
I would like to use these stubs as a dependency in the Open Source [PHP Language Server](https://github.com/felixfbecker/php-language-server). I have some problems with this:
- The language server is ISC licensed. Could you consider a more permissive license like MIT or ISC instead of Apache2?
- It would be nice to have this available as a composer package (just needs a composer.json file and a submission to packagist.org, no manual publishing needed, it will pull from git)
- Current version cannot be parsed by the PHP parser (can be checked through `php -l`):

```
PHP Parse error:  syntax error, unexpected '__halt_compiler' (T_HALT_COMPILER), expecting '(' in .\vendor\JetBrains\phpstorm-stubs\standard\_standard_manual.php on line 19

Parse error: syntax error, unexpected '__halt_compiler' (T_HALT_COMPILER), expecting '(' in .\vendor\JetBrains\phpstorm-stubs\standard\_standard_manual.php on line 19

Errors parsing .\vendor\JetBrains\phpstorm-stubs\standard\_standard_manual.php
```

`__halt_compiler` should really be defined as a keyword/language construct rather than a function, as it gets the `T_HALT_COMPILER` token and not the `T_FUNCTION` token.
- mongodb.php uses illegal nested namespaces
- It would be nice if you could enable issues for this repository
