### PR TITLE
sha1/md5 default values

### DIFF
--- a/standard/standard_0.php
+++ b/standard/standard_0.php
@@ -745,7 +745,7 @@ function get_html_translation_table ($table = null, $quote_style = null, string 
  * @since 4.3.0
  * @since 5.0
  */
-function sha1 ($str, $raw_output = null) {}
+function sha1 ($str, $raw_output = false) {}
 
 /**
  * Calculate the sha1 hash of a file
@@ -761,7 +761,7 @@ function sha1 ($str, $raw_output = null) {}
  * @since 4.3.0
  * @since 5.0
  */
-function sha1_file ($filename, $raw_output = null) {}
+function sha1_file ($filename, $raw_output = false) {}
 
 /**
  * Calculate the md5 hash of a string
@@ -778,7 +778,7 @@ function sha1_file ($filename, $raw_output = null) {}
  * @since 4.0
  * @since 5.0
  */
-function md5 ($str, $raw_output = null) {}
+function md5 ($str, $raw_output = false) {}
 
 /**
  * Calculates the md5 hash of a given file
@@ -794,7 +794,7 @@ function md5 ($str, $raw_output = null) {}
  * @since 4.2.0
  * @since 5.0
  */
-function md5_file ($filename, $raw_output = null) {}
+function md5_file ($filename, $raw_output = false) {}
 
 /**
  * Calculates the crc32 polynomial of a string


### PR DESCRIPTION
value of `$raw_output` is `false` by default

https://github.com/php/php-src/blob/master/ext/standard/sha1.c#L40-L44