### PR TITLE
Updated return types for some of the ob_ functions

### DIFF
--- a/standard/standard_8.php
+++ b/standard/standard_8.php
@@ -268,7 +268,7 @@ function ob_end_clean () {}
 /**
  * Flush the output buffer, return it as a string and turn off output buffering
  * @link http://php.net/manual/en/function.ob-get-flush.php
- * @return string the output buffer or false if no buffering is active.
+ * @return string|false the output buffer or false if no buffering is active.
  * @since 4.3.0
  * @since 5.0
  */
@@ -277,7 +277,7 @@ function ob_get_flush () {}
 /**
  * Get current buffer contents and delete current output buffer
  * @link http://php.net/manual/en/function.ob-get-clean.php
- * @return string the contents of the output buffer and end output buffering.
+ * @return string|false the contents of the output buffer and end output buffering.
  * If output buffering isn't active then false is returned.
  * @since 4.3.0
  * @since 5.0
@@ -287,7 +287,7 @@ function ob_get_clean () {}
 /**
  * Return the length of the output buffer
  * @link http://php.net/manual/en/function.ob-get-length.php
- * @return int the length of the output buffer contents or false if no
+ * @return int|false the length of the output buffer contents or false if no
  * buffering is active.
  * @since 4.0.2
  * @since 5.0
@@ -374,7 +374,7 @@ function ob_get_status ($full_status = null) {}
 /**
  * Return the contents of the output buffer
  * @link http://php.net/manual/en/function.ob-get-contents.php
- * @return string This will return the contents of the output buffer or false, if output
+ * @return string|false This will return the contents of the output buffer or false, if output
  * buffering isn't active.
  * @since 4.0
  * @since 5.0


### PR DESCRIPTION
Some of the inspection plugins (e.g. EA Extended) will emit a warning if the type casting is not necessary, which will generate false warning in cases for the signatures updated here, like this one:

<img width="434" alt="screen shot 2018-07-12 at 3 47 30 pm" src="https://user-images.githubusercontent.com/1126226/42638097-16a533b8-85ed-11e8-9170-84895c815517.png">

Function descriptions already contain "... or false if ...", just the type itself does not include it.

~Also, `false` is a valid return type to use, but I've noticed that just `bool` is used in other similar cases, hence `string|bool` here, too. I'd prefer `string|false` though, because `true` will never be returned.~

Edit: amended the commit to use `string|false`.

