### PR TITLE
DateTimeZone getOffset method accepts DateTimeInterface instead of DateTime

### DIFF
--- a/date/date_c.php
+++ b/date/date_c.php
@@ -529,11 +529,11 @@ class DateTimeZone {
 
     /**
      * Returns the timezone offset from GMT
-     * @param DateTime $datetime
+     * @param DateTimeInterface $datetime
      * @return int
      * @link https://php.net/manual/en/datetimezone.getoffset.php
      */
-    public function getOffset (DateTime $datetime) {}
+    public function getOffset (DateTimeInterface $datetime) {}
 
     /**
      * Returns all transitions for the timezone


### PR DESCRIPTION
As of now, the PHP documentation still says it is a DateTime, but testing confirms both DateTime and DateTimeImmutable work.