### PR TITLE
Fix default curl_multi_select() value

### DIFF
--- a/curl/curl.php
+++ b/curl/curl.php
@@ -2400,7 +2400,7 @@ function curl_multi_remove_handle ($mh, $ch) {}
  * the descriptor sets. On failure, this function will return -1 on a select failure or timeout (from the underlying select system call).
  * @since 5.0
  */
-function curl_multi_select ($mh, $timeout = null) {}
+function curl_multi_select ($mh, $timeout = 1.0) {}
 
 /**
  * (PHP 5 &gt;=5.5.0)<br/>


### PR DESCRIPTION
According to [the docs](https://www.php.net/manual/en/function.curl-multi-select.php), the second parameter has a default value of `1.0`.