### PR TITLE
Fixed default signal value of proc_terminate

### DIFF
--- a/standard/standard_2.php
+++ b/standard/standard_2.php
@@ -860,7 +860,7 @@ function proc_close ($process) {}
  * @return bool the termination status of the process that was run.
  * @since 5.0
  */
-function proc_terminate ($process, $signal = null) {}
+function proc_terminate ($process, $signal = 15) {}
 
 /**
  * Get information about a process opened by <function>proc_open</function>


### PR DESCRIPTION
Fixed default signal value of proc_terminate which is 15, not null. As per http://php.net/manual/en/function.proc-terminate.php#refsect1-function.proc-terminate-description