### PR TITLE
SplFileObject::current() can return false

### DIFF
--- a/SPL/SPL_c1.php
+++ b/SPL/SPL_c1.php
@@ -841,7 +841,7 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, SeekableIt
         /**
          * Retrieve current line of file
          * @link https://php.net/manual/en/splfileobject.current.php
-	 * @return string|array Retrieves the current line of the file. If the <b>SplFileObject::READ_CSV</b> flag is set, this method returns an array containing the current line parsed as CSV data.
+	 * @return string|array|false Retrieves the current line of the file. If the <b>SplFileObject::READ_CSV</b> flag is set, this method returns an array containing the current line parsed as CSV data.
          * @since 5.1.0
          */
         public function current () {}


### PR DESCRIPTION
Hi,

SplFileObject::current() can return false if the pointer is out of bounds.

This is not mentionned in the php.net website, but here's a reproducible code:
https://3v4l.org/6XefC

Thanks

