### PR TITLE
Fix incorrect documentation for Memcache::add

### DIFF
--- a/standard/memcache.php
+++ b/standard/memcache.php
@@ -159,7 +159,7 @@ class MemcachePool  {
 
     /**
      * (PECL memcache &gt;= 2.0.0)<br/>
-     * Get statistics from all servers in pool
+     * Add an item to the server. If the key already exists, the value will not be added and <b>FALSE</b> will be returned.
      * @link http://php.net/manual/en/memcache.add.php
      * @param string $key The key that will be associated with the item.
      * @param mixed $var The variable to store. Strings and integers are stored as is, other types are stored serialized.
@@ -170,7 +170,7 @@ class MemcachePool  {
      * @param int $expire [optional] <p>Expiration time of the item.
      * If it's equal to zero, the item will never expire.
      * You can also use Unix timestamp or a number of seconds starting from current time, but in the latter case the number of seconds may not exceed 2592000 (30 days).</p>
-     * @return array|boolean Returns a two-dimensional associative array of server statistics or <b>FALSE</b> on failure.
+     * @return boolean Returns <b>TRUE</b> on success or <b>FALSE</b> on failure. Returns <b>FALSE</b> if such key already exist. For the rest Memcache::add() behaves similarly to Memcache::set().
      */
     public function add ($key , $var, $flag, $expire) {}
 


### PR DESCRIPTION
It seems that the add documentation was copied and pasted from the addServer documentation, and a few things were forgotten. This PR changes that to match that of http://www.php.net/manual/en/memcache.add.php with a small amount of extra details.