### PR TITLE
Fix PDOStatement::fetchColumn() return type

### DIFF
--- a/PDO/PDO.php
+++ b/PDO/PDO.php
@@ -1134,8 +1134,8 @@ class PDOStatement implements Traversable {
 	 * no value is supplied, <b>PDOStatement::fetchColumn</b>
 	 * fetches the first column.
 	 * </p>
-	 * @return string <b>PDOStatement::fetchColumn</b> returns a single column
-	 * in the next row of a result set.
+	 * @return mixed Returns a single column from the next row of a result
+	 * set or FALSE if there are no more rows.
 	 * </p>
 	 * <p>
 	 * There is no way to return another column from the same row if you


### PR DESCRIPTION
The return type should be `mixed`, not `string`. In particular, it returns `false` when there are no more rows.

See: http://php.net/manual/en/pdostatement.fetchcolumn.php