### PR TITLE
Improve \RedisArray typehinting

### DIFF
--- a/redis/Redis.php
+++ b/redis/Redis.php
@@ -3282,6 +3282,9 @@ class Redis
 
 class RedisException extends Exception {}
 
+/**
+ * @mixin \Redis
+ */
 class RedisArray {
     /**
      * Constructor


### PR DESCRIPTION
It can be used as usual \Redis instance: https://github.com/phpredis/phpredis/blob/master/arrays.markdown#usage