### PR TITLE
Fix return type of file_get_contents()

### DIFF
--- a/standard/standard_5.php
+++ b/standard/standard_5.php
@@ -1040,7 +1040,7 @@ function file ($filename, $flags = null, $context = null) {}
  * Maximum length of data read. The default is to read until end
  * of file is reached.
  * </p>
- * @return string|bool The function returns the read data or false on failure.
+ * @return string|false The function returns the read data or false on failure.
  * @since 4.3.0
  * @since 5.0
  */


### PR DESCRIPTION
`file_get_contents()` can never return `true`. Thus the correct return type is the more specific `string|false` instead of `string|bool`.