### PR TITLE
Fix return type from DateTimeImmutable::createFromFormat()

### DIFF
--- a/date/date_c.php
+++ b/date/date_c.php
@@ -126,7 +126,7 @@ class DateTimeImmutable implements DateTimeInterface {
      * @param string $format
      * @param string $time
      * @param DateTimeZone $timezone [optional]
-     * @return DateTimeImmutable|boolean
+     * @return DateTimeImmutable|false
      */
     public static function createFromFormat($format, $time, DateTimeZone $timezone = null) { }
 


### PR DESCRIPTION
The correct return type is `DateTimeImmutable|false`, not `DateTimeImmutable|boolean`. It can never return `true`, see docs.