### PR TITLE
Add visibility for jsonSerialize() in JsonSeializable interface

### DIFF
--- a/json/json.php
+++ b/json/json.php
@@ -17,7 +17,7 @@ interface JsonSerializable  {
 	 * which is a value of any type other than a resource.
 	 * @since 5.4.0
 	 */
-    function jsonSerialize ();
+    public function jsonSerialize ();
 
 }
 


### PR DESCRIPTION
Hi. I was wondering why `jsonSerialize()` has no visibility defined. Every developer I know always adds it manually after adding method stubs.