### PR TITLE
Fix SoapVar::__construct $encoding type

### DIFF
--- a/soap/soap.php
+++ b/soap/soap.php
@@ -446,7 +446,7 @@ class SoapVar  {
 	 * @param mixed $data <p>
 	 * The data to pass or return.
 	 * </p>
-	 * @param string $encoding <p>
+	 * @param string|int $encoding <p>
 	 * The encoding ID, one of the XSD_... constants.
 	 * </p>
 	 * @param string $type_name [optional] <p>


### PR DESCRIPTION
Hi,

[Manual](https://www.php.net/manual/en/soapvar.soapvar.php) describe $encoding as:

> The encoding ID, one of the XSD_... constants.

According to https://www.php.net/manual/fr/soap.constants.php

All XSD constants types are integer.

However, the value of XSD_NAMESPACE and XSD_1999_NAMESPACE are respectively http://www.w3.org/2001/XMLSchema and http://www.w3.org/1999/XMLSchema which contradicts the manual because such value can't be stored in integers

What's strange is that the [Manual](https://www.php.net/manual/en/soapvar.soapvar.php) says that $encoding is string only.

It should be string|int at the very least.

Thanks