### PR TITLE
Change __sleep signature

### DIFF
--- a/standard/_types.php
+++ b/standard/_types.php
@@ -305,7 +305,7 @@ class object {
    * The intended use of __sleep is to commit pending data or perform similar cleanup tasks.
    * Also, the function is useful if you have very large objects which do not need to be saved completely.
    *
-   * @return array|NULL
+   * @return string[]
    * @link http://php.net/manual/en/language.oop5.magic.php#language.oop5.magic.sleep
    */
   function __sleep() {}


### PR DESCRIPTION
Docs states it must return array and if void returned, then it's serialized as null and notice issued.
Returned array contains field names to include in serialization, so it's array of strings.

http://php.net/manual/en/language.oop5.magic.php#language.oop5.magic.sleep
