### PR TITLE
Fix broken https php.net links

### DIFF
--- a/date/date_c.php
+++ b/date/date_c.php
@@ -313,7 +313,7 @@ class DateTimeImmutable implements DateTimeInterface {
 class DateTime implements DateTimeInterface {
     /**
      * (PHP 5 &gt;=5.2.0)<br/>
-     * @link https://secure.php.net/manual/en/datetime.construct.php
+     * @link https://php.net/manual/en/datetime.construct.php
      * @param string $time [optional]
      * <p>A date/time string. Valid formats are explained in {@link www.php.net/manual/en/datetime.formats.php Date and Time Formats}.</p>
      * <p>
@@ -321,7 +321,7 @@ class DateTime implements DateTimeInterface {
      * the <em>$timezone</em> parameter.
      * </p>
      * @param DateTimeZone $timezone [optional] <p>
-     * A {@link https://secure.php.net/manual/en/class.datetimezone.php DateTimeZone} object representing the
+     * A {@link https://php.net/manual/en/class.datetimezone.php DateTimeZone} object representing the
      * timezone of <em>$time</em>.
      * </p>
      * <p>

--- a/date/date_c.php
+++ b/date/date_c.php
@@ -313,7 +313,7 @@ class DateTimeImmutable implements DateTimeInterface {
 class DateTime implements DateTimeInterface {
     /**
      * (PHP 5 &gt;=5.2.0)<br/>
-     * @link https://www.php.net/manual/en/datetime.construct.php
+     * @link https://secure.php.net/manual/en/datetime.construct.php
      * @param string $time [optional]
      * <p>A date/time string. Valid formats are explained in {@link www.php.net/manual/en/datetime.formats.php Date and Time Formats}.</p>
      * <p>
@@ -321,7 +321,7 @@ class DateTime implements DateTimeInterface {
      * the <em>$timezone</em> parameter.
      * </p>
      * @param DateTimeZone $timezone [optional] <p>
-     * A {@link https://www.php.net/manual/en/class.datetimezone.php DateTimeZone} object representing the
+     * A {@link https://secure.php.net/manual/en/class.datetimezone.php DateTimeZone} object representing the
      * timezone of <em>$time</em>.
      * </p>
      * <p>


### PR DESCRIPTION
Links were changed to use https without updating the url to be secure.php.net, causing the links to be broken.