### PR TITLE
Make PHPDocs PHPDoc parser compatible

### DIFF
--- a/libsodium/libsodium.php
+++ b/libsodium/libsodium.php
@@ -385,7 +385,7 @@ namespace Sodium;
      * Update the hash state with some data
      * BLAKE2b
      * 
-     * @param &string $hashState
+     * @param string &$hashState
      * @param string $append
      * @return bool
      */
@@ -422,7 +422,7 @@ namespace Sodium;
      * @param string $salt
      * @param int $opslimit
      * @param int $memlimit
-     * @return $string
+     * @return string
      */
     function crypto_pwhash(
         int $out_len,
@@ -442,7 +442,7 @@ namespace Sodium;
      * @param string $passwd
      * @param int $opslimit
      * @param int $memlimit
-     * @return $string
+     * @return string
      */
     function crypto_pwhash_str(
         string $passwd,
@@ -478,7 +478,7 @@ namespace Sodium;
      * @param string $salt
      * @param int $opslimit
      * @param int $memlimit
-     * @return $string
+     * @return string
      */
     function crypto_pwhash_scryptsalsa208sha256(
         int $out_len,
@@ -498,7 +498,7 @@ namespace Sodium;
      * @param string $passwd
      * @param int $opslimit
      * @param int $memlimit
-     * @return $string
+     * @return string
      */
     function crypto_pwhash_scryptsalsa208sha256_str(
         string $passwd,
@@ -879,7 +879,7 @@ namespace Sodium;
     /**
      * Increment a string in little-endian
      * 
-     * @param &string $nonce
+     * @param string &$nonce
      * @return string
      */
     function increment(
@@ -891,7 +891,7 @@ namespace Sodium;
     /**
      * Add the right operand to the left
      * 
-     * @param &string $left
+     * @param string &$left
      * @param string $right
      */
     function add(
@@ -935,7 +935,7 @@ namespace Sodium;
     /**
      * Wipe a buffer
      * 
-     * @param &string $nonce
+     * @param string &$nonce
      */
     function memzero(
         string &$target

--- a/sodium/sodium.php
+++ b/sodium/sodium.php
@@ -436,7 +436,7 @@ function sodium_crypto_generichash_init(
  * Update the hash state with some data
  * BLAKE2b
  *
- * @param &string $state
+ * @param string &$state
  * @param string $append
  * @return bool
  */
@@ -473,7 +473,7 @@ function sodium_crypto_generichash_final(
  * @param string $salt
  * @param int $opslimit
  * @param int $memlimit
- * @return $string
+ * @return string
  */
 function sodium_crypto_pwhash(
     int $out_len,
@@ -493,7 +493,7 @@ function sodium_crypto_pwhash(
  * @param string $passwd
  * @param int $opslimit
  * @param int $memlimit
- * @return $string
+ * @return string
  */
 function sodium_crypto_pwhash_str(
     string $passwd,
@@ -529,7 +529,7 @@ function sodium_crypto_pwhash_str_verify(
  * @param string $salt
  * @param int $opslimit
  * @param int $memlimit
- * @return $string
+ * @return string
  */
 function sodium_crypto_pwhash_scryptsalsa208sha256(
     int $out_len,
@@ -549,7 +549,7 @@ function sodium_crypto_pwhash_scryptsalsa208sha256(
  * @param string $passwd
  * @param int $opslimit
  * @param int $memlimit
- * @return $string
+ * @return string
  */
 function sodium_crypto_pwhash_scryptsalsa208sha256_str(
     string $passwd,
@@ -930,7 +930,7 @@ function sodium_hex2bin(
 /**
  * Increment a string in little-endian
  *
- * @param &string $nonce
+ * @param string &$nonce
  * @return string
  */
 function sodium_increment(
@@ -942,7 +942,7 @@ function sodium_increment(
 /**
  * Add the right operand to the left
  *
- * @param &string $left
+ * @param string &$left
  * @param string $right
  */
 function sodium_add(
@@ -986,7 +986,7 @@ function sodium_memcmp(
 /**
  * Wipe a buffer
  *
- * @param &string $nonce
+ * @param string &$nonce
  */
 function sodium_memzero(
     string &$target

--- a/standard/_standard_manual.php
+++ b/standard/_standard_manual.php
@@ -35,7 +35,8 @@ define("__COMPILER_HALT_OFFSET__",0);
  * @link http://php.net/manual/en/function.hex2bin.php
  * @param string $data Hexadecimal string to convert.
  * @return bool|string The binary representation of the given data or <b>FALSE</b> on failure.
- * @see bin2hex(), unpack()
+ * @see bin2hex()
+ * @see unpack()
  * @since 5.4.0
  */
 function hex2bin($data) {};


### PR DESCRIPTION
This change required to parse functions PHPDocs by phpdocumentor/reflection-docblock parser.