### PR TITLE
[WIP] Fix imagick method names to lowercase as they are defined in code and PHP reflection

### DIFF
--- a/imagick/imagick.php
+++ b/imagick/imagick.php
@@ -1809,7 +1809,7 @@ class Imagick implements Iterator, Countable {
 	 * @return bool <b>TRUE</b> on success.
 	 * @throws ImagickException Throws ImagickException on error.
 	 */
-	public function readImageBlob ($image, $filename = null) {}
+	public function readimageblob ($image, $filename = null) {}
 
 	/**
 	 * (PECL imagick 2.0.0)<br/>


### PR DESCRIPTION
I have found out that there is disparity in method name case in:

* code - uses `readimageblob`
* PHP reflection - `readimageblob`
* PHP documentation - `readImageBlob` - https://www.php.net/manual/en/imagick.readimageblob.php
* these stubs - `readImageBlob`

I am using just this one method for now to avoid changing everything in case it is decided against it. I can change all the methods if we agree on this.

So as can be seen above these stubs are probably based on documentation, but according to the the authors of the extension https://bugs.php.net/bug.php?id=73766, the **all-lowercase** variant is actually correct (at least for now).

There aim is apparently to change this for Imagick extension v4: https://github.com/Imagick/imagick/issues/211 but I think it cannot be said definitely if that is the case and if so, then when this change will occur.

**So the main question is whether these stubs are trying to match the actual code or the documentation. Ideally there should be no such question, but there is :) And since the php.net bug mentioned above is currently listed as documentation bug I think it should be changed to lowercase here as well to reflect reality (and eventually change it in the future if/when it changes).**

---

Context: PHPStan started using these stubs for analysis of methods from extensions (when the extension is not loaded). In the [strict rules](https://github.com/phpstan/phpstan-strict-rules) you can enable checking for that method calls have correct name case - you can see that for example here it says https://phpstan.org/r/fbc488cb-1af6-4bd9-9b5f-47877cc65f89 is correct (because it uses information from this repository). But when you have the extension actually installed it would report it as incorrect (and vice versa https://phpstan.org/r/3dd45dcd-3ffc-469b-b9c3-8f6c51504989)