### PR TITLE
fix phpdoc

### DIFF
--- a/Reflection/Reflection.php
+++ b/Reflection/Reflection.php
@@ -2099,7 +2099,7 @@ class ReflectionClassConstant implements Reflector {
      * Checks if class constant is public
      * @since 7.1
      * @link https://php.net/manual/en/reflectionclassconstant.ispublic.php
-     * @param bool
+     * @return bool
      */
 	public function isPublic() {}
 


### PR DESCRIPTION
According to php.net
https://secure.php.net/manual/en/reflectionclassconstant.ispublic.php

The method isPublic do not take params and return a bool. Seems like a typo.