### PR TITLE
WI-39334 | Third argument for socket_cmsg_space

### DIFF
--- a/sockets/sockets.php
+++ b/sockets/sockets.php
@@ -1303,10 +1303,11 @@ function socket_import_stream ($stream) {}
  * @link http://php.net/manual/en/function.socket-cmsg-space.php
  * @param int $level
  * @param int $type
+ * @param int $n [optional]
  * @return int
  * @since 5.5.0
  */
-function socket_cmsg_space ($level, $type) {}
+function socket_cmsg_space ($level, $type, $n = 0) {}
 
 /**
  * @param $socket


### PR DESCRIPTION
The PHP source code shows that the method socket_cmsg_space has a third argument.
See PHP source: ext/sockets/sendrecvmsg.c:278