### PR TITLE
Updated return type for glob()

### DIFF
--- a/standard/standard_7.php
+++ b/standard/standard_7.php
@@ -403,7 +403,7 @@ function scandir ($directory, $sorting_order = null, $context = null) {}
  * GLOB_BRACE - Expands {a,b,c} to match 'a', 'b', or 'c'
  * GLOB_ONLYDIR - Return only directory entries which match the pattern
  * GLOB_ERR - Stop on read errors (like unreadable directories), by default errors are ignored.
- * @return array an array containing the matched files/directories, an empty array
+ * @return array|false an array containing the matched files/directories, an empty array
  * if no file matched or false on error.
  * </p>
  * <p>


### PR DESCRIPTION
`glob()` returns `false` on error ([docs](http://php.net/glob))

Using `array|false` (instead of `array|bool`) according to the discussion at #385 

Edit: opened a new PR since #385 got approved, and I didn't want to "disturb" it. I can update that one instead, if needed.