### PR TITLE
Fix return type for PDO::query()

### DIFF
--- a/PDO/PDO.php
+++ b/PDO/PDO.php
@@ -958,7 +958,7 @@ class PDO  {
 	 * Arguments of custom class constructor when the <i>mode</i>
 	 * parameter is set to <b>PDO::FETCH_CLASS</b>.
 	 * </p>
-	 * @return PDOStatement|bool <b>PDO::query</b> returns a PDOStatement object, or <b>FALSE</b>
+	 * @return PDOStatement|false <b>PDO::query</b> returns a PDOStatement object, or <b>FALSE</b>
 	 * on failure.
 	 * @see PDOStatement::setFetchMode For a full description of the second and following parameters.
 	 */


### PR DESCRIPTION
Correct return type here is `PDOStatement|false`. Can never return `true`.