### PR TITLE
PHP 7.3 stubs update

### DIFF
--- a/Core/Core.php
+++ b/Core/Core.php
@@ -1059,6 +1059,11 @@ function gc_enable () {}
 function gc_disable () {}
 
 /**
+ * @since 7.3
+ */
+function gc_status () {}
+
+/**
  * @param string $kind
  * @return int
  * @since 7.1

--- a/Core/Core_c.php
+++ b/Core/Core_c.php
@@ -475,7 +475,7 @@ class TypeError extends Error {
  * @link https://php.net/manual/en/class.parseerror.php
  * @since 7.0
  */
-class ParseError extends Error {
+class ParseError extends CompileError {
 
 }
 
@@ -505,6 +505,15 @@ class ArgumentCountError extends TypeError {}
  * @since 7.0
  */
 class ArithmeticError extends Error {
+
+}
+
+/**
+ * Class CompileError
+ * @link https://secure.php.net/manual/en/class.compileerror.php
+ * @since 7.3
+ */
+class CompileError extends Error {
 
 }
 

--- a/PDO/PDO.php
+++ b/PDO/PDO.php
@@ -71,6 +71,26 @@ class PDO  {
 	const SQLITE_DETERMINISTIC = 2048;
 
 	/**
+	 * @since 7.3
+	 */
+	const SQLITE_OPEN_READONLY = 1;
+
+	/**
+	 * @since 7.3
+	 */
+	const SQLITE_OPEN_READWRITE = 2;
+
+	/**
+	 * @since 7.3
+	 */
+	const SQLITE_OPEN_CREATE = 4;
+
+	/**
+	 * @since 7.3
+	 */
+	const SQLITE_ATTR_OPEN_FLAGS = 1000;
+
+	/**
 	 * Represents the SQL large object data type.
 	 * @link https://php.net/manual/en/pdo.constants.php#pdo.constants.param-lob
 	 */

--- a/SPL/SPL_c1.php
+++ b/SPL/SPL_c1.php
@@ -774,6 +774,7 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, SeekableIt
          * @return string a string containing the next line of the file with HTML and PHP
          * code stripped, or false on error.
          * @since 5.1.0
+         * @deprecated 7.3
          */
         public function fgetss ($allowable_tags = null) {}
 

--- a/curl/curl_d.php
+++ b/curl/curl_d.php
@@ -1221,3 +1221,204 @@ define("CURLOPT_CONNECT_TO",10243);
  * @since 7.0.7
  */
 define("CURLOPT_TCP_FASTOPEN",244);
+
+/**
+ * @since 7.3
+ */
+define('CURLE_WEIRD_SERVER_REPLY', 8);
+/**
+ * @since 7.3
+ */
+define('CURLOPT_KEEP_SENDING_ON_ERROR', 245);
+/**
+ * @since 7.3
+ */
+define('CURL_SSLVERSION_TLSv1_3', 7);
+
+/**
+ * @since 7.3
+ */
+define('CURL_VERSION_HTTPS_PROXY', 2097152);
+
+
+/**
+ * @since 7.3
+ */
+define('CURLINFO_PROTOCOL', 2097200);
+
+/**
+ * @since 7.3
+ */
+define('CURL_VERSION_ASYNCHDNS', 128);
+
+/**
+ * @since 7.3
+ */
+define('CURL_VERSION_CONV', 4096);
+
+/**
+ * @since 7.3
+ */
+define('CURL_VERSION_DEBUG', 64);
+
+/**
+ * @since 7.3
+ */
+define('CURL_VERSION_GSSNEGOTIATE', 32);
+
+/**
+ * @since 7.3
+ */
+define('CURL_VERSION_IDN', 1024);
+
+/**
+ * @since 7.3
+ */
+define('CURL_VERSION_LARGEFILE', 512);
+
+/**
+ * @since 7.3
+ */
+define('CURL_VERSION_NTLM', 16);
+
+/**
+ * @since 7.3
+ */
+define('CURL_VERSION_SPNEGO', 256);
+
+/**
+ * @since 7.3
+ */
+define('CURL_VERSION_SSPI', 2048);
+
+/**
+ * @since 7.3
+ */
+define('CURL_VERSION_TLSAUTH_SRP', 16384);
+
+/**
+ * @since 7.3
+ */
+define('CURL_VERSION_NTLM_WB', 32768);
+
+/**
+ * @since 7.3
+ */
+define('CURL_VERSION_GSSAPI', 131072);
+
+/**
+ * @since 7.3
+ */
+define('CURL_VERSION_KERBEROS5', 262144);
+
+/**
+ * @since 7.3
+ */
+define('CURLOPT_PROXY_CAINFO', 10246);
+
+/**
+ * @since 7.3
+ */
+define ('CURLOPT_PROXY_CAPATH', 10247);
+
+/**
+ * @since 7.3
+ */
+define('CURLOPT_PROXY_CRLFILE', 10260);
+
+/**
+ * @since 7.3
+ */
+define('CURLOPT_PROXY_KEYPASSWD', 10258);
+
+/**
+ * @since 7.3
+ */
+define('CURLOPT_PROXY_SSLCERTTYPE', 10255);
+
+/**
+ * @since 7.3
+ */
+define('CURLOPT_PROXY_SSLKEYTYPE', 10257);
+
+/**
+ * @since 7.3
+ */
+define('CURLOPT_PROXY_SSLVERSION', 250);
+
+/**
+ * @since 7.3
+ */
+define('CURLOPT_PROXY_TLSAUTH_USERNAME' ,10251);
+/**
+ * @since 7.3
+ */
+define('CURLOPT_PROXY_TLSAUTH_PASSWORD', 10252);
+
+/**
+ * @since 7.3
+ */
+define('CURLOPT_PROXY_TLSAUTH_TYPE', 10253);
+
+/**
+ * @since 7.3
+ */
+define('CURLPROXY_HTTPS', 2);
+
+/**
+ * @since 7.3
+ */
+define('CURLOPT_PROXY_PINNEDPUBLICKEY', 10263);
+
+/**
+ * @since 7.3
+ */
+define('CURLOPT_PROXY_SSLKEY', 10256);
+
+/**
+ * @since 7.3
+ */
+define('CURLOPT_PROXY_SSL_CIPHER_LIST', 10259);
+
+/**
+ * @since 7.3
+ */
+define('CURLOPT_PROXY_SSL_OPTIONS', 261);
+
+/**
+ * @since 7.3
+ */
+define('CURLOPT_PROXY_SSL_VERIFYHOST', 249);
+
+/**
+ * @since 7.3
+ */
+define('CURLOPT_PROXY_SSL_VERIFYPEER', 248);
+
+/**
+ * @since 7.3
+ */
+define('CURLOPT_PROXY_SSLCERT', 10254);
+
+/**
+ * @since 7.3
+ */
+define('CURLINFO_SCHEME', 1048625);
+
+/**
+ * @since 7.3
+ */
+define('CURL_VERSION_UNIX_SOCKETS', 524288);
+
+/**
+ * @since 7.3
+ */
+define('CURLINFO_HTTP_VERSION', 2097198);
+/**
+ * @since 7.3
+ */
+define('CURLOPT_PRE_PROXY', 10262);
+/**
+ * @since 7.3
+ */
+define('CURLINFO_PROXY_SSL_VERIFYRESULT', 2097199);

--- a/date/date_c.php
+++ b/date/date_c.php
@@ -373,6 +373,13 @@ class DateTime implements DateTimeInterface {
      */
     public function add (DateInterval $interval) {}
 
+
+    /**
+     * @since 7.3
+     * @return DateTime
+     */
+    public static function createFromImmutable(DateTimeImmutable $datetTimeImmutable) {}
+
     /**
      * Subtracts an amount of days, months, years, hours, minutes and seconds from a DateTime object
      * @param DateInterval $interval
@@ -757,7 +764,7 @@ class DatePeriod implements Traversable {
      */
     public function getStartDate () {}
 
-    public static function __set_state (){}
+    public static function __set_state ($array){}
 
     public function __wakeup() {}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   php:
-    image: php:7.2
+    image: php:7.3
     volumes:
      - .:/opt/project
     command: /opt/project/vendor/bin/phpunit /opt/project/tests/TestStubs.php

--- a/filter/filter.php
+++ b/filter/filter.php
@@ -314,6 +314,11 @@ define ('FILTER_VALIDATE_MAC', 276);
 define ('FILTER_DEFAULT', 516);
 
 /**
+ * @since 7.3
+ */
+define('FILTER_SANITIZE_ADD_SLASHES', 523);
+
+/**
  * ID of "unsafe_raw" filter.
  * @link https://php.net/manual/en/filter.constants.php
  */

--- a/mbstring/mbstring.php
+++ b/mbstring/mbstring.php
@@ -1212,6 +1212,7 @@ function mb_ereg_search_getregs () {}
  * @return int 
  * @since 4.2.0
  * @since 5.0
+ * @deprecated 7.3
  */
 function mb_ereg_search_getpos () {}
 
@@ -1229,6 +1230,7 @@ function mb_ereg_search_setpos ($position) {}
 
 /**
  * @param $encoding [optional]
+ * @deprecated 7.3 use {@see mb_regex_encoding} instead
  */
 function mbregex_encoding ($encoding) {}
 
@@ -1236,6 +1238,7 @@ function mbregex_encoding ($encoding) {}
  * @param $pattern
  * @param $string
  * @param $registers [optional]
+ * @deprecated 7.3 use {@see mb_ereg} instead
  */
 function mbereg ($pattern, $string, &$registers) {}
 
@@ -1243,6 +1246,7 @@ function mbereg ($pattern, $string, &$registers) {}
  * @param $pattern
  * @param $string
  * @param $registers [optional]
+ * @deprecated 7.3 use {@see mb_eregi} instead
  */
 function mberegi ($pattern, $string, &$registers) {}
 
@@ -1251,6 +1255,7 @@ function mberegi ($pattern, $string, &$registers) {}
  * @param $replacement
  * @param $string
  * @param $option [optional]
+ * @deprecated 7.3 use {@see mb_ereg_replace} instead
  */
 function mbereg_replace ($pattern, $replacement, $string, $option) {}
 
@@ -1260,6 +1265,7 @@ function mbereg_replace ($pattern, $replacement, $string, $option) {}
  * @param $string
  * @param string $option
  * @return string
+ * @deprecated 7.3 use {@see mb_eregi_replace} instead
  */
 function mberegi_replace ($pattern, $replacement, $string, string $option = "msri") {}
 
@@ -1267,6 +1273,7 @@ function mberegi_replace ($pattern, $replacement, $string, string $option = "msr
  * @param $pattern
  * @param $string
  * @param $limit [optional]
+ * @deprecated 7.3 use {@see mb_split} instead
  */
 function mbsplit ($pattern, $string, $limit) {}
 
@@ -1274,24 +1281,28 @@ function mbsplit ($pattern, $string, $limit) {}
  * @param $pattern
  * @param $string
  * @param $option [optional]
+ * @deprecated 7.3 use {@see mb_ereg_match} instead
  */
 function mbereg_match ($pattern, $string, $option) {}
 
 /**
  * @param $pattern [optional]
  * @param $option [optional]
+ * @deprecated 7.3 use {@see mb_ereg_search} instead
  */
 function mbereg_search ($pattern, $option) {}
 
 /**
  * @param $pattern [optional]
  * @param $option [optional]
+ * @deprecated 7.3 use {@see mb_ereg_search_pos} instead
  */
 function mbereg_search_pos ($pattern, $option) {}
 
 /**
  * @param $pattern [optional]
  * @param $option [optional]
+ * @deprecated 7.3 use {@see mb_ereg_search_regs} instead
  */
 function mbereg_search_regs ($pattern, $option) {}
 
@@ -1299,11 +1310,18 @@ function mbereg_search_regs ($pattern, $option) {}
  * @param $string
  * @param $pattern [optional]
  * @param $option [optional]
+ * @deprecated 7.3 use {@see mb_ereg_search_init} instead
  */
 function mbereg_search_init ($string, $pattern, $option) {}
 
+/**
+ * @deprecated 7.3 use {@see mb_ereg_search_getregs} instead
+ */
 function mbereg_search_getregs () {}
 
+/**
+ * @deprecated 7.3 use {@see mb_ereg_search_getpos} instead
+ */
 function mbereg_search_getpos () {}
 
 /**
@@ -1332,6 +1350,7 @@ function mb_scrub($str, $encoding) {}
 
 /**
  * @param $position
+ * @deprecated 7.3 use {@see mb_ereg_search_setpos} instead
  */
 function mbereg_search_setpos ($position) {}
 
@@ -1341,6 +1360,11 @@ define ('MB_OVERLOAD_REGEX', 4);
 define ('MB_CASE_UPPER', 0);
 define ('MB_CASE_LOWER', 1);
 define ('MB_CASE_TITLE', 2);
+define('MB_CASE_FOLD', 3);
+define('MB_CASE_UPPER_SIMPLE', 4);
+define('MB_CASE_LOWER_SIMPLE', 5);
+define('MB_CASE_TITLE_SIMPLE', 6);
+define('MB_CASE_FOLD_SIMPLE', 7);
 
 // End of mbstring v.
 ?>

--- a/openssl/openssl.php
+++ b/openssl/openssl.php
@@ -1025,6 +1025,14 @@ function openssl_get_cipher_methods($aliases = false) { }
 function openssl_dh_compute_key($pub_key, $dh_key) { }
 
 /**
+ * @param $peer_pub_key
+ * @param $priv_key
+ * @param $keylen
+ * @since 7.3
+ */
+function openssl_pkey_derive($peer_pub_key, $priv_key, $keylen) {}
+
+/**
  * Generates a string of pseudo-random bytes, with the number of bytes determined by the length parameter.
  * <p>It also indicates if a cryptographically strong algorithm was used to produce the pseudo-random bytes,
  * and does this via the optional crypto_strong parameter. It's rare for this to be FALSE, but some systems may be broken or old.
@@ -1234,3 +1242,8 @@ define("STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT", 17);
 define("STREAM_CRYPTO_METHOD_TLSv1_1_SERVER", 16);
 define("STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT", 33);
 define("STREAM_CRYPTO_METHOD_TLSv1_2_SERVER", 32);
+
+define("STREAM_CRYPTO_PROTO_SSLv3", 4);
+define("STREAM_CRYPTO_PROTO_TLSv1_0", 8);
+define("STREAM_CRYPTO_PROTO_TLSv1_1", 16);
+define("STREAM_CRYPTO_PROTO_TLSv1_2", 32);

--- a/pcre/pcre.php
+++ b/pcre/pcre.php
@@ -524,5 +524,19 @@ define ('PREG_UNMATCHED_AS_NULL', 512);
  */
 define ('PCRE_VERSION', "8.31 2012-07-06");
 
+/**
+ * @since 7.3
+ */
+define ('PCRE_VERSION_MAJOR', 10);
+
+/**
+ * @since 7.3
+ */
+define ('PCRE_VERSION_MINOR', 32);
+
+/**
+ * @since 7.3
+ */
+define('PCRE_JIT_SUPPORT', 1);
 // End of pcre v.
 ?>

--- a/standard/standard_4.php
+++ b/standard/standard_4.php
@@ -380,6 +380,16 @@ function show_source ($file_name, $return) {}
 function highlight_string ($str, $return = null) {}
 
 /**
+ * Get the system's high resolution time
+ * @link https://secure.php.net/manual/en/function.hrtime.php
+ * @param bool $get_as_number <p>Whether the high resolution time should be returned as array or number.<p>
+ * @since 7.3
+ * @return mixed Returns an array of integers in the form [seconds, nanoseconds], if the parameter get_as_number is false.
+ * Otherwise the nanoseconds are returned as integer (64bit platforms) or float (32bit platforms).
+ */
+function hrtime($get_as_number = FALSE) {}
+
+/**
  * Return source with stripped comments and whitespace
  * @link https://php.net/manual/en/function.php-strip-whitespace.php
  * @param string $filename <p>
@@ -823,6 +833,11 @@ function is_uploaded_file ($filename) {}
  * @since 5.0
  */
 function move_uploaded_file ($filename, $destination) {}
+
+/**
+ * @since 7.3
+ */
+function net_get_interfaces() {}
 
 /**
  * Get the Internet host name corresponding to a given IP address

--- a/standard/standard_5.php
+++ b/standard/standard_5.php
@@ -536,6 +536,7 @@ function fgets ($handle, $length = null) {}
  * If an error occurs, returns false.
  * @since 4.0
  * @since 5.0
+ * @deprecated 7.3
  */
 function fgetss ($handle, $length = null, $allowable_tags = null) {}
 

--- a/zlib/zlib.php
+++ b/zlib/zlib.php
@@ -108,6 +108,7 @@ function gzgets ($zp, $length) {}
  * @return string The uncompressed and striped string, or <b>FALSE</b> on error.
  * @since 4.0
  * @since 5.0
+ * @deprecated 7.3
  */
 function gzgetss ($zp, $length, $allowable_tags = null) {}
 


### PR DESCRIPTION
WI-42885 Update stubs for PHP 7.3 WI-44764 net_get_interfaces missing from phpstorm-stubs (PHP 7.3)