### PR TITLE
Fix missing return type of fpm_get_status() function

### DIFF
--- a/fpm/fpm.php
+++ b/fpm/fpm.php
@@ -2,5 +2,6 @@
 /**
  * Returns FPM status info array
  * @since 7.3.0
+ * @return array
  */
-function fpm_get_status() { }
+function fpm_get_status() : array { }


### PR DESCRIPTION
This function is not officially documented, yet. But it definitely returns an array. :)

See: https://github.com/php/php-src/pull/3182