### PR TITLE
Fixed ArgumentCountError DivisionByZeroError extends (WI-41073)

### DIFF
--- a/Core/Core_c.php
+++ b/Core/Core_c.php
@@ -495,7 +495,7 @@ class AssertionError extends Error {
  * @since 7.1
  * @see https://php.net/migration71.incompatible#migration71.incompatible.too-few-arguments-exception
  */
-class ArgumentCountError extends Error {}
+class ArgumentCountError extends TypeError {}
 
 /**
  * ArithmeticError is thrown when an error occurs while performing mathematical operations.
@@ -513,7 +513,7 @@ class ArithmeticError extends Error {
  * @link http://php.net/manual/en/class.divisionbyzeroerror.php
  * @since 7.0
  */
-class DivisionByZeroError extends Error {
+class DivisionByZeroError extends ArithmeticError {
 
 }
 


### PR DESCRIPTION
`ArgumentCountError`  should extends `TypeError`

`DivisionByZeroError` should extends `ArithmeticError`

Please see

* http://php.net/manual/en/class.argumentcounterror.php

* http://php.net/manual/en/class.divisionbyzeroerror.php

* https://3v4l.org/f8Boe#output

Issue

* https://youtrack.jetbrains.com/issue/WI-41073