### PR TITLE
Case mismatch in two XMLReader methods

### DIFF
--- a/xmlreader/xmlreader.php
+++ b/xmlreader/xmlreader.php
@@ -298,7 +298,7 @@ class XMLReader  {
 	 * @return string the contents of the current node as a string. Empty string on failure.
 	 * @since 5.2.0
 	 */
-	public function readInnerXml () {}
+	public function readInnerXML () {}
 
 	/**
 	 * Retrieve XML from current node, including it self
@@ -306,7 +306,7 @@ class XMLReader  {
 	 * @return string the contents of current node, including itself, as a string. Empty string on failure.
 	 * @since 5.2.0
 	 */
-	public function readOuterXml () {}
+	public function readOuterXML () {}
 
 	/**
 	 * Reads the contents of the current node as a string


### PR DESCRIPTION
The php.net site (as referred to in the annotations) uses readInnerXML and readOuterXML.
http://php.net/manual/en/xmlreader.readinnerxml.php
http://php.net/manual/en/xmlreader.readouterxml.php

I noticed this when running phpstan.