### PR TITLE
Correct type declaration

### DIFF
--- a/Parle/Parser.php
+++ b/Parle/Parser.php
@@ -141,10 +141,10 @@ class Parser
      * This method is equivalent to the pseudo variable functionality in Bison.
      *
      * @link https://php.net/manual/en/parle-parser.sigil.php
-     * @param array $idx Match index, zero based. [ int $idx ]
+     * @param int $idx Match index, zero based.
      * @return string Returns a string with the matched part.
      */
-    public function sigil(array $idx) : string {}
+    public function sigil(int $idx) : string {}
 
     /**
      * Declare a terminal to be used in the grammar.

--- a/Parle/RParser.php
+++ b/Parle/RParser.php
@@ -146,10 +146,10 @@ class RParser
      * This method is equivalent to the pseudo variable functionality in Bison.
      *
      * @link https://php.net/manual/en/parle-rparser.sigil.php
-     * @param array $idx Match index, zero based. [ int $idx ]
+     * @param int $idx Match index, zero based.
      * @return string Returns a string with the matched part.
      */
-    public function sigil(array $idx) : string {}
+    public function sigil(int $idx) : string {}
 
     /**
      * Declare a token


### PR DESCRIPTION
The type declaration on this argument should be int instead of array, unfortunately I ran into the following error:

```
PHP Fatal error:  Uncaught TypeError: Argument 1 passed to Parle\Parser::sigil() must be of the type integer, array given
```

I've submitted a patch to amend the documentation over at https://www.php.net/manual/en/parle-parser.sigil.php and https://www.php.net/manual/en/parle-rparser.sigil.php.

Please let me know if there are any issues.