### PR TITLE
Update date_c DateInterval Constructor docBlock

### DIFF
--- a/standard/date_c.php
+++ b/standard/date_c.php
@@ -594,6 +594,7 @@ class DateInterval {
     /**
      * @param string $interval_spec
      * @link http://php.net/manual/en/dateinterval.construct.php
+     * @throws \Exception when the interval_spec cannot be parsed as an interval.
      */
     public function __construct ($interval_spec) {}
 


### PR DESCRIPTION
When the interval_spec cannot be parsed as an interval an \Exception is thrown from the constructor