### PR TITLE
Update nl2br function

### DIFF
--- a/standard/standard_1.php
+++ b/standard/standard_1.php
@@ -191,7 +191,7 @@ function hebrevc ($hebrew_text, $max_chars_per_line = null) {}
  * @since 4.0
  * @since 5.0
  */
-function nl2br ($string, $is_xhtml = null) {}
+function nl2br ($string, $is_xhtml = true) {}
 
 /**
  * Returns filename component of path


### PR DESCRIPTION
The second param `$is_xhtml` default value is `true` not `null`

[Source PHP Docs](https://secure.php.net/manual/en/function.nl2br.php)