### PR TITLE
Fix missing cURL constants

### DIFF
--- a/curl/curl_d.php
+++ b/curl/curl_d.php
@@ -451,7 +451,7 @@ define ('CURL_NETRC_REQUIRED', 2);
 define ('CURL_HTTP_VERSION_NONE', 0);
 define ('CURL_HTTP_VERSION_1_0', 1);
 define ('CURL_HTTP_VERSION_1_1', 2);
-define ('CURLOPT_HTTP_VERSION_2_0', 3);
+define ('CURL_HTTP_VERSION_2_0', 3);
 define ('CURLM_CALL_MULTI_PERFORM', -1);
 define ('CURLM_OK', 0);
 define ('CURLM_BAD_HANDLE', 1);
@@ -578,6 +578,18 @@ define('CURLAUTH_NTLM_WB', 32);
  * @since 7.0.7
  */
 define('CURL_HTTP_VERSION_2', 3);
+
+/**
+ * @link http://php.net/manual/en/curl.constants.php
+ * @since 7.0.7
+ */
+define('CURL_HTTP_VERSION_2TLS', 4);
+
+/**
+ * @link http://php.net/manual/en/curl.constants.php
+ * @since 7.0.7
+ */
+define('CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE', 5);
 
 /**
  * @link http://php.net/manual/en/curl.constants.php


### PR DESCRIPTION
- `CURLOPT_HTTP_VERSION_2_0` doesn't exist, it is `CURL_HTTP_VERSION_2_0` but it's missing from the PHP documentation
- `CURLOPT_HTTP_VERSION_2TLS` and `CURLOPT_HTTP_VERSION_2_PRIOR_KNOWLEDGE` were introduced along `CURLOPT_HTTP_VERSION_2` but were missing.