### PR TITLE
Add missing newrelic_* functions

### DIFF
--- a/newrelic/newrelic.php
+++ b/newrelic/newrelic.php
@@ -356,3 +356,37 @@ function newrelic_set_user_attributes($user, $account, $product) {}
  * @return boolean
  */
 function newrelic_start_transaction($appName, $license = null) {}
+
+/**
+ * @param $curl_resource
+ * @param $header_data
+ *
+ * @return mixed
+ */
+function newrelic_curl_header_callback($curl_resource, $header_data) {}
+
+/**
+ * @param $stream_context
+ *
+ * @return mixed
+ */
+function newrelic_add_headers_to_context($stream_context) {}
+
+/**
+ * @param $stream_context
+ *
+ * @return mixed
+ */
+function newrelic_remove_headers_to_context($stream_context) {}
+
+/**
+ * @param $exception
+ */
+function newrelic_exception_handler($exception) {}
+
+/**
+ * Returns an array with keys X-NewRelic-ID and X-NewRelic-Transaction on success.
+ *
+ * @return array
+ */
+function newrelic_get_request_metadata() {}


### PR DESCRIPTION
There are about 5 functions missing from the official documents (I have reported, will be fixed) and also from this stub.
Since there are no official docs, I didn't expand more on the docblock, it's better to wait for those then we can open another PR.

I have fetched the parameters like below, but I am unsure of the types since there is no source code available.
```
root@box:~# php --rf newrelic_curl_header_callback
Function [ <internal:newrelic> function newrelic_curl_header_callback ] {

  - Parameters [2] {
    Parameter #0 [ <required> $"curl_resource" ]
    Parameter #1 [ <required> $"header_data" ]
  }
}
```