### PR TITLE
Add stub for ReflectionType::getName

### DIFF
--- a/Reflection/Reflection.php
+++ b/Reflection/Reflection.php
@@ -1970,8 +1970,19 @@ class ReflectionType
 	 * @link http://php.net/manual/en/reflectiontype.tostring.php
 	 * @return string Returns the type of the parameter.
 	 * @since 7.0
+	 * @deprecated 7.1.0:8.0.0 Please use getName()
+	 * @see \ReflectionType::getName()
 	 */
 	public function __toString()
+	{
+	}
+
+	/**
+	 * Get type of the parameter.
+	 * @return string Returns the type of the parameter.
+	 * @since 7.1.0
+	 */
+	public function getName()
 	{
 	}
 }


### PR DESCRIPTION
PHP 7.1 introduced ReflectionType::getName as alternative for __toString.

__toString deprecated and will be removed in PHP 8.0 (see php/php-src#2137 (comment))

Added getName() stub and marked __toString as deprecated.
(and removed some trailing whitespace)