### PR TITLE
SimpleXMLElement accessor always returns a single SimpleXMLElement object

### DIFF
--- a/SimpleXML/SimpleXML.php
+++ b/SimpleXML/SimpleXML.php
@@ -24,7 +24,7 @@ class SimpleXMLElement implements Traversable {
 	/**
      * Provides access to element's children
      * @param $name child name
-     * @return SimpleXMLElement[]
+     * @return SimpleXMLElement
      */
     function __get($name) {}
 


### PR DESCRIPTION
Even when several nodes with the same name exist in the document, the first element is returned when using the magic accessor.

```php
$data = <<<EOF
<feed>
 <products>
  <product>1</product>
  <product>2</product>
  <product>3</product>
 </products>
</feed>
EOF;

$data = simplexml_load_string($data);

echo get_class($data->products->product); // SimpleXMLElement
echo $data->products->product; // 1
```

Therefore the return type of `__get()` should be `SimpleXMLElement`, not `SimpleXMLElement[]`.