### PR TITLE
Change abs return value to actual PHP types

### DIFF
--- a/standard/standard_3.php
+++ b/standard/standard_3.php
@@ -68,7 +68,7 @@ function convert_uudecode ($data) {}
  * @param mixed $number <p>
  * The numeric value to process
  * </p>
- * @return number The absolute value of number. If the
+ * @return float|int The absolute value of number. If the
  * argument number is
  * of type float, the return type is also float,
  * otherwise it is integer (as float usually has a


### PR DESCRIPTION
Unable to make a parameter its own absolute value with the current number annotation.  There'll be an issue with this request soon.