### PR TITLE
Change MongoGridFS::__get to get

### DIFF
--- a/mongo/mongo.php
+++ b/mongo/mongo.php
@@ -1771,7 +1771,7 @@ class MongoGridFS extends MongoCollection {
     * @param mixed $id _id of the file to find.
     * @return MongoGridFSFile|null Returns the file, if found, or NULL.
     */
-    public function __get($id) {}
+    public function get($id) {}
 
      /**
      * Stores a file in the database


### PR DESCRIPTION
Currently the mongo.php stub defines a MongoGridFS::__get method which is actually MongoCollection's method but does not define the real get method.  This just changes the name of __get to get.

See: https://youtrack.jetbrains.com/issue/WI-37636