### PR TITLE
xmlrpc_server_register_method: use callable type

### DIFF
--- a/xmlrpc/xmlrpc.php
+++ b/xmlrpc/xmlrpc.php
@@ -125,7 +125,7 @@ function xmlrpc_server_destroy ($server) {}
  * @link https://php.net/manual/en/function.xmlrpc-server-register-method.php
  * @param resource $server
  * @param string $method_name
- * @param string $function
+ * @param callable $function
  * @return bool
  * @since 4.1.0
  * @since 5.0


### PR DESCRIPTION
xmlrpc_server_register_method third argument is any kind of callable:
-  `array($bar, "foo_func")`