### PR TITLE
Fixed sodium.sodium_crypto_secretbox_open() stub

### DIFF
--- a/sodium/sodium.php
+++ b/sodium/sodium.php
@@ -560,7 +560,7 @@ function sodium_crypto_secretbox(
  * @param string $ciphertext
  * @param string $nonce
  * @param string $key
- * @return string
+ * @return string|bool
  */
 function sodium_crypto_secretbox_open(
     string $ciphertext,


### PR DESCRIPTION
This function may return `false` on failure. 