### PR TITLE
Added a missing @return type for SolrUtils::queryPhrase()

### DIFF
--- a/solr/Utils/SolrUtils.php
+++ b/solr/Utils/SolrUtils.php
@@ -68,7 +68,7 @@ abstract class SolrUtils {
 	 * @param $str <p>
 	 * The lucene phrase.
 	 * </p>
-	 * @return <p>
+	 * @return string <p>
 	 * Returns the phrase contained in double quotes.
 	 * </p>
 	 */


### PR DESCRIPTION
The type has been added according to the documentation on: http://php.net/manual/en/solrutils.queryphrase.php

```
public static string SolrUtils::queryPhrase ( string $str )
```