### PR TITLE
PDOStatement execute method signature update

### DIFF
--- a/standard/PDO.php
+++ b/standard/PDO.php
@@ -997,7 +997,7 @@ class PDOStatement implements Traversable {
 	 * </p>
 	 * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
 	 */
-	public function execute (array $input_parameters = null) {}
+	public function execute ($input_parameters = null) {}
 
 	/**
 	 * (PHP 5 &gt;= 5.1.0, PECL pdo &gt;= 0.1.0)<br/>


### PR DESCRIPTION
We extend PDOStatement and override the execute method. We noticed that the suggested method signature does not match the actual method signature.

PhpStorm shows the signature as:
`public function execute (array $input_parameters = null)`

The actual method signature is:
`public function execute ($input_parameters = null)`

PHP version:
`PHP Version => 7.0.15-1+deb.sury.org~trusty+1`