### PR TITLE
added missing com_exception to com_dotnet stub

### DIFF
--- a/com_dotnet/com_dotnet.php
+++ b/com_dotnet/com_dotnet.php
@@ -73,6 +73,12 @@ class VARIANT {
 }
 
 /**
+ * This extension will throw instances of the class com_exception whenever there is a potentially fatal error reported by COM. All COM exceptions have a well-defined code property that corresponds to the HRESULT return value from the various COM operations. You may use this code to make programmatic decisions on how to handle the exception.
+ * @link https://php.net/manual/en/com.error-handling.php
+ */
+class com_exception extends \Exception {}
+
+/**
  * (PHP 5, PHP 7)<br/>
  * Generate a globally unique identifier (GUID)
  * @link https://php.net/manual/en/function.com-create-guid.php


### PR DESCRIPTION
This class doesn't have a manual page in the traditional format (see https://php.net/manual/en/com.error-handling.php).

Several other classes appear when writing `php --re com_dotnet`, but I did not take the time to investigate those.