### PR TITLE
CHANGED param types for Redis to satisfy phpstan

### DIFF
--- a/redis/Redis.php
+++ b/redis/Redis.php
@@ -373,7 +373,7 @@ class Redis
     /**
      * Remove specified keys.
      *
-     * @param   string|string[] $key1 An array of keys, or an undefined number of parameters, each a key: key1 key2 key3 ... keyN
+     * @param   string|array    $key1 An array of keys, or an undefined number of parameters, each a key: key1 key2 key3 ... keyN
      * @param   string          $key2 ...
      * @param   string          $key3 ...
      * @return  int             Number of keys deleted.

--- a/redis/RedisCluster.php
+++ b/redis/RedisCluster.php
@@ -209,7 +209,7 @@ class RedisCluster {
     /**
      * Remove specified keys.
      *
-     * @param   int | array $key1 An array of keys, or an undefined number of parameters, each a key: key1 key2 key3
+     * @param   int|string...|array    $key1 An array of keys, or an undefined number of parameters, each a key: key1 key2 key3
      *                            ... keyN
      * @param   string      $key2 ...
      * @param   string      $key3 ...

--- a/redis/RedisCluster.php
+++ b/redis/RedisCluster.php
@@ -209,10 +209,9 @@ class RedisCluster {
     /**
      * Remove specified keys.
      *
-     * @param   int|string...|array    $key1 An array of keys, or an undefined number of parameters, each a key: key1 key2 key3
+     * @param int|string|array $key1 An array of keys, or an undefined number of parameters, each a key: key1 key2 key3
      *                            ... keyN
-     * @param   string      $key2 ...
-     * @param   string      $key3 ...
+     * @param int|string ...$otherKeys
      *
      * @return int Number of keys deleted.
      * @link    https://redis.io/commands/del


### PR DESCRIPTION
PHP 7.2 + phpstan complains when the value is type hinted to a string as it states it can only accept an int or an array