### PR TITLE
SimpleXML: better return annotation for xpath

### DIFF
--- a/SimpleXML/SimpleXML.php
+++ b/SimpleXML/SimpleXML.php
@@ -66,7 +66,7 @@ class SimpleXMLElement implements Traversable, ArrayAccess, Countable {
 	 * @param string $path <p>
 	 * An XPath path
 	 * </p>
-	 * @return SimpleXMLElement[] an array of SimpleXMLElement objects or <b>FALSE</b> in
+	 * @return static[] an array of SimpleXMLElement (or derived) objects or <b>FALSE</b> in
 	 * case of an error.
 	 * @since 5.2.0
 	 */


### PR DESCRIPTION
If `xpath` is called from `SimpleXMLIterator`, which extends `SimpleXMLElement`, the result type of `xpath` would be `SimpleXMLIterator[]`, not `SimpleXMLElement[]`. Currently, Phpstorm would report non-existing `current`/`next`/`rewind` methods that are called on `xpath` results even if the underlying type is `SimpleXMLIterator` (which has those methods). A simplest fix is to annotate return type as `static[]`, because this way Phpstorm is able to infer proper type of the elements and stops making false reports about undefined methods.

Simple example that demonstrates that:

```php
<?php

$strXml= <<<XML
<a>
 <b>
  <c>text</c>
  <c>stuff</c>
 </b>
 <d>
  <c>code</c>
 </d>
</a>
XML;

// $xml = new SimpleXMLElement($strXml, 0);
// $root = $xml->xpath("/a");
// var_dump($root);

$xml = new SimpleXMLIterator($strXml, 0);
$root = $xml->xpath("/a");
var_dump($root);

$iter = $root[0];
$iter->rewind();
$iter->next();
var_dump($iter->current());
```