### PR TITLE
preg_split doc update

### DIFF
--- a/pcre/pcre.php
+++ b/pcre/pcre.php
@@ -359,7 +359,7 @@ function preg_filter ($pattern, $replacement, $subject, $limit = -1, &$count = n
  * <b>PREG_SPLIT_NO_EMPTY</b>
  * If this flag is set, only non-empty pieces will be returned by
  * <b>preg_split</b>.
- * @return array an array containing substrings of <i>subject</i>
+ * @return string[]|array|false an array containing substrings of <i>subject</i>
  * split along boundaries matched by <i>pattern</i>, or <b>FALSE</b>
  * if an error occurred.
  * @since 4.0

--- a/pcre/pcre.php
+++ b/pcre/pcre.php
@@ -360,7 +360,8 @@ function preg_filter ($pattern, $replacement, $subject, $limit = -1, &$count = n
  * If this flag is set, only non-empty pieces will be returned by
  * <b>preg_split</b>.
  * @return array an array containing substrings of <i>subject</i>
- * split along boundaries matched by <i>pattern</i>.
+ * split along boundaries matched by <i>pattern</i>, or <b>FALSE</b>
+ * if an error occurred.
  * @since 4.0
  * @since 5.0
  */


### PR DESCRIPTION
added missing `FALSE` as a return value for `preg_split` if error occurs

http://php.net/manual/en/function.preg-split.php