### PR TITLE
Update user_error stub to match trigger_error

### DIFF
--- a/Core/Core.php
+++ b/Core/Core.php
@@ -606,7 +606,7 @@ function trigger_error ($error_msg, $error_type = E_USER_NOTICE) {}
  * @since 4.0
  * @since 5.0
  */
-function user_error ($message, $error_type) {}
+function user_error ($message, $error_type = E_USER_NOTICE) {}
 
 /**
  * Sets a user-defined error handler function


### PR DESCRIPTION
`user_error` is lacking the default `E_USER_NOTICE` that `trigger_error` already has.