### PR TITLE
Fixed optional in hash_pbkdf2 declaration

### DIFF
--- a/hash/hash.php
+++ b/hash/hash.php
@@ -250,7 +250,7 @@ function hash_hmac_algos() {}
  * binary representation of the derived key is returned.
  * @since 5.5.0
  */
-function hash_pbkdf2 ($algo, $password, $salt, $iterations, $length, $raw_output) {}
+function hash_pbkdf2 ($algo, $password, $salt, $iterations, $length = 0, $raw_output = FALSE) {}
 
 /**
  * Generates a key


### PR DESCRIPTION
Set optional params of hash_pbkdf2 as optional correctly.

http://php.net/manual/en/function.hash-pbkdf2.php