### PR TITLE
WI-39019: remove DuplicateKeyException

### DIFF
--- a/mongodb/mongodb.php
+++ b/mongodb/mongodb.php
@@ -19,7 +19,6 @@ namespace MongoDB {}
         use MongoDB\Driver\Exception\AuthenticationException;
         use MongoDB\Driver\Exception\BulkWriteException;
         use MongoDB\Driver\Exception\ConnectionException;
-        use MongoDB\Driver\Exception\DuplicateKeyException;
         use MongoDB\Driver\Exception\Exception;
         use MongoDB\Driver\Exception\InvalidArgumentException;
         use MongoDB\Driver\Exception\RuntimeException;
@@ -69,7 +68,6 @@ namespace MongoDB {}
              * @throws AuthenticationException if authentication is needed and fails
              * @throws ConnectionException if connection to the server fails for other then authentication reasons
              * @throws RuntimeException on other errors (invalid command, command arguments, ...)
-             * @throws DuplicateKeyException if a write causes Duplicate Key error
              * @throws WriteException on Write Error
              * @throws WriteConcernException on Write Concern failure
              */
@@ -872,10 +870,6 @@ namespace MongoDB {}
          * @link http://php.net/manual/en/class.mongodb-driver-exception-connectionexception.php
          */
         class ConnectionException extends RuntimeException implements Exception
-        {
-        }
-
-        class DuplicateKeyException extends RuntimeException implements Exception
         {
         }
 


### PR DESCRIPTION
It was added to library but then removed as unused.
See https://github.com/mongodb/mongo-php-driver/commit/95774b10d2f8ec6c4ccedb71f9d9b7ca3cdc8c86 and https://github.com/mongodb/mongo-php-driver/commit/15a9f709d279bf49094f33deb74e4de49e078791.