### PR TITLE
WI-38016 fix redis del() and delete() docs

### DIFF
--- a/redis/Redis.php
+++ b/redis/Redis.php
@@ -353,7 +353,7 @@ class Redis
     /**
      * Remove specified keys.
      *
-     * @param   string|array    $key1 An array of keys, or an undefined number of parameters, each a key: key1 key2 key3 ... keyN
+     * @param   string|string[] $key1 An array of keys, or an undefined number of parameters, each a key: key1 key2 key3 ... keyN
      * @param   string          $key2 ...
      * @param   string          $key3 ...
      * @return  int             Number of keys deleted.
@@ -372,7 +372,7 @@ class Redis
 
     /**
      * @see del()
-     * @param   string|array    $key1 An array of keys, or an undefined number of parameters, each a key: key1 key2 key3 ... keyN
+     * @param   string|string[] $key1 An array of keys, or an undefined number of parameters, each a key: key1 key2 key3 ... keyN
      * @param   string          $key2 ...
      * @param   string          $key3 ...
      * @return  int             Number of keys deleted.

--- a/redis/Redis.php
+++ b/redis/Redis.php
@@ -353,10 +353,10 @@ class Redis
     /**
      * Remove specified keys.
      *
-     * @param   int|array   $key1 An array of keys, or an undefined number of parameters, each a key: key1 key2 key3 ... keyN
-     * @param   string      $key2 ...
-     * @param   string      $key3 ...
-     * @return int Number of keys deleted.
+     * @param   string|array    $key1 An array of keys, or an undefined number of parameters, each a key: key1 key2 key3 ... keyN
+     * @param   string          $key2 ...
+     * @param   string          $key3 ...
+     * @return  int             Number of keys deleted.
      * @link    http://redis.io/commands/del
      * @example
      * <pre>
@@ -372,9 +372,11 @@ class Redis
 
     /**
      * @see del()
-     * @param $key1
-     * @param null $key2
-     * @param null $key3
+     * @param   string|array    $key1 An array of keys, or an undefined number of parameters, each a key: key1 key2 key3 ... keyN
+     * @param   string          $key2 ...
+     * @param   string          $key3 ...
+     * @return  int             Number of keys deleted.
+     * @link    http://redis.io/commands/del
      */
     public function delete( $key1, $key2 = null, $key3 = null ) {}
 


### PR DESCRIPTION
Most important thing here is that the `delete()` function currently incorrectly reports `void` return type. The signatures of both functions should be the same, and keys are of type `string`. 