### PR TITLE
Fix bool on failure returns in standards

### DIFF
--- a/standard/standard_0.php
+++ b/standard/standard_0.php
@@ -178,7 +178,7 @@ function usleep ($micro_seconds) {}
  * @param int $nanoseconds <p>
  * Must be a positive integer less than 1 billion.
  * </p>
- * @return mixed true on success or false on failure.
+ * @return bool|array true on success or false on failure.
  * </p>
  * <p>
  * If the delay was interrupted by a signal, an associative array will be
@@ -216,7 +216,7 @@ function time_sleep_until ($timestamp) {}
  * For more information about the format options, read the
  * strftime page.
  * </p>
- * @return array an array or false on failure.
+ * @return array|bool an array or false on failure.
  * </p>
  * <p>
  * <table>
@@ -698,7 +698,7 @@ function iptcembed ($iptcdata, $jpeg_file_name, $spool = null) {}
  * You can use the iptcparse function to parse the
  * binary APP13 marker into something readable.
  * </p>
- * @return array an array with 7 elements.
+ * @return array|bool an array with 7 elements.
  * </p>
  * <p>
  * Index 0 and 1 contains respectively the width and the height of the image.

--- a/standard/standard_1.php
+++ b/standard/standard_1.php
@@ -545,7 +545,7 @@ function money_format ($format, $number) {}
  * </p>
  * Using a negative length
  * ]]>
- * @return string the extracted part of string or false on failure.
+ * @return string|bool the extracted part of string or false on failure.
  * @since 4.0
  * @since 5.0
  */

--- a/standard/standard_2.php
+++ b/standard/standard_2.php
@@ -707,7 +707,7 @@ function exec ($command, array &$output = null, &$return_var = null) {}
  * return status of the executed command will be written to this
  * variable.
  * </p>
- * @return string the last line of the command output on success, and false
+ * @return string|bool the last line of the command output on success, and false
  * on failure.
  * @since 4.0
  * @since 5.0
@@ -823,7 +823,7 @@ function shell_exec ($cmd) {}
  * binary_pipes: open pipes in binary mode, instead
  * of using the usual stream_encoding
  * </p>
- * @return resource a resource representing the process, which should be freed using
+ * @return resource|bool a resource representing the process, which should be freed using
  * proc_close when you are finished with it. On failure
  * returns false.
  * @since 4.3.0
@@ -869,7 +869,7 @@ function proc_terminate ($process, $signal = null) {}
  * The proc_open resource that will
  * be evaluated.
  * </p>
- * @return array An array of collected information on success, and false
+ * @return array|bool An array of collected information on success, and false
  * on failure. The returned array contains the following elements:
  * </p>
  * <p>

--- a/standard/standard_3.php
+++ b/standard/standard_3.php
@@ -21,7 +21,7 @@ function getlastmod () {}
  * Returns false if input contains character from outside the base64
  * alphabet.
  * </p>
- * @return string the original data or false on failure. The returned data may be
+ * @return string|bool the original data or false on failure. The returned data may be
  * binary.
  * @since 4.0
  * @since 5.0
@@ -730,7 +730,7 @@ function fmod ($x, $y) {}
  * @param string $in_addr <p>
  * A 32bit IPv4, or 128bit IPv6 address.
  * </p>
- * @return string a string representation of the address or false on failure.
+ * @return string|bool a string representation of the address or false on failure.
  * @since 5.1.0
  */
 function inet_ntop ($in_addr) {}

--- a/standard/standard_4.php
+++ b/standard/standard_4.php
@@ -343,7 +343,7 @@ function unregister_tick_function ($function_name) {}
  * Set this parameter to true to make this function return the
  * highlighted code.
  * </p>
- * @return mixed If return is set to true, returns the highlighted
+ * @return string|bool If return is set to true, returns the highlighted
  * code as a string instead of printing it out. Otherwise, it will return
  * true on success, false on failure.
  * @since 4.0
@@ -371,7 +371,7 @@ function show_source ($file_name, $return) {}
  * Set this parameter to true to make this function return the
  * highlighted code.
  * </p>
- * @return mixed If return is set to true, returns the highlighted
+ * @return string|bool If return is set to true, returns the highlighted
  * code as a string instead of printing it out. Otherwise, it will return
  * true on success, false on failure.
  * @since 4.0
@@ -459,7 +459,7 @@ function ini_get_all ($extension = null, $details = null) {}
  * @param string $newvalue <p>
  * The new value for the option.
  * </p>
- * @return string the old value on success, false on failure.
+ * @return string|bool the old value on success, false on failure.
  * @since 4.0
  * @since 5.0
  */
@@ -502,7 +502,7 @@ function get_include_path () {}
  * @param string $new_include_path <p>
  * The new value for the include_path
  * </p>
- * @return string the old include_path on
+ * @return string|bool the old include_path on
  * success or false on failure.
  * @since 4.3.0
  * @since 5.0
@@ -758,7 +758,7 @@ function ignore_user_abort ($value = null) {}
  * and <em>"none"</em> are considered <b>FALSE</b>. <em>"null"</em> is converted to <b>NULL</b>
  * in typed mode. Also, all numeric strings are converted to integer type if it is possible.
  * </p>
- * @return array The settings are returned as an associative array on success,
+ * @return array|bool The settings are returned as an associative array on success,
  * and false on failure.
  * @since 4.0
  * @since 5.0
@@ -782,7 +782,7 @@ function parse_ini_file ($filename, $process_sections = null, $scanner_mode = nu
  * INI_SCANNER_RAW. If INI_SCANNER_RAW 
  * is supplied, then option values will not be parsed.
  * </p>
- * @return array The settings are returned as an associative array on success,
+ * @return array|bool The settings are returned as an associative array on success,
  * and false on failure.
  * @since 5.3.0
  */

--- a/standard/standard_5.php
+++ b/standard/standard_5.php
@@ -534,7 +534,7 @@ function fgetss ($handle, $length = null, $allowable_tags = null) {}
  * @param int $length <p>
  * Up to length number of bytes read.
  * </p>
- * @return string the read string or false on failure.
+ * @return string|bool the read string or false on failure.
  * @since 4.0
  * @since 5.0
  */
@@ -976,7 +976,7 @@ function tempnam ($dir, $prefix) {}
 /**
  * Creates a temporary file
  * @link http://php.net/manual/en/function.tmpfile.php
- * @return resource a file handle, similar to the one returned by
+ * @return resource|bool a file handle, similar to the one returned by
  * fopen, for the new file or false on failure.
  * @since 4.0
  * @since 5.0
@@ -1002,7 +1002,7 @@ function tmpfile () {}
  * <p>
  * &note.context-support;
  * </p>
- * @return array the file in an array. Each element of the array corresponds to a
+ * @return array|bool the file in an array. Each element of the array corresponds to a
  * line in the file, with the newline still attached. Upon failure,
  * file returns false.
  * </p>
@@ -1087,7 +1087,7 @@ function file ($filename, $flags = null, $context = null) {}
  * Maximum length of data read. The default is to read until end
  * of file is reached.
  * </p>
- * @return string The function returns the read data or false on failure.
+ * @return string|bool The function returns the read data or false on failure.
  * @since 4.3.0
  * @since 5.0
  */
@@ -1186,7 +1186,7 @@ function file_get_contents ($filename, $flags = null, $context = null, $offset =
  * A valid context resource created with 
  * stream_context_create.
  * </p>
- * @return int The function returns the number of bytes that were written to the file, or
+ * @return int|bool The function returns the number of bytes that were written to the file, or
  * false on failure.
  * @since 5.0
  */

--- a/standard/standard_6.php
+++ b/standard/standard_6.php
@@ -317,7 +317,7 @@ function stream_filter_remove ($stream_filter) {}
  * @param resource $context [optional] <p>
  * A valid context resource created with stream_context_create.
  * </p>
- * @return resource On success a stream resource is returned which may
+ * @return resource|bool On success a stream resource is returned which may
  * be used together with the other file functions (such as
  * fgets, fgetss,
  * fwrite, fclose, and
@@ -552,7 +552,7 @@ function stream_socket_shutdown ($stream, $how) {}
  * STREAM_IPPROTO_TCP or
  * STREAM_IPPROTO_UDP 
  * </p>
- * @return array an array with the two socket resources on success, or
+ * @return array|bool an array with the two socket resources on success, or
  * false on failure.
  * @since 5.1.0
  */
@@ -591,7 +591,7 @@ function stream_copy_to_stream ($source, $dest, $maxlength = null, $offset = nul
  * @param int $offset [optional] <p>
  * Seek to the specified offset before reading.
  * </p>
- * @return string a string or false on failure.
+ * @return string|bool a string or false on failure.
  * @since 5.0
  */
 function stream_get_contents ($handle, $maxlength = null, $offset = null) {}
@@ -664,7 +664,7 @@ function fgetcsv ($handle, $length = null, $delimiter = null, $enclosure = null,
  * enclosure (one character only).
  * </p>
  * @param string $escape_char The optional escape_char parameter sets the escape character (one character only).
- * @return int the length of the written string or false on failure.
+ * @return int|bool the length of the written string or false on failure.
  * @since 5.1.0
  */
 function fputcsv ($handle, array $fields, $delimiter = ",", $enclosure = '"', $escape_char = "\\") {}
@@ -976,7 +976,7 @@ function stream_register_wrapper ($protocol, $classname, $flags) {}
  * @link http://php.net/manual/en/function.stream-resolve-include-path.php
  * @param string $filename The filename to resolve.<p>
  * </p>
- * @return string containing the resolved absolute filename, or FALSE on failure.
+ * @return string|bool containing the resolved absolute filename, or FALSE on failure.
  * @since 5.3.2
  */
 function stream_resolve_include_path ($filename) {}
@@ -1157,7 +1157,7 @@ function socket_get_status (resource $stream) {}
  * @param string $path <p>
  * The path being checked.
  * </p>
- * @return string the canonicalized absolute pathname on success. The resulting path 
+ * @return string|bool the canonicalized absolute pathname on success. The resulting path 
  * will have no symbolic link, '/./' or '/../' components.
  * </p>
  * <p>

--- a/standard/standard_7.php
+++ b/standard/standard_7.php
@@ -250,7 +250,7 @@ function crypt ($str, $salt = null) {}
  * refer to the streams section of
  * the manual.
  * </p>
- * @return resource a directory handle resource on success, or
+ * @return resource|bool a directory handle resource on success, or
  * false on failure.
  * </p> 
  * <p>
@@ -347,7 +347,7 @@ function rewinddir ($dir_handle = null) {}
  * not specified, the last link opened by opendir 
  * is assumed.
  * </p>
- * @return string the filename on success or false on failure.
+ * @return string|bool the filename on success or false on failure.
  * @since 4.0
  * @since 5.0
  */
@@ -420,7 +420,7 @@ function glob ($pattern, $flags = null) {}
  * @param string $filename <p>
  * Path to the file.
  * </p>
- * @return int the time the file was last accessed, or false on failure.
+ * @return int|bool the time the file was last accessed, or false on failure.
  * The time is returned as a Unix timestamp.
  * @since 4.0
  * @since 5.0
@@ -433,7 +433,7 @@ function fileatime ($filename) {}
  * @param string $filename <p>
  * Path to the file.
  * </p>
- * @return int the time the file was last changed, or false on failure.
+ * @return int|bool the time the file was last changed, or false on failure.
  * The time is returned as a Unix timestamp.
  * @since 4.0
  * @since 5.0
@@ -446,7 +446,7 @@ function filectime ($filename) {}
  * @param string $filename <p>
  * Path to the file.
  * </p>
- * @return int the group ID of the file, or false in case
+ * @return int|bool the group ID of the file, or false in case
  * of an error. The group ID is returned in numerical format, use
  * posix_getgrgid to resolve it to a group name.
  * Upon failure, false is returned.
@@ -461,7 +461,7 @@ function filegroup ($filename) {}
  * @param string $filename <p>
  * Path to the file.
  * </p>
- * @return int the inode number of the file, or false on failure.
+ * @return int|bool the inode number of the file, or false on failure.
  * @since 4.0
  * @since 5.0
  */
@@ -473,7 +473,7 @@ function fileinode ($filename) {}
  * @param string $filename <p>
  * Path to the file.
  * </p>
- * @return int the time the file was last modified, or false on failure.
+ * @return int|bool the time the file was last modified, or false on failure.
  * The time is returned as a Unix timestamp, which is
  * suitable for the date function.
  * @since 4.0
@@ -487,7 +487,7 @@ function filemtime ($filename) {}
  * @param string $filename <p>
  * Path to the file.
  * </p>
- * @return int the user ID of the owner of the file, or false on failure.
+ * @return int|bool the user ID of the owner of the file, or false on failure.
  * The user ID is returned in numerical format, use
  * posix_getpwuid to resolve it to a username.
  * @since 4.0
@@ -501,7 +501,7 @@ function fileowner ($filename) {}
  * @param string $filename <p>
  * Path to the file.
  * </p>
- * @return int the permissions on the file, or false on failure.
+ * @return int|bool the permissions on the file, or false on failure.
  * @since 4.0
  * @since 5.0
  */
@@ -907,7 +907,7 @@ function clearstatcache ($clear_realpath_cache = null, $filename = null) {}
  * @param string $directory <p>
  * A directory of the filesystem or disk partition.
  * </p>
- * @return float the total number of bytes as a float
+ * @return float|bool the total number of bytes as a float
  * or false on failure.
  * @since 4.1.0
  * @since 5.0
@@ -925,7 +925,7 @@ function disk_total_space ($directory) {}
  * function is unspecified and may differ between operating systems and
  * PHP versions.
  * </p>
- * @return float the number of available bytes as a float
+ * @return float|bool the number of available bytes as a float
  * or false on failure.
  * @since 4.1.0
  * @since 5.0

--- a/standard/standard_8.php
+++ b/standard/standard_8.php
@@ -91,7 +91,7 @@ function header_register_callback ( callable $callback ) {}
  * Some programs use these APP markers to embed text information in images. <br>
  * A very common one is to embed » IPTC information in the APP13 marker. <br>
  * You can use the iptcparse() function to parse the binary APP13 marker into something readable.
- * @return array Returns an array with 7 elements.<br>
+ * @return array|bool Returns an array with 7 elements.<br>
  * Index 0 and 1 contains respectively the width and the height of the image.<br>
  * Index 2 is one of the <b>IMAGETYPE_XXX</b> constants indicating the type of the image.<br>
  * Index 3 is a text string with the correct <b>height="yyy" width="xxx"</b> string<br>
@@ -116,7 +116,7 @@ function stream_set_chunk_size ($fp , $chunk_size) {}
  * Import a stream.
  * @link http://www.php.net/manual/en/function.socket-import-stream.php
  * @param resource $stream The stream resource to import.
- * @return void Returns <b>FALSE</b> or <b>NULL</b> on failure.
+ * @return void|bool|null Returns <b>FALSE</b> or <b>NULL</b> on failure.
  */
 function socket_import_stream ($stream) {}
 
@@ -149,7 +149,7 @@ function lcg_value () {}
  * This parameter restricts the returned metaphone key to phonemes characters in length.
  * The default value of 0 means no restriction.
  * </p>
- * @return string the metaphone key as a string, or FALSE on failure
+ * @return string|bool the metaphone key as a string, or FALSE on failure
  * @since 4.0
  * @since 5.0
  */

--- a/standard/standard_9.php
+++ b/standard/standard_9.php
@@ -179,7 +179,7 @@ function array_pad(array $input, $pad_size, $pad_value) { }
  * @param array $trans <p>
  * An array of key/value pairs to be flipped.
  * </p>
- * @return array the flipped array on success and false on failure.
+ * @return array|bool the flipped array on success and false on failure.
  * @since 4.0
  * @since 5.0
  */


### PR DESCRIPTION
It was pointed out @ https://github.com/etsy/phan/issues/55#issuecomment-276126690 that many of these are wrong.

This adds the bool return type for methods that are marked as returning false on failure.