### PR TITLE
Make NumberFormatter::__construct()'s third param optional

### DIFF
--- a/intl/intl.php
+++ b/intl/intl.php
@@ -875,7 +875,7 @@ class NumberFormatter {
      * @param $style
      * @param $pattern [optional]
      */
-    public function __construct($locale, $style, $pattern) { }
+    public function __construct($locale, $style, $pattern = null) { }
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>


### PR DESCRIPTION
It was documented as such in the doc comment, but not actually optional
in the signature, so calling the constructor with two parameters
would incorrectly cause a warning.