### PR TITLE
Revert "DOMNodeList::item() returns DOMNode instead of DOMElement"

### DIFF
--- a/dom/dom_c.php
+++ b/dom/dom_c.php
@@ -1147,7 +1147,7 @@ class DOMNodeList implements Traversable, Countable {
 	 * @param int $index <p>
 	 * Index of the node into the collection.
 	 * </p>
-	 * @return DOMNode|null The node at the indexth position in the 
+	 * @return DOMElement The node at the indexth position in the 
 	 * DOMNodeList, or &null; if that is not a valid
 	 * index.
 	 * @since 5.0


### PR DESCRIPTION
Reverts JetBrains/phpstorm-stubs#503

The return type is actually `DOMElement`: https://3v4l.org/4Z5oj