### PR TITLE
Fix return types of DateTimeImmutable methods

### DIFF
--- a/date/date_c.php
+++ b/date/date_c.php
@@ -115,7 +115,7 @@ class DateTimeImmutable implements DateTimeInterface {
      * (PHP 5 &gt;=5.5.0)<br/>
      * Adds an amount of days, months, years, hours, minutes and seconds
      * @param DateInterval $interval
-     * @return static
+     * @return \DateTimeImmutable
      */
     public function add(DateInterval $interval) { }
 
@@ -153,7 +153,7 @@ class DateTimeImmutable implements DateTimeInterface {
      * @link https://secure.php.net/manual/en/datetimeimmutable.modify.php
      * @param string $modify  <p>A date/time string. Valid formats are explained in
      * {@link https://secure.php.net/manual/en/datetime.formats.php Date and Time Formats}.</p>
-     * @return static
+     * @return DateTimeImmutable|False
      * Returns the {@link https://secure.php.net/manual/en/class.datetimeimmutable.php DateTimeImmutable} object for method chaining or <b>FALSE</b> on failure.
      */
 
@@ -176,7 +176,7 @@ class DateTimeImmutable implements DateTimeInterface {
      * @param int $year <p>Year of the date.</p>
      * @param int $month <p>Month of the date.</p>
      * @param int $day <p>Day of the date.</p>
-     * @return static|false
+     * @return \DateTimeImmutable|false
      * Returns the {@link https://secure.php.net/manual/en/class.datetimeimmutable.php DateTimeImmutable} object for method chaining or <b>FALSE</b> on failure.
      *
      */
@@ -189,7 +189,7 @@ class DateTimeImmutable implements DateTimeInterface {
      * @param int $year <p>Year of the date.</p>
      * @param int $week  <p>Week of the date.</p>
      * @param int $day [optional] <p>Offset from the first day of the week.</p>
-     * @return static|false
+     * @return \DateTimeImmutable|false
      * Returns the {@link https://secure.php.net/manual/en/class.datetimeimmutable.php DateTimeImmutable} object for method chaining or <b>FALSE</b> on failure.
      */
     public function setISODate($year, $week, $day = 1) { }
@@ -202,7 +202,7 @@ class DateTimeImmutable implements DateTimeInterface {
      * @param int $minute <p> Minute of the time. </p>
      * @param int $second [optional] <p> Second of the time. </p>
      * @param int $microseconds [optional] <p> Microseconds of the time. </p>
-     * @return static|false
+     * @return \DateTimeImmutable|false
      * @since 7.1.0 $microseconds parameter added.
      * Returns the {@link https://secure.php.net/manual/en/class.datetimeimmutable.php DateTimeImmutable} object for method chaining or <b>FALSE</b> on failure.
      */
@@ -213,7 +213,7 @@ class DateTimeImmutable implements DateTimeInterface {
      * Sets the date and time based on an Unix timestamp
      * @link https://secure.php.net/manual/en/datetimeimmutable.settimestamp.php
      * @param int $unixtimestamp <p>Unix timestamp representing the date.</p>
-     * @return static|false
+     * @return \DateTimeImmutable|false
      * Returns the {@link https://secure.php.net/manual/en/class.datetimeimmutable.php DateTimeImmutable} object for method chaining or <b>FALSE</b> on failure.
      */
     public function setTimestamp($unixtimestamp) { }
@@ -226,7 +226,7 @@ class DateTimeImmutable implements DateTimeInterface {
      * A {@link https://secure.php.net/manual/en/class.datetimezone.php DateTimeZone} object representing the
      * desired time zone.
      * </p>
-     * @return static|false
+     * @return \DateTimeImmutable|false
      * Returns the {@link https://secure.php.net/manual/en/class.datetimeimmutable.php DateTimeImmutable} object for method chaining or <b>FALSE</b> on failure.
      */
     public function setTimezone(DateTimeZone $timezone) { }
@@ -238,7 +238,7 @@ class DateTimeImmutable implements DateTimeInterface {
      * @param DateInterval $interval <p>
      * A {@link https://secure.php.net/manual/en/class.dateinterval.php DateInterval} object
      * </p>
-     * @return static|false
+     * @return \DateTimeImmutable|false
      * Returns the {@link https://secure.php.net/manual/en/class.datetimeimmutable.php DateTimeImmutable} object for method chaining or <b>FALSE</b> on failure.
      */
     public function sub(DateInterval $interval) { }


### PR DESCRIPTION
Change the return types of several methods of the DateTimeImmutable class. Most of these methods currently use `static` as return type hint, which does not work well when chaining several method calls on a DateTimeImmultable instance.

In case this PR is indeed the proper way to fix this problem, then the same fix could be applied to the DateTime class. It displays the same problem. I can extend the PR if desired.