### PR TITLE
Added CURLOPT_POSTREDIR, which has been available since 5.3.2

### DIFF
--- a/standard/curl_d.php
+++ b/standard/curl_d.php
@@ -83,6 +83,7 @@ define ('CURLOPT_NETRC', 51);
  * @link http://us.php.net/manual/en/function.curl-setopt.php
  * @since 5.3.2
  */
+define ('CURLOPT_POSTREDIR', 161);
 define ('CURLOPT_CERTINFO', -1);
 define ('CURLOPT_FTPASCII', -1);
 define ('CURLOPT_MUTE', -1);


### PR DESCRIPTION
This closes https://youtrack.jetbrains.com/issue/WI-29746