### PR TITLE
Annotate PSR-14 Event Dispatcher

### DIFF
--- a/meta/.phpstorm.meta.php
+++ b/meta/.phpstorm.meta.php
@@ -87,6 +87,7 @@ namespace PHPSTORM_META {
   override(\DOMNode::insertBefore(0), type(0));
   override(\DOMNode::removeChild(0), type(0));
   override(\DOMNode::replaceChild(0), type(1));
+  override(\Psr\EventDispatcher\EventDispatcherInterface::dispatch(0), type(0));
 
     function expectedArguments($functionReference, $argumentIndex, $values) {
         return "expectedArguments " . $functionReference . "at " . $argumentIndex . ": " . $values;


### PR DESCRIPTION
The `EventDispatcherInterface` returns the same object as it was passed. https://github.com/php-fig/event-dispatcher/blob/master/src/EventDispatcherInterface.php#L18

This makes it possible to get type completion in scenarios like this.

```php
$event = $eventDispatcher->dispatch(new MyEvent());
$event->callSomeMethodOnMyEvent();
```