### PR TITLE
Remove double definition

### DIFF
--- a/standard/standard_9.php
+++ b/standard/standard_9.php
@@ -810,22 +810,6 @@ function key_exists($key, $search) { }
 function assert($assertion, $description = '') { }
 
 /**
- * (PHP 5 &gt;=5.5.0)<br/>
- * Returns the current process title
- * @link https://secure.php.net/manual/en/function.cli-get-process-title.php
- * @return string
- */
-function cli_get_process_title() { }
-
-/**
- * (PHP 5 &gt;=5.5.0)<br/>
- * Sets the process title
- * @param string $title <p>The new title</p>
- * @return bool Returns TRUE on success or FALSE on failure.
- */
-function cli_set_process_title($title) { }
-
-/**
  * Set/get the various assert flags
  * @link https://php.net/manual/en/function.assert-options.php
  * @param int $what <p>


### PR DESCRIPTION
The function `cli_get_process_title` and `cli_set_process_title` are already defined in `basic.php` and as such I've removed them from `standard_9.php`. If you prefer it to be the other way around, raise your voice.