### PR TITLE
 Support for typed properties in ReflectionProperty

### DIFF
--- a/Reflection/Reflection.php
+++ b/Reflection/Reflection.php
@@ -1599,7 +1599,7 @@ class ReflectionProperty implements Reflector {
 
 	/**
 	 * Gets property type
-	 * @return ReflectionNamedType|null
+	 * @return ReflectionType|null
 	 * @since 7.4.0
 	 */
 	public function getType() {}

--- a/Reflection/Reflection.php
+++ b/Reflection/Reflection.php
@@ -1597,6 +1597,29 @@ class ReflectionProperty implements Reflector {
 	 */
 	public function setAccessible ($accessible) {}
 
+	/**
+	 * Gets property type
+	 * @return ReflectionNamedType|null
+	 * @since 7.4.0
+	 */
+	public function getType() {}
+
+	/**
+	 * Checks if property has type
+	 * @return bool
+	 * @since 7.4.0
+	 */
+	public function hasType() {}
+
+	/**
+	 * Checks if property is initialized
+	 * @param object $object [optional]<p>
+	 * If the property is non-static an object must be provided.
+	 * </p>
+	 * @return bool
+	 * @since 7.4.0
+	 */
+	public function isInitialized ($object) {}
 }
 
 /**


### PR DESCRIPTION
The [typed properties RFC](https://wiki.php.net/rfc/typed_properties_v2) (accepted, implemented in PHP 7.4.0, currently beta2) introduces 3 new reflection methods:

```php
class ReflectionProperty {
    // ...
 
    public function getType(): ?ReflectionType;
    public function hasType(): bool;
    public function isInitialized([object $object]): bool;
}
```

Even though these are not in the PHP manual yet, they will be soon, and it would be nice to get PHPStorm support right now.

Test script:

```php
class Test {
    public $foo;
    public int $bar;
}

$test = new Test;

$foo = new ReflectionProperty('Test', 'foo');
var_export($foo->hasType()); // false
var_export($foo->getType()); // NULL
var_export($foo->isInitialized($test)); // true

$bar = new ReflectionProperty('Test', 'bar');
var_export($bar->hasType()); // true
echo get_class($bar->getType()); // ReflectionNamedType
var_export($bar->isInitialized($test)); // false
```