### PR TITLE
Add ext-rdkafka missing timestamp on Message

### DIFF
--- a/rdkafka/RdKafka/Message.php
+++ b/rdkafka/RdKafka/Message.php
@@ -17,6 +17,11 @@ class Message
     /**
      * @var int
      */
+    public $timestamp;
+
+    /**
+     * @var int
+     */
     public $partition;
 
     /**


### PR DESCRIPTION
Ran into this today, thought this was already on the stub, found out it wasn't so PRing it to be added.