### PR TITLE
Updated SoapClient::__call() $arguments type to array

### DIFF
--- a/soap/soap.php
+++ b/soap/soap.php
@@ -263,7 +263,7 @@ class SoapClient  {
 	 * Calls a SOAP function (deprecated)
 	 * @link http://php.net/manual/en/soapclient.call.php
 	 * @param string $function_name
-	 * @param string $arguments
+	 * @param array $arguments
 	 * @return mixed
 	 * @since 5.0.1
 	 */


### PR DESCRIPTION
See php.net: http://php.net/manual/en/soapclient.call.php