### PR TITLE
Change ArrayObject to object in PHPDoc for array iterator functions.

### DIFF
--- a/standard/standard_8.php
+++ b/standard/standard_8.php
@@ -702,7 +702,7 @@ function count ($var, $mode = COUNT_NORMAL) {}
 /**
  * Set the internal pointer of an array to its last element
  * @link http://php.net/manual/en/function.end.php
- * @param array|ArrayObject $array <p>
+ * @param array|object $array <p>
  * The array. This array is passed by reference because it is modified by
  * the function. This means you must pass it a real variable and not
  * a function returning an array because only actual variables may be
@@ -717,7 +717,7 @@ function end (array &$array) {}
 /**
  * Rewind the internal array pointer
  * @link http://php.net/manual/en/function.prev.php
- * @param array|ArrayObject $array <p>
+ * @param array|object $array <p>
  * The input array.
  * </p>
  * @return mixed the array value in the previous place that's pointed to by
@@ -731,7 +731,7 @@ function prev (array &$array) {}
 /**
  * Advance the internal array pointer of an array
  * @link http://php.net/manual/en/function.next.php
- * @param array|ArrayObject $array <p>
+ * @param array|object $array <p>
  * The array being affected.
  * </p>
  * @return mixed the array value in the next place that's pointed to by the
@@ -744,7 +744,7 @@ function next (array &$array) {}
 /**
  * Set the internal pointer of an array to its first element
  * @link http://php.net/manual/en/function.reset.php
- * @param array|ArrayObject $array <p>
+ * @param array|object $array <p>
  * The input array.
  * </p>
  * @return mixed the value of the first array element, or false if the array is
@@ -757,7 +757,7 @@ function reset (array &$array) {}
 /**
  * Return the current element in an array
  * @link http://php.net/manual/en/function.current.php
- * @param array|ArrayObject $array <p>
+ * @param array|object $array <p>
  * The array.
  * </p>
  * @return mixed The current function simply returns the
@@ -773,7 +773,7 @@ function current (array $array) {}
 /**
  * Fetch a key from an array
  * @link http://php.net/manual/en/function.key.php
- * @param array|ArrayObject $array <p>
+ * @param array|object $array <p>
  * The array.
  * </p>
  * @return int|string|null The key function simply returns the


### PR DESCRIPTION
For https://youtrack.jetbrains.com/issue/WI-22258

The array iterator functions end, prev, next, reset, current, and key are all written to accept an array or an object instance

```
/* {{{ proto mixed current(array array_arg)
   Return the element currently pointed to by the internal array pointer */
PHP_FUNCTION(current)
{
	HashTable *array;
	zval *entry;

#ifndef FAST_ZPP
	if (zend_parse_parameters(ZEND_NUM_ARGS(), "H", &array) == FAILURE) {
		return;
	}
#else
	ZEND_PARSE_PARAMETERS_START(1, 1)
		Z_PARAM_ARRAY_OR_OBJECT_HT(array)
	ZEND_PARSE_PARAMETERS_END();
#endif
```

From http://php.net/manual/en/internals2.funcs.php
```
H | array or object | HashTable*
```

Even though the {{{ proto and http://php.net/manual/en/function.current.php claim it only takes an array.