### PR TITLE
Fix return type of shell_exec which can be null

### DIFF
--- a/standard/standard_2.php
+++ b/standard/standard_2.php
@@ -760,7 +760,7 @@ function passthru ($command, &$return_var = null) {}
  * @param string $cmd <p>
  * The command that will be executed.
  * </p>
- * @return string The output from the executed command.
+ * @return string|null The output from the executed command or NULL if an error occurred or the command produces no output.
  * @since 4.0
  * @since 5.0
  */


### PR DESCRIPTION
According to the official PHP documentation and actual behaviour the return type of shell_exec can be null if an error occurred or the command did not produce any output.

* See http://php.net/manual/en/function.shell-exec.php