### PR TITLE
Changed MongoCursor.hint `key_pattern` from array to mixed

### DIFF
--- a/mongo/mongo.php
+++ b/mongo/mongo.php
@@ -1439,11 +1439,11 @@ class MongoCursor implements Iterator, Traversable {
    /**
 	* Gives the database a hint about the query
 	* @link http://www.php.net/manual/en/mongocursor.hint.php
-	* @param array $key_pattern Indexes to use for the query.
+	* @param string $key_pattern Indexes to use for the query.
 	* @throws MongoCursorException
     * @return MongoCursor Returns this cursor
     */
-    public function hint(array $key_pattern) {}
+    public function hint($key_pattern) {}
 
 
 	/**

--- a/mongo/mongo.php
+++ b/mongo/mongo.php
@@ -1439,11 +1439,11 @@ class MongoCursor implements Iterator, Traversable {
    /**
 	* Gives the database a hint about the query
 	* @link http://www.php.net/manual/en/mongocursor.hint.php
-	* @param string $key_pattern Indexes to use for the query.
+	* @param mixed $key_pattern Indexes to use for the query.
 	* @throws MongoCursorException
     * @return MongoCursor Returns this cursor
     */
-    public function hint($key_pattern) {}
+    public function hint(mixed $key_pattern) {}
 
 
 	/**


### PR DESCRIPTION
MongoClient requires mixed not only arrays for hints. Throwing warnings all over the codebase.