### PR TITLE
Fix return type and description of stream_copy_to_stream

### DIFF
--- a/standard/standard_6.php
+++ b/standard/standard_6.php
@@ -573,7 +573,7 @@ function stream_socket_pair ($domain, $type, $protocol) {}
  * @param int $offset [optional] <p>
  * The offset where to start to copy data
  * </p>
- * @return int the total count of bytes copied.
+ * @return int|bool the total count of bytes copied, or false on failure.
  * @since 5.0
  */
 function stream_copy_to_stream ($source, $dest, $maxlength = null, $offset = null) {}

--- a/standard/standard_6.php
+++ b/standard/standard_6.php
@@ -573,7 +573,7 @@ function stream_socket_pair ($domain, $type, $protocol) {}
  * @param int $offset [optional] <p>
  * The offset where to start to copy data
  * </p>
- * @return int|bool the total count of bytes copied, or false on failure.
+ * @return int|false the total count of bytes copied, or false on failure.
  * @since 5.0
  */
 function stream_copy_to_stream ($source, $dest, $maxlength = null, $offset = null) {}


### PR DESCRIPTION
* Official documentation says it can return int or false on failure
* See http://php.net/manual/en/function.stream-copy-to-stream.php