### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.json]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
Settings for different IDE in order to adhere to a common style when editing.

For example, the `composer.json` contains 2 spaces, however, by default, the IDE settings correspond to 4 and `Ctrl + Alt + Shift + L` break formatting if `.editorconfig` file is missing.