### PR TITLE
Update - Stubs: Out of date definition for E_ALL.

### DIFF
--- a/Core/Core.php
+++ b/Core/Core.php
@@ -243,7 +243,7 @@ function each (array &$array) {}
  * </td>
  * </tr>
  * <tr valign="top">
- * <td>6143</td>
+ * <td>32767</td>
  * <td>
  * E_ALL
  * </td>
@@ -866,7 +866,11 @@ function get_extension_funcs ($module_name) {}
  * [E_USER_ERROR] => 256
  * [E_USER_WARNING] => 512
  * [E_USER_NOTICE] => 1024
- * [E_ALL] => 2047
+ * [E_STRICT] => 2048
+ * [E_RECOVERABLE_ERROR] => 4096
+ * [E_DEPRECATED] => 8192
+ * [E_USER_DEPRECATED] => 16384
+ * [E_ALL] => 32767
  * [TRUE] => 1
  * )
  * [pcre] => Array

--- a/Core/Core_d.php
+++ b/Core/Core_d.php
@@ -123,9 +123,11 @@ define ('E_USER_DEPRECATED', 16384);
 /**
  * All errors and warnings, as supported, except of level
  * <b>E_STRICT</b> prior to PHP 5.4.0.
+ * Value of <b>E_ALL</b> is 32767 since PHP 5.4.x,
+ * 30719 in PHP 5.3.x, 6143 in PHP 5.2.x, 2047 previously
  * @link https://php.net/manual/en/errorfunc.constants.php
  */
-define ('E_ALL', 30719);
+define ('E_ALL', 32767);
 define ('DEBUG_BACKTRACE_PROVIDE_OBJECT', 1);
 define ('DEBUG_BACKTRACE_IGNORE_ARGS', 2);
 define ('S_MEMORY', 1);

--- a/tests/TestData/mutedProblems.json
+++ b/tests/TestData/mutedProblems.json
@@ -1,12 +1,6 @@
 {
   "constants": [
     {
-      "name": "E_ALL",
-      "problems": [
-        "wrong value"
-      ]
-    },
-    {
       "name": "DEBUG_BACKTRACE_PROVIDE_OBJECT",
       "problems": [
         "wrong value"


### PR DESCRIPTION
Updates the value for E_ALL, multiple places. Adds others to the list a for `get_defined_constants()`.

Closes WI-39737