### PR TITLE
Fix expected arguments for ob_implicit_flush

### DIFF
--- a/meta/.phpstorm.meta.php
+++ b/meta/.phpstorm.meta.php
@@ -195,7 +195,7 @@ namespace PHPSTORM_META {
     expectedArguments(\mysqli_stmt_attr_set(), 1, argumentsSet("mysqliAttributesSet"));
 
 	expectedArguments(\ob_start(), 2, \PHP_OUTPUT_HANDLER_CLEANABLE | \PHP_OUTPUT_HANDLER_FLUSHABLE | PHP_OUTPUT_HANDLER_REMOVABLE, PHP_OUTPUT_HANDLER_STDFLAGS);
-	expectedArguments(\ob_implicit_flush(), 0, 1, 2);
+	expectedArguments(\ob_implicit_flush(), 0, 0, 1);
     expectedArguments(\OCI_Lob::flush(), 0, OCI_LOB_BUFFER_FREE);
     expectedArguments(\oci_execute(), 1, OCI_COMMIT_ON_SUCCESS,OCI_DESCRIBE_ONLY,OCI_NO_AUTO_COMMIT);
     expectedArguments(\odbc_binmode(), 1, ODBC_BINMODE_PASSTHRU,ODBC_BINMODE_RETURN,ODBC_BINMODE_CONVERT);


### PR DESCRIPTION
According to documentation there is no value `2` for `ob_implicit_flush`. Only `0` and `1` are allowed:
https://www.php.net/manual/en/function.ob-implicit-flush.php