### PR TITLE
[mongodb] Fix CommandStartedEvent::getCommand() return type

### DIFF
--- a/mongodb/mongodb.php
+++ b/mongodb/mongodb.php
@@ -1551,7 +1551,7 @@ namespace MongoDB {}
              * Returns the command document
              * The reply document will be converted from BSON to PHP using the default deserialization rules (e.g. BSON documents will be converted to stdClass).
              * @link   https://secure.php.net/manual/en/mongodb-driver-monitoring-commandstartedevent.getcommand.php
-             * @return string the command document as a stdClass object.
+             * @return object the command document as a stdClass object.
              * @throws \InvalidArgumentException on argument parsing errors.
              * @since 1.3.0
              */


### PR DESCRIPTION
According to https://www.php.net/manual/en/mongodb-driver-monitoring-commandstartedevent.getcommand.php, it returns an object