### PR TITLE
array_reduce fix return override

### DIFF
--- a/meta/.phpstorm.meta.php
+++ b/meta/.phpstorm.meta.php
@@ -46,7 +46,7 @@ namespace PHPSTORM_META {
   override(\array_shift(0), elementType(0));
   override(\array_reverse(0), type(0));
   override(\array_pop(0), elementType(0));
-  override(\array_reduce(0), elementType(0));
+  override(\array_reduce(0), type(2));
   override(\array_slice(0), type(0));
   override(\array_diff(0), type(0));
   override(\array_diff_assoc(0), type(0));


### PR DESCRIPTION
`elementType(0)` have no connection with returned value, last parameter *should* be correct return type if present.

https://www.php.net/manual/en/function.array-reduce.php