### PR TITLE
make strftime() $timestamp optional

### DIFF
--- a/date/date.php
+++ b/date/date.php
@@ -769,7 +769,7 @@ function checkdate ($month, $day, $year) {}
  * @since 4.0
  * @since 5.0
  */
-function strftime ($format, $timestamp) {}
+function strftime ($format, $timestamp = 'time()') {}
 
 /**
  * Format a GMT/UTC time/date according to locale settings

--- a/date/date.php
+++ b/date/date.php
@@ -769,7 +769,7 @@ function checkdate ($month, $day, $year) {}
  * @since 4.0
  * @since 5.0
  */
-function strftime ($format, $timestamp = 'time()') {}
+function strftime ($format, $timestamp = null) {}
 
 /**
  * Format a GMT/UTC time/date according to locale settings


### PR DESCRIPTION
I think this should be optional and default to the value returned by `time()`: https://www.php.net/manual/en/function.strftime.php