### PR TITLE
Specify that DOMNodeList::item() indexes are 0-based

### DIFF
--- a/dom/dom_c.php
+++ b/dom/dom_c.php
@@ -1146,6 +1146,7 @@ class DOMNodeList implements Traversable, Countable {
 	 * @link https://php.net/manual/en/domnodelist.item.php
 	 * @param int $index <p>
 	 * Index of the node into the collection.
+	 * The range of valid child node indices is 0 to length - 1 inclusive.
 	 * </p>
 	 * @return DOMNode|null The node at the indexth position in the
 	 * DOMNodeList, or &null; if that is not a valid


### PR DESCRIPTION
Although this is not specified on the `item()` documentation page itself, it is specified here:

https://www.php.net/manual/en/class.domnodelist.php

> length
> The number of nodes in the list. The range of valid child node indices is 0 to length - 1 inclusive.

It's important that it's part of the `item()` doc IMO. I was myself looking for this information just now.