### PR TITLE
Fixed stub for socket_export_stream function

### DIFF
--- a/sockets/sockets.php
+++ b/sockets/sockets.php
@@ -196,6 +196,7 @@ function socket_create ($domain, $type, $protocol) {}
 
 /**
  * @param resource $socket
+ * @return resource
  */
 function socket_export_stream($socket) {}
 


### PR DESCRIPTION
When you import this function using
```php
use function socket_export_stream;
```
PhpStorm says this:
![изображение](https://user-images.githubusercontent.com/13465245/62683104-59a29080-b9c6-11e9-981d-71acb3465447.png)
