### PR TITLE
Fix false for return.

### DIFF
--- a/Core/Core.php
+++ b/Core/Core.php
@@ -329,7 +329,7 @@ function defined ($name) {}
  * @param object $object [optional] <p>
  * The tested object. This parameter may be omitted when inside a class.
  * </p>
- * @return string the name of the class of which <i>object</i> is an
+ * @return string|false <p>The name of the class of which <i>object</i> is an
  * instance. Returns false if <i>object</i> is not an
  * object.
  * </p>
@@ -344,7 +344,7 @@ function get_class ($object = null) {}
 /**
  * the "Late Static Binding" class name
  * @link https://php.net/manual/en/function.get-called-class.php
- * @return string the class name. Returns false if called from outside a class.
+ * @return string|false The class name. Returns false if called from outside a class.
  * @since 5.3
  */
 function get_called_class () {}
@@ -352,10 +352,10 @@ function get_called_class () {}
 /**
  * Retrieves the parent class name for object or class
  * @link https://php.net/manual/en/function.get-parent-class.php
- * @param mixed $object [optional] <p>
+ * @param object|string|null $object [optional] <p>
  * The tested object or class name
  * </p>
- * @return string the name of the parent class of the class of which
+ * @return string|false <p>The name of the parent class of the class of which
  * <i>object</i> is an instance or the name.
  * </p>
  * <p>
@@ -371,7 +371,7 @@ function get_parent_class ($object = null) {}
 /**
  * Checks if the class method exists
  * @link https://php.net/manual/en/function.method-exists.php
- * @param mixed $object <p>
+ * @param object|string $object <p>
  * An object instance or a class name
  * </p>
  * @param string $method_name <p>

--- a/Core/Core.php
+++ b/Core/Core.php
@@ -352,7 +352,7 @@ function get_called_class () {}
 /**
  * Retrieves the parent class name for object or class
  * @link https://php.net/manual/en/function.get-parent-class.php
- * @param object|string|null $object [optional] <p>
+ * @param mixed $object [optional] <p>
  * The tested object or class name
  * </p>
  * @return string|false <p>The name of the parent class of the class of which
@@ -371,7 +371,7 @@ function get_parent_class ($object = null) {}
 /**
  * Checks if the class method exists
  * @link https://php.net/manual/en/function.method-exists.php
- * @param object|string $object <p>
+ * @param mixed $object <p>
  * An object instance or a class name
  * </p>
  * @param string $method_name <p>


### PR DESCRIPTION
Refs https://youtrack.jetbrains.com/issue/WI-50517

I don't like this `<p>` stuff in the docblock lines - maybe the can be removed in follow up PRs.
But since they close with `</p>` already, they should also correctly open (so I added those, too).
