### PR TITLE
Correct session_gc signature

### DIFF
--- a/session/session.php
+++ b/session/session.php
@@ -190,7 +190,7 @@ function session_create_id($prefix) {}
 
 /**
  * Perform session data garbage collection
- * @return int number of deleted session data for success, FALSE for failure.
+ * @return int|false number of deleted session data for success, false for failure.
  * @since 7.1
  */
 function session_gc() {}


### PR DESCRIPTION
you see the cast to int seems unnecessary but that indication is false because the function returns false is no sessions were deleted

![screenshot from 2019-01-16 16-23-26](https://user-images.githubusercontent.com/391674/51258826-20172300-19ab-11e9-94b2-1c00440062f3.png)
