### PR TITLE
Fix optional parameter for get_headers()

### DIFF
--- a/standard/standard_6.php
+++ b/standard/standard_6.php
@@ -1045,7 +1045,7 @@ function stream_is_local ($stream_or_url) {}
  * failure.
  * @since 5.0
  */
-function get_headers ($url, $format = null, $context) {}
+function get_headers ($url, $format = null, $context = null) {}
 
 /**
  * Set timeout period on a stream


### PR DESCRIPTION
Marks the final parameter for `get_headers()` as optional.