### PR TITLE
Fix return phpdocs in date_c

### DIFF
--- a/standard/date_c.php
+++ b/standard/date_c.php
@@ -101,7 +101,7 @@ class DateTimeImmutable implements DateTimeInterface {
      * (PHP 5 &gt;=5.5.0)<br/>
      * Adds an amount of days, months, years, hours, minutes and seconds
      * @param DateInterval $interval
-     * @return DateTimeImmutable
+     * @return static
      */
     public function add(DateInterval $interval) { }
 
@@ -139,7 +139,7 @@ class DateTimeImmutable implements DateTimeInterface {
      * @link http://www.php.net/manual/en/datetimeimmutable.modify.php
      * @param string $modify  <p>A date/time string. Valid formats are explained in
      * {@link http://www.php.net/manual/en/datetime.formats.php Date and Time Formats}.</p>
-     * @return DateTimeImmutable
+     * @return static
      * Returns the {@link http://www.php.net/manual/en/class.datetimeimmutable.php DateTimeImmutable} object for method chaining or <b>FALSE</b> on failure.
      */
 
@@ -162,7 +162,7 @@ class DateTimeImmutable implements DateTimeInterface {
      * @param int $year <p>Year of the date.</p>
      * @param int $month <p>Month of the date.</p>
      * @param int $day <p>Day of the date.</p>
-     * @return DateTimeImmutable|bool
+     * @return static|bool
      * Returns the {@link http://www.php.net/manual/en/class.datetimeimmutable.php DateTimeImmutable} object for method chaining or <b>FALSE</b> on failure.
      *
      */
@@ -175,7 +175,7 @@ class DateTimeImmutable implements DateTimeInterface {
      * @param int $year <p>Year of the date.</p>
      * @param int $week  <p>Week of the date.</p>
      * @param int $day [optional] <p>Offset from the first day of the week.</p>
-     * @return DateTimeImmutable|bool
+     * @return static|bool
      * Returns the {@link http://www.php.net/manual/en/class.datetimeimmutable.php DateTimeImmutable} object for method chaining or <b>FALSE</b> on failure.
      */
     public function setISODate($year, $week, $day = 1) { }
@@ -187,7 +187,7 @@ class DateTimeImmutable implements DateTimeInterface {
      * @param int $hour <p> Hour of the time. </p>
      * @param int $minute <p> Minute of the time. </p>
      * @param int $second [optional] <p> Second of the time. </p>
-     * @return DateTimeImmutable|bool
+     * @return static|bool
      * Returns the {@link http://www.php.net/manual/en/class.datetimeimmutable.php DateTimeImmutable} object for method chaining or <b>FALSE</b> on failure.
      */
     public function setTime($hour, $minute, $second = 0) { }
@@ -197,7 +197,7 @@ class DateTimeImmutable implements DateTimeInterface {
      * Sets the date and time based on an Unix timestamp
      * @link http://www.php.net/manual/en/datetimeimmutable.settimestamp.php
      * @param int $unixtimestamp <p>Unix timestamp representing the date.</p>
-     * @return DateTimeImmutable|bool
+     * @return static|bool
      * Returns the {@link http://www.php.net/manual/en/class.datetimeimmutable.php DateTimeImmutable} object for method chaining or <b>FALSE</b> on failure.
      */
     public function setTimestamp($unixtimestamp) { }
@@ -210,7 +210,7 @@ class DateTimeImmutable implements DateTimeInterface {
      * A {@link http://www.php.net/manual/en/class.datetimezone.php DateTimeZone} object representing the
      * desired time zone.
      * </p>
-     * @return DateTimeImmutable|bool
+     * @return static|bool
      * Returns the {@link http://www.php.net/manual/en/class.datetimeimmutable.php DateTimeImmutable} object for method chaining or <b>FALSE</b> on failure.
      */
     public function setTimezone(DateTimeZone $timezone) { }
@@ -222,7 +222,7 @@ class DateTimeImmutable implements DateTimeInterface {
      * @param DateInterval $interval <p>
      * A {@link http://www.php.net/manual/en/class.dateinterval.php DateInterval} object
      * </p>
-     * @return DateTimeImmutable|bool
+     * @return static|bool
      * Returns the {@link http://www.php.net/manual/en/class.datetimeimmutable.php DateTimeImmutable} object for method chaining or <b>FALSE</b> on failure.
      */
     public function sub(DateInterval $interval) { }
@@ -317,7 +317,7 @@ class DateTime implements DateTimeInterface {
     public function __construct ($time='now', DateTimeZone $timezone=null) {}
 
     /**
-     * @return DateTime
+     * @return void
      * @link http://php.net/manual/en/datetime.wakeup.php
      */
     public function __wakeup () {}
@@ -335,7 +335,7 @@ class DateTime implements DateTimeInterface {
      * Alter the timestamp of a DateTime object by incrementing or decrementing
      * in a format accepted by strtotime().
      * @param string $modify A date/time string. Valid formats are explained in <a href="http://www.php.net/manual/en/datetime.formats.php">Date and Time Formats</a>.
-     * @return DateTime Returns the DateTime object for method chaining or FALSE on failure.
+     * @return static Returns the DateTime object for method chaining or FALSE on failure.
      * @link http://php.net/manual/en/datetime.modify.php
      */
     public function modify ($modify) {}
@@ -343,7 +343,7 @@ class DateTime implements DateTimeInterface {
     /**
      * Adds an amount of days, months, years, hours, minutes and seconds to a DateTime object
      * @param DateInterval $interval
-     * @return DateTime
+     * @return static
      * @link http://php.net/manual/en/datetime.add.php
      */
     public function add (DateInterval $interval) {}
@@ -351,7 +351,7 @@ class DateTime implements DateTimeInterface {
     /**
      * Subtracts an amount of days, months, years, hours, minutes and seconds from a DateTime object
      * @param DateInterval $interval
-     * @return DateTime
+     * @return static
      * @link http://php.net/manual/en/datetime.sub.php
      */
     public function sub (DateInterval $interval) {}
@@ -366,7 +366,7 @@ class DateTime implements DateTimeInterface {
     /**
      * Set the TimeZone associated with the DateTime
      * @param DateTimeZone $timezone
-     * @return $this
+     * @return static
      * @link http://php.net/manual/en/datetime.settimezone.php
      */
     public function setTimezone ($timezone) {}
@@ -383,7 +383,7 @@ class DateTime implements DateTimeInterface {
      * @param int $hour
      * @param int $minute
      * @param int $second
-     * @return $this
+     * @return static
      * @link http://php.net/manual/en/datetime.settime.php
      */
     public function setTime ($hour, $minute, $second=0) {}
@@ -393,7 +393,7 @@ class DateTime implements DateTimeInterface {
      * @param int $year
      * @param int $month
      * @param int $day
-     * @return $this
+     * @return static
      * @link http://php.net/manual/en/datetime.setdate.php
      */
     public function setDate ($year, $month, $day) {}
@@ -403,7 +403,7 @@ class DateTime implements DateTimeInterface {
      * @param int $year
      * @param int $week
      * @param int $day
-     * @return $this
+     * @return static
      * @link http://php.net/manual/en/datetime.setisodate.php
      */
     public function setISODate ($year, $week, $day=1) {}
@@ -411,7 +411,7 @@ class DateTime implements DateTimeInterface {
     /**
      * Sets the date and time based on a Unix timestamp.
      * @param int $unixtimestamp
-     * @return $this
+     * @return static
      * @link http://php.net/manual/en/datetime.settimestamp.php
      */
     public function setTimestamp ($unixtimestamp) {}
@@ -451,7 +451,7 @@ class DateTime implements DateTimeInterface {
     public static function getLastErrors () {}
 
     /**
-     * The __set_state handler
+     * The handler
      * @link http://php.net/manual/en/datetime.set-state.php
      * @param array $array <p>Initialization array.</p>
      * @return DateTime <p>Returns a new instance of a DateTime object.</p>
@@ -660,7 +660,7 @@ class DatePeriod implements Traversable {
 
     /**
      * Gets the end date
-     * @return DateTime
+     * @return DateTimeInterface
      * @link http://php.net/manual/en/dateperiod.getenddate.php
      * @since 5.6.5
      */
@@ -668,7 +668,7 @@ class DatePeriod implements Traversable {
 
     /**
      * Gets the start date
-     * @return DateTime
+     * @return DateTimeInterface
      * @link http://php.net/manual/en/dateperiod.getstartdate.php
      * @since 5.6.5
      */

--- a/standard/date_c.php
+++ b/standard/date_c.php
@@ -451,7 +451,7 @@ class DateTime implements DateTimeInterface {
     public static function getLastErrors () {}
 
     /**
-     * The handler
+     * The __set_state handler
      * @link http://php.net/manual/en/datetime.set-state.php
      * @param array $array <p>Initialization array.</p>
      * @return DateTime <p>Returns a new instance of a DateTime object.</p>


### PR DESCRIPTION
- Most methods fixed according to php behaviour (see https://3v4l.org/GlZGq) (`$this` to `static` is just for consistency)
- Magic method __wakeup fixed according to php documentation
- DatePeriod getters is just an attempt to describe weird implementation (see https://3v4l.org/TqasA)
