### PR TITLE
Add missing DatePeriod properties and fix getEndDate return type.

### DIFF
--- a/date/date_c.php
+++ b/date/date_c.php
@@ -626,7 +626,43 @@ class DateInterval {
  */
 class DatePeriod implements Traversable {
     const EXCLUDE_START_DATE = 1;
+    
+    /**
+     * Start date
+     * @var DateTimeInterface
+     */
+    public $start;
 
+    /**
+     * Current iterator value.
+     * @var DateTimeInterface|null
+     */
+    public $current;
+    
+    /**
+     * End date.
+     * @var DateTimeInterface|null
+     */
+    public $end;
+    
+    /**
+     * The interval
+     * @var DateInterval
+     */
+    public $interval;
+    
+    /**
+     * Number of recurrences.
+     * @var int
+     */
+    public $recurrences;
+    
+    /**
+     * Start of period.
+     * @var bool
+     */
+    public $include_start_date;
+    
     /**
      * @param DateTimeInterface $start
      * @param DateInterval $interval
@@ -665,7 +701,7 @@ class DatePeriod implements Traversable {
 
     /**
      * Gets the end date
-     * @return DateTimeInterface
+     * @return DateTimeInterface|null
      * @link http://php.net/manual/en/dateperiod.getenddate.php
      * @since 5.6.5
      */


### PR DESCRIPTION
- DatePeriod has 6 undocumented properties
- getEndDate() can also return null.

See https://bugs.php.net/bug.php?id=74176 and https://3v4l.org/kSsIo