### PR TITLE
Add dummy ArrayAccess to SimpleXMLElement to fix WI-15760

### DIFF
--- a/SimpleXML/SimpleXML.php
+++ b/SimpleXML/SimpleXML.php
@@ -217,36 +217,36 @@ class SimpleXMLElement implements Traversable, ArrayAccess {
 
     /**
      * Class provides access to children by position, and attributes by name
-     * Stub only: method not callable directly.
+     * @access private Method not callable directly, stub exists for typehint only
      * @param string|int $offset
      * @return boolean true on success or false on failure.
      */
-    public function offsetExists ($offset) {}
+    private function offsetExists ($offset) {}
 
     /**
      * Class provides access to children by position, and attributes by name
-     * Stub only: method not callable directly.
+     * @access private Method not callable directly, stub exists for typehint only
      * @param string|int $offset
      * @return SimpleXMLElement Either a named attribute or an element from a list of children
      */
-    public function offsetGet ($offset) {}
+    private function offsetGet ($offset) {}
 
     /**
      * Class provides access to children by position, and attributes by name
-     * Stub only: method not callable directly.
+     * @access private Method not callable directly, stub exists for typehint only
      * @param string|int $offset
      * @param mixed $value
      * @return void
      */
-    public function offsetSet ($offset, $value) {}
+    private function offsetSet ($offset, $value) {}
 
     /**
      * Class provides access to children by position, and attributes by name
-     * Stub only: method not callable directly.
+     * @access private Method not callable directly, stub exists for typehint only
      * @param string|int $offset
      * @return void
      */
-    public function offsetUnset ($offset) {}
+    private function offsetUnset ($offset) {}
 }
 
 /**

--- a/SimpleXML/SimpleXML.php
+++ b/SimpleXML/SimpleXML.php
@@ -23,10 +23,11 @@ class SimpleXMLElement implements Traversable, ArrayAccess {
 
 	/**
      * Provides access to element's children
+     * @access private Method not callable directly, stub exists for typehint only
      * @param $name child name
      * @return SimpleXMLElement
      */
-    function __get($name) {}
+    private function __get($name) {}
 
 	/**
 	 * Return a well-formed XML string based on SimpleXML element

--- a/SimpleXML/SimpleXML.php
+++ b/SimpleXML/SimpleXML.php
@@ -6,7 +6,7 @@
  * Represents an element in an XML document.
  * @link http://php.net/manual/en/class.simplexmlelement.php
  */
-class SimpleXMLElement implements Traversable {
+class SimpleXMLElement implements Traversable, ArrayAccess {
 
 	/**
 	 * Creates a new SimpleXMLElement object
@@ -24,7 +24,7 @@ class SimpleXMLElement implements Traversable {
 	/**
      * Provides access to element's children
      * @param $name child name
-     * @return SimpleXMLElement[]
+     * @return SimpleXMLElement
      */
     function __get($name) {}
 
@@ -215,6 +215,38 @@ class SimpleXMLElement implements Traversable {
 	 */
 	public function count () {}
 
+    /**
+     * Class provides access to children by position, and attributes by name
+     * Stub only: method not callable directly.
+     * @param string|int $offset
+     * @return boolean true on success or false on failure.
+     */
+    public function offsetExists ($offset) {}
+
+    /**
+     * Class provides access to children by position, and attributes by name
+     * Stub only: method not callable directly.
+     * @param string|int $offset
+     * @return SimpleXMLElement Either a named attribute or an element from a list of children
+     */
+    public function offsetGet ($offset) {}
+
+    /**
+     * Class provides access to children by position, and attributes by name
+     * Stub only: method not callable directly.
+     * @param string|int $offset
+     * @param mixed $value
+     * @return void
+     */
+    public function offsetSet ($offset, $value) {}
+
+    /**
+     * Class provides access to children by position, and attributes by name
+     * Stub only: method not callable directly.
+     * @param string|int $offset
+     * @return void
+     */
+    public function offsetUnset ($offset) {}
 }
 
 /**


### PR DESCRIPTION
The actual array access methods are not available, but the internal class implements the equivalent C-level handlers, so that [0], ['foo'], etc are always available. 

This removes the need to mark any returns as SimpleXMLElement[], except for ->xpath(), which really does return a true array.

Issue was reported in 2012: https://youtrack.jetbrains.com/issue/WI-15760 This solution is not ideal, but the stub already contains a dummy __get(), so this seems a logical improvement.