### PR TITLE
Add missing @throws in ReflectionClass::getProperty()

### DIFF
--- a/Reflection/Reflection.php
+++ b/Reflection/Reflection.php
@@ -1045,6 +1045,7 @@ class ReflectionClass implements Reflector {
 	 * The property name.
 	 * </p>
 	 * @return ReflectionProperty A <b>ReflectionProperty</b>.
+	 * @throws ReflectionException If no property exists by that name.
 	 * @since 5.0
 	 */
 	public function getProperty ($name) {}


### PR DESCRIPTION
Although not properly documented [on the php.net website](http://php.net/manual/en/reflectionclass.getproperty.php) (only in the comments section), `ReflectionClass::getProperty()` throws a `ReflectionException` when the property does not exist:

```php
class A {}

(new ReflectionClass('A'))->getProperty('B'); // ReflectionException: Property B does not exist
```

Demo [here](https://3v4l.org/JOobg).