### PR TITLE
Specify return type of curl_exec() further

### DIFF
--- a/curl/curl.php
+++ b/curl/curl.php
@@ -2260,7 +2260,7 @@ function  curl_unescape ($ch, $str)  {}
  * Perform a cURL session
  * @link https://php.net/manual/en/function.curl-exec.php
  * @param resource $ch 
- * @return mixed true on success or false on failure. However, if the CURLOPT_RETURNTRANSFER
+ * @return string|bool true on success or false on failure. However, if the CURLOPT_RETURNTRANSFER
  * option is set, it will return the result on success, false on failure.
  * @since 4.0.2
  * @since 5.0


### PR DESCRIPTION
The return type of `curl_exec()` right now is `mixed`, which is very unspecific, as it could be anything - an array, an object, a string, a float, just anything. But in fact, `curl_exec()` can only return `string|bool` (depending on the passed setting `CURLOPT_RETURNTRANSFER`), but never things like an array or an object.