### PR TITLE
Correct naming and default value of mbstring $before_needle params

### DIFF
--- a/mbstring/mbstring.php
+++ b/mbstring/mbstring.php
@@ -9,9 +9,9 @@
  * The string being converted.
  * </p>
  * @param int $mode <p>
- * The mode of the conversion. It can be one of 
- * MB_CASE_UPPER, 
- * MB_CASE_LOWER, or 
+ * The mode of the conversion. It can be one of
+ * MB_CASE_UPPER,
+ * MB_CASE_LOWER, or
  * MB_CASE_TITLE.
  * </p>
  * @param string $encoding [optional] &mbstring.encoding.parameter;
@@ -58,14 +58,14 @@ function mb_strtolower ($str, $encoding = null) {}
  * (UTF-8). mb_send_mail uses this setting to
  * encode e-mail.
  * </p>
- * <p> 
+ * <p>
  * Language and its setting is ISO-2022-JP/Base64 for
  * Japanese, UTF-8/Base64 for uni, ISO-8859-1/quoted printable for
  * English.
  * </p>
  * @return bool|string If language is set and
  * language is valid, it returns
- * true. Otherwise, it returns false. 
+ * true. Otherwise, it returns false.
  * When language is omitted, it returns the language
  * name as a string. If no language is set previously, it then returns
  * false.
@@ -78,14 +78,14 @@ function mb_language ($language = null) {}
  * Set/Get internal character encoding
  * @link https://php.net/manual/en/function.mb-internal-encoding.php
  * @param string $encoding [optional] <p>
- * encoding is the character encoding name 
- * used for the HTTP input character encoding conversion, HTTP output 
- * character encoding conversion, and the default character encoding 
+ * encoding is the character encoding name
+ * used for the HTTP input character encoding conversion, HTTP output
+ * character encoding conversion, and the default character encoding
  * for string functions defined by the mbstring module.
  * </p>
  * @return bool|string If encoding is set, then
  * true on success or false on failure.
- * If encoding is omitted, then 
+ * If encoding is omitted, then
  * the current character encoding name is returned.
  * @since 4.0.6
  * @since 5.0
@@ -96,10 +96,10 @@ function mb_internal_encoding ($encoding = null) {}
  * Detect HTTP input character encoding
  * @link https://php.net/manual/en/function.mb-http-input.php
  * @param string $type [optional] <p>
- * Input string specifies the input type. 
+ * Input string specifies the input type.
  * "G" for GET, "P" for POST, "C" for COOKIE, "S" for string, "L" for list, and
- * "I" for the whole list (will return array). 
- * If type is omitted, it returns the last input type processed. 
+ * "I" for the whole list (will return array).
+ * If type is omitted, it returns the last input type processed.
  * </p>
  * @return false|string The character encoding name, as per the type.
  * If mb_http_input does not process specified
@@ -124,7 +124,7 @@ function mb_http_input ($type = null) {}
  * </p>
  * @return bool|string If encoding is omitted,
  * mb_http_output returns the current HTTP output
- * character encoding. Otherwise, 
+ * character encoding. Otherwise,
  * true on success or false on failure.
  * @since 4.0.6
  * @since 5.0
@@ -135,7 +135,7 @@ function mb_http_output ($encoding = null) {}
  * Set/Get character encoding detection order
  * @link https://php.net/manual/en/function.mb-detect-order.php
  * @param mixed $encoding_list [optional] <p>
- * encoding_list is an array or 
+ * encoding_list is an array or
  * comma separated list of character encoding. ("auto" is expanded to
  * "ASCII, JIS, UTF-8, EUC-JP, SJIS")
  * </p>
@@ -156,7 +156,7 @@ function mb_http_output ($encoding = null) {}
  * ASCII,
  * EUC-JP,SJIS,
  * eucJP-win, SJIS-win,
- * JIS, ISO-2022-JP 
+ * JIS, ISO-2022-JP
  * <p>
  * For ISO-8859-*, mbstring
  * always detects as ISO-8859-*.
@@ -361,9 +361,9 @@ function mb_strripos ($haystack, $needle, $offset = 0, $encoding = null) {}
  * @param string $needle <p>
  * The string to find in haystack
  * </p>
- * @param bool $part [optional] <p>
+ * @param bool $before_needle [optional] <p>
  * Determines which portion of haystack
- * this function returns. 
+ * this function returns.
  * If set to true, it returns all of haystack
  * from the beginning to the first occurrence of needle.
  * If set to false, it returns all of haystack
@@ -377,7 +377,7 @@ function mb_strripos ($haystack, $needle, $offset = 0, $encoding = null) {}
  * or false if needle is not found.
  * @since 5.2.0
  */
-function mb_strstr ($haystack, $needle, $part = null, $encoding = null) {}
+function mb_strstr ($haystack, $needle, $before_needle = false, $encoding = null) {}
 
 /**
  * Finds the last occurrence of a character in a string within another
@@ -389,9 +389,9 @@ function mb_strstr ($haystack, $needle, $part = null, $encoding = null) {}
  * @param string $needle <p>
  * The string to find in haystack
  * </p>
- * @param bool $part [optional] <p>
+ * @param bool $before_needle [optional] <p>
  * Determines which portion of haystack
- * this function returns. 
+ * this function returns.
  * If set to true, it returns all of haystack
  * from the beginning to the last occurrence of needle.
  * If set to false, it returns all of haystack
@@ -405,7 +405,7 @@ function mb_strstr ($haystack, $needle, $part = null, $encoding = null) {}
  * or false if needle is not found.
  * @since 5.2.0
  */
-function mb_strrchr ($haystack, $needle, $part = null, $encoding = null) {}
+function mb_strrchr ($haystack, $needle, $before_needle = false, $encoding = null) {}
 
 /**
  * Finds first occurrence of a string within another, case insensitive
@@ -417,9 +417,9 @@ function mb_strrchr ($haystack, $needle, $part = null, $encoding = null) {}
  * @param string $needle <p>
  * The string to find in haystack
  * </p>
- * @param bool $part [optional] <p>
+ * @param bool $before_needle [optional] <p>
  * Determines which portion of haystack
- * this function returns. 
+ * this function returns.
  * If set to true, it returns all of haystack
  * from the beginning to the first occurrence of needle.
  * If set to false, it returns all of haystack
@@ -433,7 +433,7 @@ function mb_strrchr ($haystack, $needle, $part = null, $encoding = null) {}
  * or false if needle is not found.
  * @since 5.2.0
  */
-function mb_stristr ($haystack, $needle, $part = null, $encoding = null) {}
+function mb_stristr ($haystack, $needle, $before_needle = false, $encoding = null) {}
 
 /**
  * Finds the last occurrence of a character in a string within another, case insensitive
@@ -445,9 +445,9 @@ function mb_stristr ($haystack, $needle, $part = null, $encoding = null) {}
  * @param string $needle <p>
  * The string to find in haystack
  * </p>
- * @param bool $part [optional] <p>
+ * @param bool $before_needle [optional] <p>
  * Determines which portion of haystack
- * this function returns. 
+ * this function returns.
  * If set to true, it returns all of haystack
  * from the beginning to the last occurrence of needle.
  * If set to false, it returns all of haystack
@@ -461,7 +461,7 @@ function mb_stristr ($haystack, $needle, $part = null, $encoding = null) {}
  * or false if needle is not found.
  * @since 5.2.0
  */
-function mb_strrichr ($haystack, $needle, $part = null, $encoding = null) {}
+function mb_strrichr ($haystack, $needle, $before_needle = false, $encoding = null) {}
 
 /**
  * Count the number of substring occurrences
@@ -552,7 +552,7 @@ function mb_strwidth ($str, $encoding = null) {}
  * The width of the desired trim.
  * </p>
  * @param string $trimmarker [optional] <p>
- * A string that is added to the end of string 
+ * A string that is added to the end of string
  * when string is truncated.
  * </p>
  * @param string $encoding [optional] &mbstring.encoding.parameter;
@@ -575,11 +575,11 @@ function mb_strimwidth ($str, $start, $width, $trimmarker = null, $encoding = nu
  * @param string|string[] $from_encoding [optional] <p>
  * Is specified by character code names before conversion. It is either
  * an array, or a comma separated enumerated list.
- * If from_encoding is not specified, the internal 
+ * If from_encoding is not specified, the internal
  * encoding will be used.
  * </p>
  * <p>
- * "auto" may be used, which expands to 
+ * "auto" may be used, which expands to
  * "ASCII,JIS,UTF-8,EUC-JP,SJIS".
  * </p>
  * @return string The encoded string.
@@ -807,7 +807,7 @@ function mb_decode_mimeheader ($str) {}
  * @param string|string[] $from_encoding <p>
  * from_encoding is specified as an array
  * or comma separated string, it tries to detect encoding from
- * from-coding. When from_encoding 
+ * from-coding. When from_encoding
  * is omitted, detect_order is used.
  * </p>
  * @param string|array|object $vars <p>
@@ -864,7 +864,7 @@ function mb_decode_numericentity ($str, array $convmap, $encoding = null) {}
  * @param string $to <p>
  * The mail addresses being sent to. Multiple
  * recipients may be specified by putting a comma between each
- * address in to. 
+ * address in to.
  * This parameter is not automatically encoded.
  * </p>
  * @param string $subject <p>
@@ -897,7 +897,7 @@ function mb_send_mail ($to, $subject, $message, $additional_headers = null, $add
  * If type isn't specified or is specified to
  * "all", an array having the elements "internal_encoding",
  * "http_output", "http_input", "func_overload", "mail_charset",
- * "mail_header_encoding", "mail_body_encoding" will be returned. 
+ * "mail_header_encoding", "mail_body_encoding" will be returned.
  * </p>
  * <p>
  * If type is specified as "http_output",
@@ -946,7 +946,7 @@ function mb_regex_encoding ($encoding = null) {}
  * @param string $options [optional] <p>
  * The options to set.
  * </p>
- * @return string The previous options. If options is omitted, 
+ * @return string The previous options. If options is omitted,
  * it returns the string that describes the current options.
  * @since 4.3.0
  * @since 5.0
@@ -965,7 +965,7 @@ function mb_regex_set_options ($options = null) {}
  * @param string[] $regs [optional] <p>
  * Contains a substring of the matched string.
  * </p>
- * @return int 
+ * @return int
  * @since 4.2.0
  * @since 5.0
  */
@@ -983,7 +983,7 @@ function mb_ereg ($pattern, $string, array $regs = null) {}
  * @param string[] $regs [optional] <p>
  * Contains a substring of the matched string.
  * </p>
- * @return int 
+ * @return int
  * @since 4.2.0
  * @since 5.0
  */
@@ -1010,7 +1010,7 @@ function mb_eregi ($pattern, $string, array $regs = null) {}
  * specified, white space will be ignored. If m
  * is specified, match will be executed in multiline mode and line
  * break will be included in '.'. If p is
- * specified, match will be executed in POSIX mode, line break 
+ * specified, match will be executed in POSIX mode, line break
  * will be considered as normal character. If e
  * is specified, replacement string will be
  * evaluated as PHP expression.
@@ -1096,7 +1096,7 @@ function mb_eregi_replace ($pattern, $replace, $string, $option = "msr") {}
  * @param string $string <p>
  * The string being split.
  * </p>
- * @param int $limit [optional] If optional parameter limit is specified, 
+ * @param int $limit [optional] If optional parameter limit is specified,
  * it will be split in limit elements as
  * maximum.
  * @return string[] The result as an array.
@@ -1116,7 +1116,7 @@ function mb_split ($pattern, $string, $limit = null) {}
  * </p>
  * @param string $option [optional] <p>
  * </p>
- * @return bool 
+ * @return bool
  * @since 4.2.0
  * @since 5.0
  */
@@ -1131,7 +1131,7 @@ function mb_ereg_match ($pattern, $string, $option = null) {}
  * @param string $option [optional] <p>
  * The search option.
  * </p>
- * @return bool 
+ * @return bool
  * @since 4.2.0
  * @since 5.0
  */
@@ -1186,7 +1186,7 @@ function mb_ereg_search_regs ($pattern = null, $option = null) {}
  * @param string $option [optional] <p>
  * The search option.
  * </p>
- * @return bool 
+ * @return bool
  * @since 4.2.0
  * @since 5.0
  */
@@ -1209,7 +1209,7 @@ function mb_ereg_search_getregs () {}
 /**
  * Returns start point for next regular expression match
  * @link https://php.net/manual/en/function.mb-ereg-search-getpos.php
- * @return int 
+ * @return int
  * @since 4.2.0
  * @since 5.0
  * @deprecated 7.3

--- a/mbstring/mbstring.php
+++ b/mbstring/mbstring.php
@@ -9,9 +9,9 @@
  * The string being converted.
  * </p>
  * @param int $mode <p>
- * The mode of the conversion. It can be one of
- * MB_CASE_UPPER,
- * MB_CASE_LOWER, or
+ * The mode of the conversion. It can be one of 
+ * MB_CASE_UPPER, 
+ * MB_CASE_LOWER, or 
  * MB_CASE_TITLE.
  * </p>
  * @param string $encoding [optional] &mbstring.encoding.parameter;
@@ -58,14 +58,14 @@ function mb_strtolower ($str, $encoding = null) {}
  * (UTF-8). mb_send_mail uses this setting to
  * encode e-mail.
  * </p>
- * <p>
+ * <p> 
  * Language and its setting is ISO-2022-JP/Base64 for
  * Japanese, UTF-8/Base64 for uni, ISO-8859-1/quoted printable for
  * English.
  * </p>
  * @return bool|string If language is set and
  * language is valid, it returns
- * true. Otherwise, it returns false.
+ * true. Otherwise, it returns false. 
  * When language is omitted, it returns the language
  * name as a string. If no language is set previously, it then returns
  * false.
@@ -78,14 +78,14 @@ function mb_language ($language = null) {}
  * Set/Get internal character encoding
  * @link https://php.net/manual/en/function.mb-internal-encoding.php
  * @param string $encoding [optional] <p>
- * encoding is the character encoding name
- * used for the HTTP input character encoding conversion, HTTP output
- * character encoding conversion, and the default character encoding
+ * encoding is the character encoding name 
+ * used for the HTTP input character encoding conversion, HTTP output 
+ * character encoding conversion, and the default character encoding 
  * for string functions defined by the mbstring module.
  * </p>
  * @return bool|string If encoding is set, then
  * true on success or false on failure.
- * If encoding is omitted, then
+ * If encoding is omitted, then 
  * the current character encoding name is returned.
  * @since 4.0.6
  * @since 5.0
@@ -96,10 +96,10 @@ function mb_internal_encoding ($encoding = null) {}
  * Detect HTTP input character encoding
  * @link https://php.net/manual/en/function.mb-http-input.php
  * @param string $type [optional] <p>
- * Input string specifies the input type.
+ * Input string specifies the input type. 
  * "G" for GET, "P" for POST, "C" for COOKIE, "S" for string, "L" for list, and
- * "I" for the whole list (will return array).
- * If type is omitted, it returns the last input type processed.
+ * "I" for the whole list (will return array). 
+ * If type is omitted, it returns the last input type processed. 
  * </p>
  * @return false|string The character encoding name, as per the type.
  * If mb_http_input does not process specified
@@ -124,7 +124,7 @@ function mb_http_input ($type = null) {}
  * </p>
  * @return bool|string If encoding is omitted,
  * mb_http_output returns the current HTTP output
- * character encoding. Otherwise,
+ * character encoding. Otherwise, 
  * true on success or false on failure.
  * @since 4.0.6
  * @since 5.0
@@ -135,7 +135,7 @@ function mb_http_output ($encoding = null) {}
  * Set/Get character encoding detection order
  * @link https://php.net/manual/en/function.mb-detect-order.php
  * @param mixed $encoding_list [optional] <p>
- * encoding_list is an array or
+ * encoding_list is an array or 
  * comma separated list of character encoding. ("auto" is expanded to
  * "ASCII, JIS, UTF-8, EUC-JP, SJIS")
  * </p>
@@ -156,7 +156,7 @@ function mb_http_output ($encoding = null) {}
  * ASCII,
  * EUC-JP,SJIS,
  * eucJP-win, SJIS-win,
- * JIS, ISO-2022-JP
+ * JIS, ISO-2022-JP 
  * <p>
  * For ISO-8859-*, mbstring
  * always detects as ISO-8859-*.
@@ -363,7 +363,7 @@ function mb_strripos ($haystack, $needle, $offset = 0, $encoding = null) {}
  * </p>
  * @param bool $before_needle [optional] <p>
  * Determines which portion of haystack
- * this function returns.
+ * this function returns. 
  * If set to true, it returns all of haystack
  * from the beginning to the first occurrence of needle.
  * If set to false, it returns all of haystack
@@ -391,7 +391,7 @@ function mb_strstr ($haystack, $needle, $before_needle = false, $encoding = null
  * </p>
  * @param bool $before_needle [optional] <p>
  * Determines which portion of haystack
- * this function returns.
+ * this function returns. 
  * If set to true, it returns all of haystack
  * from the beginning to the last occurrence of needle.
  * If set to false, it returns all of haystack
@@ -447,7 +447,7 @@ function mb_stristr ($haystack, $needle, $before_needle = false, $encoding = nul
  * </p>
  * @param bool $before_needle [optional] <p>
  * Determines which portion of haystack
- * this function returns.
+ * this function returns. 
  * If set to true, it returns all of haystack
  * from the beginning to the last occurrence of needle.
  * If set to false, it returns all of haystack
@@ -552,7 +552,7 @@ function mb_strwidth ($str, $encoding = null) {}
  * The width of the desired trim.
  * </p>
  * @param string $trimmarker [optional] <p>
- * A string that is added to the end of string
+ * A string that is added to the end of string 
  * when string is truncated.
  * </p>
  * @param string $encoding [optional] &mbstring.encoding.parameter;
@@ -575,11 +575,11 @@ function mb_strimwidth ($str, $start, $width, $trimmarker = null, $encoding = nu
  * @param string|string[] $from_encoding [optional] <p>
  * Is specified by character code names before conversion. It is either
  * an array, or a comma separated enumerated list.
- * If from_encoding is not specified, the internal
+ * If from_encoding is not specified, the internal 
  * encoding will be used.
  * </p>
  * <p>
- * "auto" may be used, which expands to
+ * "auto" may be used, which expands to 
  * "ASCII,JIS,UTF-8,EUC-JP,SJIS".
  * </p>
  * @return string The encoded string.
@@ -807,7 +807,7 @@ function mb_decode_mimeheader ($str) {}
  * @param string|string[] $from_encoding <p>
  * from_encoding is specified as an array
  * or comma separated string, it tries to detect encoding from
- * from-coding. When from_encoding
+ * from-coding. When from_encoding 
  * is omitted, detect_order is used.
  * </p>
  * @param string|array|object $vars <p>
@@ -864,7 +864,7 @@ function mb_decode_numericentity ($str, array $convmap, $encoding = null) {}
  * @param string $to <p>
  * The mail addresses being sent to. Multiple
  * recipients may be specified by putting a comma between each
- * address in to.
+ * address in to. 
  * This parameter is not automatically encoded.
  * </p>
  * @param string $subject <p>
@@ -897,7 +897,7 @@ function mb_send_mail ($to, $subject, $message, $additional_headers = null, $add
  * If type isn't specified or is specified to
  * "all", an array having the elements "internal_encoding",
  * "http_output", "http_input", "func_overload", "mail_charset",
- * "mail_header_encoding", "mail_body_encoding" will be returned.
+ * "mail_header_encoding", "mail_body_encoding" will be returned. 
  * </p>
  * <p>
  * If type is specified as "http_output",
@@ -946,7 +946,7 @@ function mb_regex_encoding ($encoding = null) {}
  * @param string $options [optional] <p>
  * The options to set.
  * </p>
- * @return string The previous options. If options is omitted,
+ * @return string The previous options. If options is omitted, 
  * it returns the string that describes the current options.
  * @since 4.3.0
  * @since 5.0
@@ -965,7 +965,7 @@ function mb_regex_set_options ($options = null) {}
  * @param string[] $regs [optional] <p>
  * Contains a substring of the matched string.
  * </p>
- * @return int
+ * @return int 
  * @since 4.2.0
  * @since 5.0
  */
@@ -983,7 +983,7 @@ function mb_ereg ($pattern, $string, array $regs = null) {}
  * @param string[] $regs [optional] <p>
  * Contains a substring of the matched string.
  * </p>
- * @return int
+ * @return int 
  * @since 4.2.0
  * @since 5.0
  */
@@ -1010,7 +1010,7 @@ function mb_eregi ($pattern, $string, array $regs = null) {}
  * specified, white space will be ignored. If m
  * is specified, match will be executed in multiline mode and line
  * break will be included in '.'. If p is
- * specified, match will be executed in POSIX mode, line break
+ * specified, match will be executed in POSIX mode, line break 
  * will be considered as normal character. If e
  * is specified, replacement string will be
  * evaluated as PHP expression.
@@ -1096,7 +1096,7 @@ function mb_eregi_replace ($pattern, $replace, $string, $option = "msr") {}
  * @param string $string <p>
  * The string being split.
  * </p>
- * @param int $limit [optional] If optional parameter limit is specified,
+ * @param int $limit [optional] If optional parameter limit is specified, 
  * it will be split in limit elements as
  * maximum.
  * @return string[] The result as an array.
@@ -1116,7 +1116,7 @@ function mb_split ($pattern, $string, $limit = null) {}
  * </p>
  * @param string $option [optional] <p>
  * </p>
- * @return bool
+ * @return bool 
  * @since 4.2.0
  * @since 5.0
  */
@@ -1131,7 +1131,7 @@ function mb_ereg_match ($pattern, $string, $option = null) {}
  * @param string $option [optional] <p>
  * The search option.
  * </p>
- * @return bool
+ * @return bool 
  * @since 4.2.0
  * @since 5.0
  */
@@ -1186,7 +1186,7 @@ function mb_ereg_search_regs ($pattern = null, $option = null) {}
  * @param string $option [optional] <p>
  * The search option.
  * </p>
- * @return bool
+ * @return bool 
  * @since 4.2.0
  * @since 5.0
  */
@@ -1209,7 +1209,7 @@ function mb_ereg_search_getregs () {}
 /**
  * Returns start point for next regular expression match
  * @link https://php.net/manual/en/function.mb-ereg-search-getpos.php
- * @return int
+ * @return int 
  * @since 4.2.0
  * @since 5.0
  * @deprecated 7.3


### PR DESCRIPTION
The "$part" parameter is incorrectly named and defines an incorrect default value (null) for haystack/needle mbstring functions.  Correct name is $before_needle and value is false.