### PR TITLE
Change entity to real char to avoid breaking type resolution

### DIFF
--- a/standard/standard_1.php
+++ b/standard/standard_1.php
@@ -452,8 +452,8 @@ function strpbrk ($haystack, $char_list) {}
  * If case_insensitivity is true, comparison is
  * case insensitive.
  * </p>
- * @return int &lt; 0 if main_str from position
- * offset is less than str, &gt;
+ * @return int < 0 if main_str from position
+ * offset is less than str, >
  * 0 if it is greater than str, and 0 if they are equal.
  * If offset is equal to or greater than the length of
  * main_str or length is set and


### PR DESCRIPTION
Hi,

The ```&lt;``` entity after return type is breaking the phpstorm resolver:
![Capture](https://user-images.githubusercontent.com/9605520/70643513-6881a400-1c41-11ea-8f71-389d3e5d7249.PNG)

Not sure if it's the right way to go as I'm not sure why there are entities and what'd happen if we remove them.

There are other functions where this is the case too (for example, strcoll), If this commit is validated, I'll modify the others