### PR TITLE
Fix return type in iconv()

### DIFF
--- a/iconv/iconv.php
+++ b/iconv/iconv.php
@@ -24,7 +24,7 @@
  * @param string $str <p>
  * The string to be converted.
  * </p>
- * @return string the converted string or <b>FALSE</b> on failure.
+ * @return string|false the converted string or <b>FALSE</b> on failure.
  * @since 4.0.5
  * @since 5.0
  */


### PR DESCRIPTION
The return type of `iconv()` is either `string` or `false`. Actually, the description is correct, just the declared return type is wrong.