### PR TITLE
add @throws to the mongodb

### DIFF
--- a/mongodb/mongodb.php
+++ b/mongodb/mongodb.php
@@ -55,6 +55,11 @@ namespace MongoDB {}
              * @param BulkWrite $bulk The MongoDB\Driver\BulkWrite to execute.
              * @param array|WriteConcern $options WriteConcern type for backwards compatibility
              * @return WriteResult
+             * @throws InvalidArgumentException on argument parsing errors.
+             * @throws ConnectionException if connection to the server fails for other then authentication reasons
+             * @throws AuthenticationException if authentication is needed and fails             
+             * @throws BulkWriteException on any write failure 
+             * @throws RuntimeException on other errors (invalid command, command arguments, ...)
              * @since 1.4.0 added $options argument
              */
             final public function executeBulkWrite($namespace, BulkWrite $bulk, $options = [])


### PR DESCRIPTION
adding @throws to the mongodb/Manager::executeBulkWrite

According to docs this method actually throws exceptions
https://www.php.net/manual/en/mongodb-driver-manager.executebulkwrite.php