### PR TITLE
Flags parameter in Regex constructor is optional

### DIFF
--- a/mongodb/mongodb.php
+++ b/mongodb/mongodb.php
@@ -1159,7 +1159,7 @@ namespace MongoDB {}
              * @param string $pattern
              * @param string $flags
              */
-            public function __construct($pattern, $flags)
+            public function __construct($pattern, $flags = "")
             {
             }
 

--- a/mongodb/mongodb.php
+++ b/mongodb/mongodb.php
@@ -1157,7 +1157,7 @@ namespace MongoDB {}
              * Construct a new Regex
              * @link http://php.net/manual/en/mongodb-bson-regex.construct.php
              * @param string $pattern
-             * @param string $flags
+             * @param string $flags [optional]
              */
             public function __construct($pattern, $flags = "")
             {


### PR DESCRIPTION
The parameter $flags for the class MongoDB\BSON\Regex is optional:
http://php.net/manual/en/mongodb-bson-regex.construct.php