### PR TITLE
Fixes the "com_dotnet" extension name

### DIFF
--- a/com_dotnet/com_dotnet.php
+++ b/com_dotnet/com_dotnet.php
@@ -1,6 +1,6 @@
 <?php
 
-// Start of com v.
+// Start of com_dotnet v.
 
 /**
  * The COM class allows you to instantiate an OLE compatible COM object and call its methods and access its properties.


### PR DESCRIPTION
When using e.g. `\COM`, an inspection warns about `ext-com` missing from `composer.json`.

![grafik](https://user-images.githubusercontent.com/495429/46529789-0ccac680-c898-11e8-83ef-e2a0a71ac7c4.png)

However, `composer require ext-com` fails:

![grafik](https://user-images.githubusercontent.com/495429/46529886-50bdcb80-c898-11e8-950d-c79930bee474.png)

This is because the library is actually called `com_dotnet`, not `com`:

![grafik](https://user-images.githubusercontent.com/495429/46529932-79de5c00-c898-11e8-93da-cc5ac490f83b.png)

(Source: https://secure.php.net/manual/de/com.installation.php)