### PR TITLE
Set correct return type for insert method

### DIFF
--- a/SPL/SPL_c1.php
+++ b/SPL/SPL_c1.php
@@ -1553,7 +1553,7 @@ class SplPriorityQueue implements Iterator, Countable {
          * @param mixed $priority <p>
          * The associated priority.
          * </p>
-         * @return bool 
+         * @return true
          * @since 5.3.0
          */
         public function insert ($value, $priority) {}

--- a/SPL/SPL_c1.php
+++ b/SPL/SPL_c1.php
@@ -1553,7 +1553,7 @@ class SplPriorityQueue implements Iterator, Countable {
          * @param mixed $priority <p>
          * The associated priority.
          * </p>
-         * @return void 
+         * @return bool 
          * @since 5.3.0
          */
         public function insert ($value, $priority) {}


### PR DESCRIPTION
The official php-documentation was even incorrect at this point as
shown in https://3v4l.org/X3h8Q
Insert returns true when successfull. It is unclear if it can ever
return false.