### PR TITLE
Updating default value of intval 2nd parameter

### DIFF
--- a/standard/standard_5.php
+++ b/standard/standard_5.php
@@ -37,7 +37,7 @@ function boolval($var) {}
  * @since 4.0
  * @since 5.0
  */
-function intval ($var, $base = null) {}
+function intval ($var, $base = 10) {}
 
 /**
  * Get float value of a variable


### PR DESCRIPTION
The default of the second parameter of intval was always 10.
Documentation:
https://www.php.net/manual/en/function.intval.php

Example: 
https://3v4l.org/qj37f