### PR TITLE
Replace number type with int|float

### DIFF
--- a/intl/intl.php
+++ b/intl/intl.php
@@ -907,7 +907,7 @@ class NumberFormatter {
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
      * Format a number
      * @link http://php.net/manual/en/numberformatter.format.php
-     * @param number $value <p>
+     * @param int|float $value <p>
      * The value to format. Can be integer or float,
      * other values will be converted to a numeric value.
      * </p>
@@ -3392,7 +3392,7 @@ function numfmt_create($locale, $style, $pattern = null) { }
  * Format a number
  * @link http://php.net/manual/en/numberformatter.format.php
  * @param NumberFormatter $fmt
- * @param number $value <p>
+ * @param int|float $value <p>
  * The value to format. Can be integer or float,
  * other values will be converted to a numeric value.
  * </p>

--- a/oci8/oci8.php
+++ b/oci8/oci8.php
@@ -2151,7 +2151,7 @@ function ocicollmax ($collection) {}
  * {@see OCI_Collection::trim}
  * @link http://php.net/manual/en/function.ocicolltrim.php
  * @param collection
- * @param number
+ * @param int|float
  * @return bool Returns <b>TRUE</b> or <b>FALSE</b> on failure.
  */
 function ocicolltrim ($collection, $number) {}

--- a/standard/standard_3.php
+++ b/standard/standard_3.php
@@ -383,13 +383,13 @@ function is_infinite ($val) {}
 /**
  * Exponential expression
  * @link http://php.net/manual/en/function.pow.php
- * @param number $base <p>
+ * @param int|float $base <p>
  * The base to use
  * </p>
- * @param number $exp <p>
+ * @param int|float $exp <p>
  * The exponent
  * </p>
- * @return number base raised to the power of exp.
+ * @return int|float base raised to the power of exp.
  * If the result can be represented as integer it will be returned as type
  * integer, else it will be returned as type float.
  * If the power cannot be computed false will be returned instead.
@@ -498,7 +498,7 @@ function rad2deg ($number) {}
  * @param string $binary_string <p>
  * The binary string to convert
  * </p>
- * @return number The decimal value of binary_string
+ * @return int|float The decimal value of binary_string
  * @since 4.0
  * @since 5.0
  */
@@ -510,7 +510,7 @@ function bindec ($binary_string) {}
  * @param string $hex_string <p>
  * The hexadecimal string to convert
  * </p>
- * @return number The decimal representation of hex_string
+ * @return int|float The decimal representation of hex_string
  * @since 4.0
  * @since 5.0
  */
@@ -522,7 +522,7 @@ function hexdec ($hex_string) {}
  * @param string $octal_string <p>
  * The octal string to convert
  * </p>
- * @return number The decimal representation of octal_string
+ * @return int|float The decimal representation of octal_string
  * @since 4.0
  * @since 5.0
  */

--- a/standard/standard_8.php
+++ b/standard/standard_8.php
@@ -962,7 +962,7 @@ function array_fill_keys (array $keys, $value) {}
  * @param mixed $high <p>
  * High value.
  * </p>
- * @param number $step [optional] <p>
+ * @param int|float $step [optional] <p>
  * If a step value is given, it will be used as the
  * increment between elements in the sequence. step
  * should be given as a positive number. If not specified,


### PR DESCRIPTION
Inspired by #256, I replaced `number` type to `int|float` in all stubs.

Php documentation uses `number` to denote `int|float`: http://php.net/manual/en/language.pseudo-types.php#language.types.number