### PR TITLE
Fixed mb_ereg_replace() mb_ereg_replace() openssl_encrypt() openssl_decrypt() token_get_all() descriptions

### DIFF
--- a/mbstring/mbstring.php
+++ b/mbstring/mbstring.php
@@ -1019,7 +1019,7 @@ function mb_eregi ($pattern, $string, array $regs = null) {}
  * @since 4.2.0
  * @since 5.0
  */
-function mb_ereg_replace ($pattern, $replacement, $string, $option = null) {}
+function mb_ereg_replace ($pattern, $replacement, $string, $option = "msr") {}
 
 /**
  * Perform a regular expresssion seach and replace with multibyte support using a callback
@@ -1085,7 +1085,7 @@ function mb_ereg_replace_callback ($pattern, callable $callback, $string, $optio
  * @since 4.2.0
  * @since 5.0
  */
-function mb_eregi_replace ($pattern, $replace, $string, $option = null) {}
+function mb_eregi_replace ($pattern, $replace, $string, $option = "msr") {}
 
 /**
  * Split multibyte string using regular expression

--- a/openssl/openssl.php
+++ b/openssl/openssl.php
@@ -648,20 +648,24 @@ function openssl_digest($data, $method, $raw_output = false) { }
  * @param string $method <p>
  * The cipher method.
  * </p>
- * @param string $password <p>
- * The password.
+ * @param string $key <p>
+ * The key. For a list of available cipher methods, use {@see openssl_get_cipher_methods()}.
  * </p>
  * @param int $options [optional] <p>
- * Setting to true will return as raw output data, otherwise the return
- * value is base64 encoded.
+ * options is a bitwise disjunction of the flags OPENSSL_RAW_DATA and OPENSSL_ZERO_PADDING.
  * </p>
  * @param string $iv [optional] <p>
  * A non-NULL Initialization Vector.
  * </p>
+ * @param string &$tag <p>The authentication tag passed by reference when using AEAD cipher mode (GCM or CCM).</p>
+ * @param string $aad <p>Additional authentication data.</p>
+ * @param int $tag_length [optional] <p>
+ * The length of the authentication tag. Its value can be between 4 and 16 for GCM mode.
+ * </p>
  * @return string the encrypted string on success or false on failure.
  * @since 5.3.0
  */
-function openssl_encrypt($data, $method, $password, $options = 0, $iv = "") { }
+function openssl_encrypt($data, $method, $key, $options = 0, $iv = "", &$tag = NULL, $aad = "", $tag_length = 16) { }
 
 /**
  * Decrypts data
@@ -683,10 +687,14 @@ function openssl_encrypt($data, $method, $password, $options = 0, $iv = "") { }
  * @param string $iv [optional] <p>
  * A non-NULL Initialization Vector.
  * </p>
+ * @param string $tag [optional] <p>
+ * The authentication tag in AEAD cipher mode. If it is incorrect, the authentication fails and the function returns <b>FALSE</b>.
+ * </p>
+ * @param string $aad [optional] <p>Additional authentication data.</p>
  * @return string The decrypted string on success or false on failure.
  * @since 5.3.0
  */
-function openssl_decrypt($data, $method, $password, $options = 1, $iv = "") { }
+function openssl_decrypt($data, $method, $password, $options = 1, $iv = "", $tag = "",  $aad = "") { }
 
 /**
  * (PHP 5 &gt;= PHP 5.3.3)<br/>

--- a/tokenizer/tokenizer.php
+++ b/tokenizer/tokenizer.php
@@ -8,6 +8,18 @@
  * @param string $source <p>
  * The PHP source to parse.
  * </p>
+ * @param int $flags
+ * <p>
+ * <p>
+ * Valid flags:
+ * </p><ul>
+ * <li>
+ *
+ * <b>TOKEN_PARSE</b> - Recognises the ability to use
+ * reserved words in specific contexts.
+ * </li>
+ * </ul>
+ * </p>
  * @return array An array of token identifiers. Each individual token identifier is either
  * a single character (i.e.: ;, .,
  * &gt;, !, etc...),
@@ -16,7 +28,7 @@
  * @since 4.2.0
  * @since 5.0
  */
-function token_get_all ($source) {}
+function token_get_all ($source, $flags = 0) {}
 
 /**
  * Get the symbolic name of a given PHP token


### PR DESCRIPTION
Fixed $option default value mb_ereg_replace() and mb_ereg_replace()

Added missing parameters to openssl_encrypt() openssl_decrypt()

WI-37444 Invalid stub for token_get_all php 7.0


