### PR TITLE
Fix ReflectionClass::setStaticPropertyValue signature

### DIFF
--- a/Reflection/Reflection.php
+++ b/Reflection/Reflection.php
@@ -1292,7 +1292,7 @@ class ReflectionClass implements Reflector {
 	 * @param string $name <p>
 	 * Property name.
 	 * </p>
-	 * @param string $value <p>
+	 * @param mixed $value <p>
 	 * New property value.
 	 * </p>
 	 * @return void No value is returned.


### PR DESCRIPTION
[PHP documentation][1] also gets it wrong, as suggested by the [engine source][2]
    
[1]: http://php.net/manual/en/reflectionclass.setstaticpropertyvalue.php
[2]: https://github.com/php/php-src/blob/12c386f5b90387ce373e16cdf74fd4d3155d5aa7/ext/reflection/php_reflection.c#L3904

Resolves https://youtrack.jetbrains.com/issue/WI-39719