### PR TITLE
ArrayObject construct input default is empty array, not null

### DIFF
--- a/SPL/SPL.php
+++ b/SPL/SPL.php
@@ -1537,7 +1537,7 @@ class ArrayObject implements IteratorAggregate, Traversable, ArrayAccess, Serial
      * @since 5.0.0
      *
      */
-    public function __construct($input = null, $flags = 0, $iterator_class = "ArrayIterator") { }
+    public function __construct($input = [], $flags = 0, $iterator_class = "ArrayIterator") { }
 
     /**
      * Returns whether the requested index exists


### PR DESCRIPTION
As according to the PHP doc: http://php.net/manual/en/arrayobject.construct.php
ArrayObject 1st parameter $input is default an empty array, not null.