### PR TITLE
Update return type of `newrelic_disable_autorum`

### DIFF
--- a/newrelic/newrelic.php
+++ b/newrelic/newrelic.php
@@ -102,7 +102,7 @@ function newrelic_custom_metric($metricName, $value) {}
  *
  * @link https://docs.newrelic.com/docs/agents/php-agent/configuration/php-agent-api#api-rum-disable
  *
- * @return true
+ * @return boolean
  */
 function newrelic_disable_autorum() {}
 


### PR DESCRIPTION
When using `function foo(): bool {return newrelic_disable_autorum();}`, PhpStorm report an error because true is not a boolean.