### PR TITLE
curl_file_create optional parameters

### DIFF
--- a/curl/curl.php
+++ b/curl/curl.php
@@ -13,7 +13,7 @@ class CURLFile {
      * @param string $postname [optional] <p>Name of the file.</p>
      * @since 5.5
      */
-    function __construct($filename, $mimetype, $postname) {
+    function __construct($filename, $mimetype = '', $postname = '') {
     }
 
     /**
@@ -2348,7 +2348,7 @@ function curl_escape($ch, $str) {}
  * Returns a {@link https://secure.php.net/manual/en/class.curlfile.php CURLFile} object.
  * @since 5.5
  */
-function curl_file_create($filename, $mimetype, $postname) {}
+function curl_file_create($filename, $mimetype = '', $postname = '') {}
 
 /**
  * Close a cURL session


### PR DESCRIPTION
Fix optional parameters in `CURLFile::__construct` and `curl_file_create`

https://github.com/php/php-src/blob/94938934127c43b02b23c95de99e4a08aa194122/ext/curl/curl_file.c#L36-L41
https://github.com/php/php-src/blob/86675dd3f90f1b807aacba1a5e6fe5e39f15da32/ext/curl/interface.c#L2660-L2667