### PR TITLE
Add typehints for optional, nullable parameters

### DIFF
--- a/standard/standard_2.php
+++ b/standard/standard_2.php
@@ -971,7 +971,7 @@ function rand ($min = 0, $max = null) {}
  * an alias of {@see mt_srand()}.
  * </p>
  * @link https://php.net/manual/en/function.srand.php
- * @param int $seed [optional] <p>
+ * @param int|null $seed [optional] <p>
  * Optional seed value
  * </p>
  * @param int $mode [optional] <p>


### PR DESCRIPTION
Some parameters have a certain type (e.g. string or int) but default to `null` to be optional. I changed the typehints to reflect this possible value.