### PR TITLE
Update SplFileObject

### DIFF
--- a/SPL/SPL_c1.php
+++ b/SPL/SPL_c1.php
@@ -551,7 +551,7 @@ class GlobIterator extends FilesystemIterator implements Countable {
 class SplFileObject extends SplFileInfo implements RecursiveIterator, SeekableIterator {
         const DROP_NEW_LINE = 1;
         const READ_AHEAD = 2;
-        const SKIP_EMPTY = 6;
+        const SKIP_EMPTY = 4;
         const READ_CSV = 8;
 
 


### PR DESCRIPTION
http://php.net/manual/en/class.splfileobject.php

Version | Description
-- | --
5.3.9 | SplFileObject::SKIP_EMPTY value changed to 4. Previously, value was 6.

