### PR TITLE
Fixed GMP stub for PHP >= 5.6

### DIFF
--- a/gmp/gmp.php
+++ b/gmp/gmp.php
@@ -19,7 +19,7 @@
  * hexadecimal is assumed, otherwise if the first character is "0",
  * octal is assumed, otherwise decimal is assumed.
  * </p>
- * @return resource A GMP number resource.
+ * @return resource|GMP A GMP number resource.
  * @since 4.0.4
  * @since 5.0
  */
@@ -28,7 +28,7 @@ function gmp_init ($number, $base = 0) {}
 /**
  * Convert GMP number to integer
  * @link https://php.net/manual/en/function.gmp-intval.php
- * @param resource $gmpnumber <p>
+ * @param resource|string|GMP $gmpnumber <p>
  * A GMP number.
  * </p>
  * @return int An integer value of <i>gmpnumber</i>.
@@ -39,7 +39,7 @@ function gmp_intval ($gmpnumber) {}
 
 /**
  * Sets the RNG seed
- * @param mixed $seed <p>
+ * @param resource|string|GMP $seed <p>
  * The seed to be set for the {@see gmp_random()}, {@see gmp_random_bits()}, and {@see gmp_random_range()} functions.
  * </p>
  * Either a GMP number resource in PHP 5.5 and earlier, a GMP object in PHP 5.6 and later, or a numeric string provided that it is possible to convert the latter to a number.
@@ -50,7 +50,7 @@ function gmp_random_seed ($seed ) {}
 /**
  * Convert GMP number to string
  * @link https://php.net/manual/en/function.gmp-strval.php
- * @param resource|string $gmpnumber <p>
+ * @param resource|string|GMP $gmpnumber <p>
  * The GMP number that will be converted to a string.
  * </p>
  * It can be either a GMP number resource, or a
@@ -68,17 +68,17 @@ function gmp_strval ($gmpnumber, $base = 10) {}
 /**
  * Add numbers
  * @link https://php.net/manual/en/function.gmp-add.php
- * @param resource|string $a <p>
+ * @param resource|string|GMP $a <p>
  * A number that will be added.
  * </p>
  * It can be either a GMP number resource, or a
  * numeric string given that it is possible to convert the latter to a number.</p>
- * @param resource|string $b <p>
+ * @param resource|string|GMP $b <p>
  * A number that will be added.
  * </p>
  * It can be either a GMP number resource, or a
  * numeric string given that it is possible to convert the latter to a number.</p>
- * @return resource A GMP number representing the sum of the arguments.
+ * @return resource|GMP A GMP number representing the sum of the arguments.
  * @since 4.0.4
  * @since 5.0
  */
@@ -87,17 +87,17 @@ function gmp_add ($a, $b) {}
 /**
  * Subtract numbers
  * @link https://php.net/manual/en/function.gmp-sub.php
- * @param resource|string $a <p>
+ * @param resource|string|GMP $a <p>
  * The number being subtracted from.
  * </p>
  * It can be either a GMP number resource, or a
  * numeric string given that it is possible to convert the latter to a number.</p>
- * @param resource|string $b <p>
+ * @param resource|string|GMP $b <p>
  * The number subtracted from <i>a</i>.
  * </p>
  * It can be either a GMP number resource, or a
  * numeric string given that it is possible to convert the latter to a number.</p>
- * @return GMP A GMP number resource.
+ * @return resource|GMP A GMP number resource.
  * @since 4.0.4
  * @since 5.0
  */
@@ -106,17 +106,17 @@ function gmp_sub ($a, $b) {}
 /**
  * Multiply numbers
  * @link https://php.net/manual/en/function.gmp-mul.php
- * @param resource|string $a <p>
+ * @param resource|string|GMP $a <p>
  * A number that will be multiplied by <i>b</i>.
  * </p>
  * It can be either a GMP number resource, or a
  * numeric string given that it is possible to convert the latter to a number.</p>
- * @param resource|string $b <p>
+ * @param resource|string|GMP $b <p>
  * A number that will be multiplied by <i>a</i>.
  * </p>
  * It can be either a GMP number resource, or a
  * numeric string given that it is possible to convert the latter to a number.</p>
- * @return resource A GMP number resource.
+ * @return resource|GMP A GMP number resource.
  * @since 4.0.4
  * @since 5.0
  */
@@ -125,12 +125,12 @@ function gmp_mul ($a, $b) {}
 /**
  * Divide numbers and get quotient and remainder
  * @link https://php.net/manual/en/function.gmp-div-qr.php
- * @param resource|string $n <p>
+ * @param resource|string|GMP $n <p>
  * The number being divided.
  * </p>
  * It can be either a GMP number resource, or a
  * numeric string given that it is possible to convert the latter to a number.</p>
- * @param resource|string $d <p>
+ * @param resource|string|GMP $d <p>
  * The number that <i>n</i> is being divided by.
  * </p>
  * It can be either a GMP number resource, or a
@@ -151,12 +151,12 @@ function gmp_div_qr ($n, $d, $round = GMP_ROUND_ZERO) {}
 /**
  * Divide numbers
  * @link https://php.net/manual/en/function.gmp-div-q.php
- * @param resource|string $a <p>
+ * @param resource|string|GMP $a <p>
  * The number being divided.
  * </p>
  * It can be either a GMP number resource, or a
  * numeric string given that it is possible to convert the latter to a number.</p>
- * @param resource|string $b <p>
+ * @param resource|string|GMP $b <p>
  * The number that <i>a</i> is being divided by.
  * </p>
  * It can be either a GMP number resource, or a
@@ -167,7 +167,7 @@ function gmp_div_qr ($n, $d, $round = GMP_ROUND_ZERO) {}
  * values:
  * <b>GMP_ROUND_ZERO</b>: The result is truncated
  * towards 0.
- * @return resource A GMP number resource.
+ * @return resource|GMP A GMP number resource.
  * @since 4.0.4
  * @since 5.0
  */
@@ -176,12 +176,12 @@ function gmp_div_q ($a, $b, $round = GMP_ROUND_ZERO) {}
 /**
  * Remainder of the division of numbers
  * @link https://php.net/manual/en/function.gmp-div-r.php
- * @param resource|string $n <p>
+ * @param resource|string|GMP $n <p>
  * The number being divided.
  * </p>
  * It can be either a GMP number resource, or a
  * numeric string given that it is possible to convert the latter to a number.</p>
- * @param resource|string $d <p>
+ * @param resource|string|GMP $d <p>
  * The number that <i>n</i> is being divided by.
  * </p>
  * It can be either a GMP number resource, or a
@@ -190,7 +190,7 @@ function gmp_div_q ($a, $b, $round = GMP_ROUND_ZERO) {}
  * See the <b>gmp_div_q</b> function for description
  * of the <i>round</i> argument.
  * </p>
- * @return resource The remainder, as a GMP number.
+ * @return resource|GMP The remainder, as a GMP number.
  * @since 4.0.4
  * @since 5.0
  */
@@ -215,7 +215,7 @@ function gmp_div_r ($n, $d, $round = GMP_ROUND_ZERO) {}
  * values:
  * <b>GMP_ROUND_ZERO</b>: The result is truncated
  * towards 0.
- * @return resource A GMP number resource.
+ * @return resource|GMP A GMP number resource.
  * @since 4.0.4
  * @since 5.0
  */
@@ -224,14 +224,14 @@ function gmp_div ($a, $b, $round = GMP_ROUND_ZERO) {}
 /**
  * Modulo operation
  * @link https://php.net/manual/en/function.gmp-mod.php
- * @param resource|string $n It can be either a GMP number resource, or a
+ * @param resource|string|GMP $n It can be either a GMP number resource, or a
  * numeric string given that it is possible to convert the latter to a number.</p>
- * @param resource|string $d <p>
+ * @param resource|string|GMP $d <p>
  * The modulo that is being evaluated.
  * </p>
  * It can be either a GMP number resource, or a
  * numeric string given that it is possible to convert the latter to a number.</p>
- * @return resource A GMP number resource.
+ * @return resource|GMP A GMP number resource.
  * @since 4.0.4
  * @since 5.0
  */
@@ -250,7 +250,7 @@ function gmp_mod ($n, $d) {}
  * </p>
  * It can be either a GMP number resource, or a
  * numeric string given that it is possible to convert the latter to a number.</p>
- * @return resource A GMP number resource.
+ * @return resource|GMP A GMP number resource.
  * @since 4.0.4
  * @since 5.0
  */
@@ -259,9 +259,9 @@ function gmp_divexact ($n, $d) {}
 /**
  * Negate number
  * @link https://php.net/manual/en/function.gmp-neg.php
- * @param resource|string $a It can be either a GMP number resource, or a
+ * @param resource|string|GMP $a It can be either a GMP number resource, or a
  * numeric string given that it is possible to convert the latter to a number.</p>
- * @return resource -<i>a</i>, as a GMP number.
+ * @return resource|GMP -<i>a</i>, as a GMP number.
  * @since 4.0.4
  * @since 5.0
  */
@@ -270,9 +270,9 @@ function gmp_neg ($a) {}
 /**
  * Absolute value
  * @link https://php.net/manual/en/function.gmp-abs.php
- * @param resource|string $a It can be either a GMP number resource, or a
+ * @param resource|string|GMP $a It can be either a GMP number resource, or a
  * numeric string given that it is possible to convert the latter to a number.</p>
- * @return resource the absolute value of <i>a</i>, as a GMP number.
+ * @return resource|GMP the absolute value of <i>a</i>, as a GMP number.
  * @since 4.0.4
  * @since 5.0
  */
@@ -281,12 +281,12 @@ function gmp_abs ($a) {}
 /**
  * Factorial
  * @link https://php.net/manual/en/function.gmp-fact.php
- * @param resource|string $a <p>
+ * @param resource|string|GMP $a <p>
  * The factorial number.
  * </p>
  * It can be either a GMP number resource, or a
  * numeric string given that it is possible to convert the latter to a number.</p>
- * @return resource A GMP number resource.
+ * @return resource|GMP A GMP number resource.
  * @since 4.0.4
  * @since 5.0
  */
@@ -295,9 +295,9 @@ function gmp_fact ($a) {}
 /**
  * Calculate square root
  * @link https://php.net/manual/en/function.gmp-sqrt.php
- * @param resource|string $a It can be either a GMP number resource, or a
+ * @param resource|string|GMP $a It can be either a GMP number resource, or a
  * numeric string given that it is possible to convert the latter to a number.</p>
- * @return resource The integer portion of the square root, as a GMP number.
+ * @return resource|GMP The integer portion of the square root, as a GMP number.
  * @since 4.0.4
  * @since 5.0
  */
@@ -306,7 +306,7 @@ function gmp_sqrt ($a) {}
 /**
  * Square root with remainder
  * @link https://php.net/manual/en/function.gmp-sqrtrem.php
- * @param resource|string $a <p>
+ * @param resource|string|GMP $a <p>
  * The number being square rooted.
  * </p>
  * It can be either a GMP number resource, or a
@@ -323,7 +323,7 @@ function gmp_sqrtrem ($a) {}
 /**
  * Raise number into power
  * @link https://php.net/manual/en/function.gmp-pow.php
- * @param resource|string $base <p>
+ * @param resource|string|GMP $base <p>
  * The base number.
  * </p>
  * It can be either a GMP number resource, or a
@@ -331,7 +331,7 @@ function gmp_sqrtrem ($a) {}
  * @param int $exp <p>
  * The positive power to raise the <i>base</i>.
  * </p>
- * @return resource The new (raised) number, as a GMP number. The case of
+ * @return resource|GMP The new (raised) number, as a GMP number. The case of
  * 0^0 yields 1.
  * @since 4.0.4
  * @since 5.0
@@ -341,22 +341,22 @@ function gmp_pow ($base, $exp) {}
 /**
  * Raise number into power with modulo
  * @link https://php.net/manual/en/function.gmp-powm.php
- * @param resource|string $base <p>
+ * @param resource|string|GMP $base <p>
  * The base number.
  * </p>
  * It can be either a GMP number resource, or a
  * numeric string given that it is possible to convert the latter to a number.</p>
- * @param resource|string $exp <p>
+ * @param resource|string|GMP $exp <p>
  * The positive power to raise the <i>base</i>.
  * </p>
  * It can be either a GMP number resource, or a
  * numeric string given that it is possible to convert the latter to a number.</p>
- * @param resource|string $mod <p>
+ * @param resource|string|GMP $mod <p>
  * The modulo.
  * </p>
  * It can be either a GMP number resource, or a
  * numeric string given that it is possible to convert the latter to a number.</p>
- * @return resource The new (raised) number, as a GMP number.
+ * @return resource|GMP The new (raised) number, as a GMP number.
  * @since 4.0.4
  * @since 5.0
  */
@@ -365,7 +365,7 @@ function gmp_powm ($base, $exp, $mod) {}
 /**
  * Perfect square check
  * @link https://php.net/manual/en/function.gmp-perfect-square.php
- * @param resource|string $a <p>
+ * @param resource|string|GMP $a <p>
  * The number being checked as a perfect square.
  * </p>
  * It can be either a GMP number resource, or a
@@ -380,7 +380,7 @@ function gmp_perfect_square ($a) {}
 /**
  * Check if number is "probably prime"
  * @link https://php.net/manual/en/function.gmp-prob-prime.php
- * @param resource|string $a <p>
+ * @param resource|string|GMP $a <p>
  * The number being checked as a prime.
  * </p>
  * It can be either a GMP number resource, or a
@@ -424,11 +424,11 @@ function gmp_random_range(GMP $min, GMP $max) {}
 /**
  * Calculate GCD
  * @link https://php.net/manual/en/function.gmp-gcd.php
- * @param resource|string $a It can be either a GMP number resource, or a
+ * @param resource|string|GMP $a It can be either a GMP number resource, or a
  * numeric string given that it is possible to convert the latter to a number.</p>
- * @param resource|string $b It can be either a GMP number resource, or a
+ * @param resource|string|GMP $b It can be either a GMP number resource, or a
  * numeric string given that it is possible to convert the latter to a number.</p>
- * @return resource A positive GMP number that divides into both
+ * @return resource|GMP A positive GMP number that divides into both
  * <i>a</i> and <i>b</i>.
  * @since 4.0.4
  * @since 5.0
@@ -438,9 +438,9 @@ function gmp_gcd ($a, $b) {}
 /**
  * Calculate GCD and multipliers
  * @link https://php.net/manual/en/function.gmp-gcdext.php
- * @param resource|string $a It can be either a GMP number resource, or a
+ * @param resource|string|GMP $a It can be either a GMP number resource, or a
  * numeric string given that it is possible to convert the latter to a number.</p>
- * @param resource|string $b It can be either a GMP number resource, or a
+ * @param resource|string|GMP $b It can be either a GMP number resource, or a
  * numeric string given that it is possible to convert the latter to a number.</p>
  * @return array An array of GMP numbers.
  * @since 4.0.4
@@ -451,11 +451,11 @@ function gmp_gcdext ($a, $b) {}
 /**
  * Inverse by modulo
  * @link https://php.net/manual/en/function.gmp-invert.php
- * @param resource|string $a It can be either a GMP number resource, or a
+ * @param resource|string|GMP $a It can be either a GMP number resource, or a
  * numeric string given that it is possible to convert the latter to a number.</p>
- * @param resource|string $b It can be either a GMP number resource, or a
+ * @param resource|string|GMP $b It can be either a GMP number resource, or a
  * numeric string given that it is possible to convert the latter to a number.</p>
- * @return resource A GMP number on success or <b>FALSE</b> if an inverse does not exist.
+ * @return resource|GMP A GMP number on success or <b>FALSE</b> if an inverse does not exist.
  * @since 4.0.4
  * @since 5.0
  */
@@ -464,9 +464,9 @@ function gmp_invert ($a, $b) {}
 /**
  * Jacobi symbol
  * @link https://php.net/manual/en/function.gmp-jacobi.php
- * @param resource|string $a It can be either a GMP number resource, or a
+ * @param resource|string|GMP $a It can be either a GMP number resource, or a
  * numeric string given that it is possible to convert the latter to a number.</p>
- * @param resource|string $p It can be either a GMP number resource, or a
+ * @param resource|string|GMP $p It can be either a GMP number resource, or a
  * numeric string given that it is possible to convert the latter to a number.</p>
  * <p>
  * Should be odd and must be positive.
@@ -480,9 +480,9 @@ function gmp_jacobi ($a, $p) {}
 /**
  * Legendre symbol
  * @link https://php.net/manual/en/function.gmp-legendre.php
- * @param resource|string $a It can be either a GMP number resource, or a
+ * @param resource|string|GMP $a It can be either a GMP number resource, or a
  * numeric string given that it is possible to convert the latter to a number.</p>
- * @param resource|string $p It can be either a GMP number resource, or a
+ * @param resource|string|GMP $p It can be either a GMP number resource, or a
  * numeric string given that it is possible to convert the latter to a number.</p>
  * <p>
  * Should be odd and must be positive.
@@ -496,9 +496,9 @@ function gmp_legendre ($a, $p) {}
 /**
  * Compare numbers
  * @link https://php.net/manual/en/function.gmp-cmp.php
- * @param resource|string $a It can be either a GMP number resource, or a
+ * @param resource|string|GMP $a It can be either a GMP number resource, or a
  * numeric string given that it is possible to convert the latter to a number.</p>
- * @param resource|string $b It can be either a GMP number resource, or a
+ * @param resource|string|GMP $b It can be either a GMP number resource, or a
  * numeric string given that it is possible to convert the latter to a number.</p>
  * @return int a positive value if a &gt; b, zero if
  * a = b and a negative value if a &lt;
@@ -511,7 +511,7 @@ function gmp_cmp ($a, $b) {}
 /**
  * Sign of number
  * @link https://php.net/manual/en/function.gmp-sign.php
- * @param resource|string $a It can be either a GMP number resource, or a
+ * @param resource|string|GMP $a It can be either a GMP number resource, or a
  * numeric string given that it is possible to convert the latter to a number.</p>
  * @return int 1 if <i>a</i> is positive,
  * -1 if <i>a</i> is negative,
@@ -529,7 +529,7 @@ function gmp_sign ($a) {}
  * </p>
  * It can be either a GMP number resource, or a
  * numeric string given that it is possible to convert the latter to a number.</p>
- * @return resource A random GMP number.
+ * @return resource|GMP A random GMP number.
  * @since 4.0.4
  * @since 5.0
  */
@@ -538,11 +538,11 @@ function gmp_random ($limiter = 20) {}
 /**
  * Bitwise AND
  * @link https://php.net/manual/en/function.gmp-and.php
- * @param resource|string $a It can be either a GMP number resource, or a
+ * @param resource|string|GMP $a It can be either a GMP number resource, or a
  * numeric string given that it is possible to convert the latter to a number.</p>
- * @param resource|string $b It can be either a GMP number resource, or a
+ * @param resource|string|GMP $b It can be either a GMP number resource, or a
  * numeric string given that it is possible to convert the latter to a number.</p>
- * @return resource A GMP number representing the bitwise AND comparison.
+ * @return resource|GMP A GMP number representing the bitwise AND comparison.
  * @since 4.0.4
  * @since 5.0
  */
@@ -551,11 +551,11 @@ function gmp_and ($a, $b) {}
 /**
  * Bitwise OR
  * @link https://php.net/manual/en/function.gmp-or.php
- * @param resource|string $a It can be either a GMP number resource, or a
+ * @param resource|string|GMP $a It can be either a GMP number resource, or a
  * numeric string given that it is possible to convert the latter to a number.</p>
- * @param resource|string $b It can be either a GMP number resource, or a
+ * @param resource|string|GMP $b It can be either a GMP number resource, or a
  * numeric string given that it is possible to convert the latter to a number.</p>
- * @return resource A GMP number resource.
+ * @return resource|GMP A GMP number resource.
  * @since 4.0.4
  * @since 5.0
  */
@@ -564,9 +564,9 @@ function gmp_or ($a, $b) {}
 /**
  * Calculates one's complement
  * @link https://php.net/manual/en/function.gmp-com.php
- * @param resource|string $a It can be either a GMP number resource, or a
+ * @param resource|string|GMP $a It can be either a GMP number resource, or a
  * numeric string given that it is possible to convert the latter to a number.</p>
- * @return resource the one's complement of <i>a</i>, as a GMP number.
+ * @return resource|GMP the one's complement of <i>a</i>, as a GMP number.
  * @since 4.0.4
  * @since 5.0
  */
@@ -575,11 +575,11 @@ function gmp_com ($a) {}
 /**
  * Bitwise XOR
  * @link https://php.net/manual/en/function.gmp-xor.php
- * @param resource|string $a It can be either a GMP number resource, or a
+ * @param resource|string|GMP $a It can be either a GMP number resource, or a
  * numeric string given that it is possible to convert the latter to a number.</p>
- * @param resource|string $b It can be either a GMP number resource, or a
+ * @param resource|string|GMP $b It can be either a GMP number resource, or a
  * numeric string given that it is possible to convert the latter to a number.</p>
- * @return resource A GMP number resource.
+ * @return resource|GMP A GMP number resource.
  * @since 4.0.4
  * @since 5.0
  */
@@ -588,7 +588,7 @@ function gmp_xor ($a, $b) {}
 /**
  * Set bit
  * @link https://php.net/manual/en/function.gmp-setbit.php
- * @param resource|string $a <p>
+ * @param resource|string|GMP $a <p>
  * The number being set to.
  * </p>
  * It can be either a GMP number resource, or a
@@ -622,7 +622,7 @@ function gmp_clrbit (&$a, $index) {}
 /**
  * Scan for 0
  * @link https://php.net/manual/en/function.gmp-scan0.php
- * @param resource|string $a <p>
+ * @param resource|string|GMP $a <p>
  * The number to scan.
  * </p>
  * It can be either a GMP number resource, or a
@@ -640,7 +640,7 @@ function gmp_scan0 ($a, $start) {}
 /**
  * Scan for 1
  * @link https://php.net/manual/en/function.gmp-scan1.php
- * @param resource|string $a <p>
+ * @param resource|string|GMP $a <p>
  * The number to scan.
  * </p>
  * It can be either a GMP number resource, or a
@@ -671,7 +671,7 @@ function gmp_testbit ($a, $index) {}
 /**
  * Population count
  * @link https://php.net/manual/en/function.gmp-popcount.php
- * @param resource|string $a It can be either a GMP number resource, or a
+ * @param resource|string|GMP $a It can be either a GMP number resource, or a
  * numeric string given that it is possible to convert the latter to a number.</p>
  * @return int The population count of <i>a</i>, as an integer.
  * @since 4.0.4
@@ -748,7 +748,7 @@ function gmp_rootrem (GMP $a, $nth) {}
 /**
  * Find next prime number
  * @link https://php.net/manual/en/function.gmp-nextprime.php
- * @param resource|string $a It can be either a GMP number resource, or a
+ * @param resource|string|GMP $a It can be either a GMP number resource, or a
  * numeric string given that it is possible to convert the latter to a number.</p>
  * @return resource Return the next prime number greater than <i>a</i>,
  * as a GMP number.


### PR DESCRIPTION
GMP transitioned to objects in PHP 5.6, which was not reflected by the stub, causing false positives wherever it was used.