### PR TITLE
Fix return type in curl_init()

### DIFF
--- a/curl/curl.php
+++ b/curl/curl.php
@@ -77,7 +77,7 @@ class CURLFile {
  * to its value. You can manually set this using the 
  * curl_setopt function.
  * </p>
- * @return resource a cURL handle on success, false on errors.
+ * @return resource|false a cURL handle on success, false on errors.
  * @since 4.0.2
  * @since 5.0
  */


### PR DESCRIPTION
The return type of `curl_init()` is either `resource` or `false`. Actually, the description is correct, just the declared return type is wrong.