### PR TITLE
Grpc\ChannelCredentials::createSsl() has all optional parameters.

### DIFF
--- a/grpc/grpc.php
+++ b/grpc/grpc.php
@@ -513,7 +513,7 @@ namespace Grpc
          * @throws \InvalidArgumentException
          */
         public static function createSsl(
-            $pem_root_certs,
+            $pem_root_certs = '',
             $pem_private_key = '',
             $pem_cert_chain = ''
         ) {}


### PR DESCRIPTION
The first parameter of `Grpc\ChannelCredentials::createSsl` is currently required according to the stubs but this conflicts with the grpc extension.

If you look at the reflection information using something like:
```php
<?php
use Grpc\ChannelCredentials;
$method = new \ReflectionMethod(
    ChannelCredentials::class,
    "createSsl"
);
foreach ($method->getParameters() as $parameter) {
    $attr = $parameter->isOptional()
        ? ' (optional)'
        : '';

    printf("%s\n", $parameter->getName() . $attr);
}
```

All parameters are marked as optional.
```
pem_root_certs (optional)
pem_private_key (optional)
pem_cert_chain (optional)
```

You can also see that in the source, of course.
https://github.com/grpc/grpc/blob/99af46ca647efa10581c08579d13101fe30e1345/src/php/ext/grpc/channel_credentials.c#L135-L136
