### PR TITLE
SplFixedArray method setSize does not return an integer

### DIFF
--- a/SPL/SPL_c1.php
+++ b/SPL/SPL_c1.php
@@ -1683,7 +1683,7 @@ class SplFixedArray implements Iterator, Traversable, ArrayAccess, Countable {
          * @param int $size <p>
          * The new array size.
          * </p>
-         * @return int 
+         * @return bool
          * @since 5.3.0
          */
         public function setSize ($size) {}


### PR DESCRIPTION
SplFixedArray method setSize does not return an integer, but returns boolean as tested using PHP version 5.3 to 7.0, even though the PHP documentation states otherwise.