### PR TITLE
Ns => NS, according to PHP documentation.

### DIFF
--- a/standard/xmlwriter.php
+++ b/standard/xmlwriter.php
@@ -117,7 +117,7 @@ class XMLWriter  {
 	 * </p>
 	 * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
 	 */
-	public function startAttributeNs ($prefix, $name, $uri) {}
+	public function startAttributeNS ($prefix, $name, $uri) {}
 
 	/**
 	 * (PHP 5 &gt;= 5.1.2, PECL xmlwriter &gt;= 0.1.0)<br/>
@@ -137,7 +137,7 @@ class XMLWriter  {
 	 * </p>
 	 * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
 	 */
-	public function writeAttributeNs ($prefix, $name, $uri, $content) {}
+	public function writeAttributeNS ($prefix, $name, $uri, $content) {}
 
 	/**
 	 * (PHP 5 &gt;= 5.1.2, PECL xmlwriter &gt;= 0.1.0)<br/>
@@ -181,7 +181,7 @@ class XMLWriter  {
 	 * </p>
 	 * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
 	 */
-	public function startElementNs ($prefix, $name, $uri) {}
+	public function startElementNS ($prefix, $name, $uri) {}
 
 	/**
 	 * (PHP 5 &gt;= 5.1.2, PECL xmlwriter &gt;= 0.1.0)<br/>
@@ -215,7 +215,7 @@ class XMLWriter  {
 	 * </p>
 	 * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
 	 */
-	public function writeElementNs ($prefix, $name, $uri, $content = null) {}
+	public function writeElementNS ($prefix, $name, $uri, $content = null) {}
 
 	/**
 	 * (PHP 5 &gt;= 5.1.2, PECL xmlwriter &gt;= 0.1.0)<br/>


### PR DESCRIPTION
According to PHP documentation, the prefix should be "NS" instead of "Ns".

http://php.net/manual/en/function.xmlwriter-write-attribute-ns.php
http://php.net/manual/en/function.xmlwriter-start-attribute-ns.php
http://php.net/manual/en/function.xmlwriter-write-element-ns.php
http://php.net/manual/en/function.xmlwriter-start-element-ns.php