### PR TITLE
getimagesizefromstring: mark 2nd parameter as optional

### DIFF
--- a/standard/standard_8.php
+++ b/standard/standard_8.php
@@ -98,7 +98,7 @@ function header_register_callback ( callable $callback ) {}
  * that can be used directly in an IMG tag.<br>
  * On failure, FALSE is returned.
  */
-function getimagesizefromstring ($imagedata , array &$imageinfo) {}
+function getimagesizefromstring ($imagedata , array &$imageinfo = null) {}
 
 /**
  * PHP > 5.4.0<br/>


### PR DESCRIPTION
In the new PHPStorm 2017.1 EAP this change is needed to use this function with one parameter only. In PHPStorm 2016.3.2 the parameter is recognized as optional without this change.