### PR TITLE
fixing __soapCall() method signature

### DIFF
--- a/soap/soap.php
+++ b/soap/soap.php
@@ -311,7 +311,7 @@ class SoapClient  {
 	 * option set to <b>FALSE</b>, a SoapFault object will be returned.
 	 * @since 5.0.1
 	 */
-	public function __soapCall ($function_name, array $arguments, array $options = null, $input_headers = null, array &$output_headers = null) {}
+	public function __soapCall ($function_name, $arguments, $options = null, $input_headers = null, &$output_headers = null) {}
 
 	/**
 	 * Returns last SOAP request


### PR DESCRIPTION
Storm complains when the correct method signature is in place. Using the stub's signature throws a warning in the `error_log`, so I updated the method signature.

Please see https://youtrack.jetbrains.com/issue/WI-47198 