### PR TITLE
Changing "<?" to "<?php" in apc/apc.php

### DIFF
--- a/apc/apc.php
+++ b/apc/apc.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 /**
  * Stubs for APC 3.1.4


### PR DESCRIPTION
The lack of "php" here causes some configurations to interpret the file as non-php.