### PR TITLE
Changed the return type in php doc for gmp_sub from "resource" to "GMP"

### DIFF
--- a/standard/gmp.php
+++ b/standard/gmp.php
@@ -97,7 +97,7 @@ function gmp_add ($a, $b) {}
  * </p>
  * It can be either a GMP number resource, or a
  * numeric string given that it is possible to convert the latter to a number.</p>
- * @return resource A GMP number resource.
+ * @return GMP A GMP number resource.
  * @since 4.0.4
  * @since 5.0
  */


### PR DESCRIPTION
I made this change to remove an inspection warning in PhpStorm.