### PR TITLE
Changed detail and headerfault from string to mixed

### DIFF
--- a/soap/soap.php
+++ b/soap/soap.php
@@ -653,7 +653,7 @@ class SoapFault extends Exception  {
      */
     public $faultactor;
     /**
-     * @var string
+     * @var mixed
      */
     public $detail;
     /**
@@ -661,7 +661,7 @@ class SoapFault extends Exception  {
      */
     public $faultname;
     /**
-     * @var string
+     * @var mixed
      */
     public $headerfault;
 
@@ -677,13 +677,13 @@ class SoapFault extends Exception  {
 	 * @param string $faultactor [optional] <p>
 	 * A string identifying the actor that caused the error.
 	 * </p>
-	 * @param string $detail [optional] <p>
+	 * @param mixed $detail [optional] <p>
 	 * More details about the cause of the error.
 	 * </p>
 	 * @param string $faultname [optional] <p>
 	 * Can be used to select the proper fault encoding from WSDL.
 	 * </p>
-	 * @param string $headerfault [optional] <p>
+	 * @param mixed $headerfault [optional] <p>
 	 * Can be used during SOAP header handling to report an error in the
 	 * response header.
 	 * </p>


### PR DESCRIPTION
The recent change to expose the semi-public properties of SoapFault is a good thing.  

I know that http://php.net/manual/en/class.soapfault.php shows $details and $headerfault as strings but they're zvals in the engine

```
soap.c
/* {{{ proto object SoapFault::SoapFault ( string faultcode, string faultstring [, string faultactor [, mixed detail [, string faultname [, mixed headerfault]]]])

	if (zend_parse_parameters(ZEND_NUM_ARGS(), "zs|s!z!s!z",
		&code,
		&fault_string, &fault_string_len,
		&fault_actor, &fault_actor_len,
		&details, &name, &name_len, &headerfault) == FAILURE) {
		return;
	}
```

and being declared as string in the stub causes PhpStorm to raise invalid issues while inspecting "correct" code.

```
    /**
     * populate error response
     *
     * @param SoapFault $soapfaultObj
     * @param array     &$responseObj
     * @param array     $errCodes
     * @param string    $faultCls
     */
    protected function populateErrorResponse($soapfaultObj, &$responseObj, $errCodes, $faultCls) {
        // This method will parse the soap fault object and populate the response object
        // SoapFault
        $moreInfo = $soapfaultObj->detail->FaultFault->ProviderInfo;

```

Here's the PhpStorm youtrack issue: https://youtrack.jetbrains.com/issue/WI-39477