### PR TITLE
Fix OCI-Lob and OCI-Collection class names

### DIFF
--- a/oci8/oci8.php
+++ b/oci8/oci8.php
@@ -2,11 +2,14 @@
 
 // Start of oci8 v.2.0.7
 
+class_alias('__InternalOCILob', 'OCI-Lob');
+class_alias('__InternalOCICollection', 'OCI-Collection');
+
 /**
  * OCI8 LOB functionality for large binary (BLOB) and character (CLOB) objects.
  * @link http://php.net/manual/en/class.OCI-Lob.php
  */
-class OCI_Lob  {
+class __InternalOCILob {
 
 	/**
 	 * (PHP 5, PECL OCI8 &gt;= 1.1.0)<br/>
@@ -276,7 +279,7 @@ class OCI_Lob  {
  * OCI8 Collection functionality.
  * @link http://php.net/manual/en/class.OCI-Collection.php
  */
-class OCI_Collection  {
+class __InternalOCICollection {
 
 	/**
 	 * (PHP 5, PECL OCI8 &gt;= 1.1.0)<br/>


### PR DESCRIPTION
Attempt to fix incorrect names of OCI classes.
Correct names are `OCI-Lob` and `OCI-Collection`, not with underscores:
http://php.net/manual/en/class.OCI-Lob.php
http://php.net/manual/en/class.OCI-Collection.php
Since these names are not valid class names, I haven't found any better way than trick with class_alias().

Is it somehow possible to prevent `__Internal*` from appearing in autocomplete?

References:
https://github.com/doctrine/dbal/pull/3025#discussion_r198236056
https://github.com/phpstan/phpstan/issues/1123
https://github.com/phpstan/phpstan/commit/6149780143f59e82b048ec995f88a88eede7bd53 