### PR TITLE
Add missing Rdkafka\Message::$len property

### DIFF
--- a/rdkafka/RdKafka/Message.php
+++ b/rdkafka/RdKafka/Message.php
@@ -28,6 +28,11 @@ class Message
      * @var string
      */
     public $payload;
+    
+    /**
+     * @var int
+     */
+    public $len;
 
     /**
      * @var string


### PR DESCRIPTION
Source code that proves that this property exists:

- https://github.com/arnaud-lb/php-rdkafka/blob/546e17eb04ae6/message.c#L157
- https://github.com/arnaud-lb/php-rdkafka/blob/546e17eb04ae6/message.c#L63