### PR TITLE
[WI-44284] Add PASSWORD_ARGON2ID constant (PHP 7.3)

### DIFF
--- a/password/password.php
+++ b/password/password.php
@@ -79,7 +79,7 @@ define("PASSWORD_BCRYPT", 1);
 
 /**
  *
- * PASSWORD_ARGON2I is used to create new password hashes using the Argon2 algorithm.
+ * PASSWORD_ARGON2I is used to create new password hashes using the Argon2i algorithm.
  *
  * Supported Options:
  * <ul>
@@ -93,6 +93,23 @@ define("PASSWORD_BCRYPT", 1);
  * @since 7.2
  */
 define('PASSWORD_ARGON2I', 2);
+
+/**
+ *
+ * PASSWORD_ARGON2ID is used to create new password hashes using the Argon2id algorithm.
+ *
+ * Supported Options:
+ * <ul>
+ * <li>memory_cost (integer) - Maximum memory (in bytes) that may be used to compute the Argon2 hash. Defaults to PASSWORD_ARGON2_DEFAULT_MEMORY_COST.</li>
+ *
+ * <li>time_cost (integer) - Maximum amount of time it may take to compute the Argon2 hash. Defaults to PASSWORD_ARGON2_DEFAULT_TIME_COST.</li>
+ *
+ * <li>threads (integer) - Number of threads to use for computing the Argon2 hash. Defaults to PASSWORD_ARGON2_DEFAULT_THREADS.</li>
+ * </ul>
+ * Available as of PHP 7.3.0.
+ * @since 7.3
+ */
+define('PASSWORD_ARGON2ID', 3);
 
 /**
  * Default amount of memory in bytes that Argon2lib will use while trying to compute a hash.


### PR DESCRIPTION
See https://wiki.php.net/rfc/argon2_password_hash_enhancements

Ref https://youtrack.jetbrains.com/issue/WI-44284