### PR TITLE
Add expectedArguments common for dirname

### DIFF
--- a/meta/.phpstorm.meta.php
+++ b/meta/.phpstorm.meta.php
@@ -104,6 +104,15 @@ namespace PHPSTORM_META {
     expectedArguments(\variant_cmp(), 0, NORM_IGNORECASE|NORM_IGNORENONSPACE|NORM_IGNORESYMBOLS|NORM_IGNOREWIDTH|NORM_IGNOREKANATYPE|NORM_IGNOREKASHIDA);
 
     expectedArguments(\DOMDocument::schemaValidateSource(), 1, LIBXML_SCHEMA_CREATE);
+    
+    registerArgumentsSet('common_dirname_constants', __DIR__, __FILE__);
+    expectedArguments(\dirname(), 0, argumentsSet('common_dirname_constants'));
+
+    // this allows completion for "dirname()" inside dirname(<caret>)
+    registerArgumentsSet('common_dirname_return', __DIR__);
+    expectedArguments(\dirname(), 0, argumentsSet('common_dirname_return'));
+    expectedReturnValues(\dirname(), argumentsSet('common_dirname_return'));
+    
     expectedArguments(\EvLoop::__construct(), 0, \Ev::FLAG_AUTO,\Ev::FLAG_NOENV,\Ev::FLAG_FORKCHECK,\Ev::FLAG_NOINOTIFY,\Ev::FLAG_SIGNALFD,\Ev::FLAG_NOSIGMASK); //todo support
     expectedArguments(\Ev::run(), 0, \Ev::FLAG_AUTO,\Ev::FLAG_NOENV,\Ev::FLAG_FORKCHECK,\Ev::FLAG_NOINOTIFY,\Ev::FLAG_SIGNALFD,\Ev::FLAG_NOSIGMASK);
     expectedArguments(\EvLoop::run(), 0, \Ev::RUN_NOWAIT,\Ev::RUN_ONCE);

--- a/meta/.phpstorm.meta.php
+++ b/meta/.phpstorm.meta.php
@@ -105,13 +105,9 @@ namespace PHPSTORM_META {
 
     expectedArguments(\DOMDocument::schemaValidateSource(), 1, LIBXML_SCHEMA_CREATE);
     
-    registerArgumentsSet('common_dirname_constants', __DIR__, __FILE__);
-    expectedArguments(\dirname(), 0, argumentsSet('common_dirname_constants'));
-
-    // this allows completion for "dirname()" inside dirname(<caret>)
     registerArgumentsSet('common_dirname_return', __DIR__);
-    expectedArguments(\dirname(), 0, argumentsSet('common_dirname_return'));
-    expectedReturnValues(\dirname(), argumentsSet('common_dirname_return'));
+    expectedArguments(\dirname(), 0, argumentsSet('common_dirname_return'), __FILE__);
+    expectedReturnValues(\dirname(), argumentsSet('common_dirname_return'));    // this allows completion for "dirname()" inside dirname(<caret>)
     
     expectedArguments(\EvLoop::__construct(), 0, \Ev::FLAG_AUTO,\Ev::FLAG_NOENV,\Ev::FLAG_FORKCHECK,\Ev::FLAG_NOINOTIFY,\Ev::FLAG_SIGNALFD,\Ev::FLAG_NOSIGMASK); //todo support
     expectedArguments(\Ev::run(), 0, \Ev::FLAG_AUTO,\Ev::FLAG_NOENV,\Ev::FLAG_FORKCHECK,\Ev::FLAG_NOINOTIFY,\Ev::FLAG_SIGNALFD,\Ev::FLAG_NOSIGMASK);


### PR DESCRIPTION
It's very common to have `__DIR__` and `__FILE__` as arguments for `dirname()`. 
(Getting current directory or parent directories)

This also uses `expectedReturnValues` as a trick, so `dirname()` gets listed when calling it nested:

`dirname(dirname(dirname(__DIR__)))`

![image](https://user-images.githubusercontent.com/4896363/55179906-c5f3c480-5188-11e9-876b-1e050b4680a3.png)

Also you get completion in comparison for `__DIR__`:

```php
if (dirname($file) == <caret>) { ...
```