### PR TITLE
Fix invalid defaulting.

### DIFF
--- a/standard/standard_1.php
+++ b/standard/standard_1.php
@@ -260,7 +260,7 @@ function dirname ($path, $levels = 1) {}
  * extension (if any), and filename.
  * </p>
  * <p>
- * If options is used, this function will return a 
+ * If options is used, this function will return a
  * string if not all elements are requested.
  * @since 4.0.3
  * @since 5.0
@@ -741,7 +741,7 @@ function addslashes ($str) {}
  * t and v. They will be converted to \0, \a, \b, \f, \n, \r, \t
  * and \v.
  * In PHP \0 (NULL), \r (carriage return), \n (newline), \f (form feed),
- * \v (vertical tab) and \t (tab) are predefined escape sequences, 
+ * \v (vertical tab) and \t (tab) are predefined escape sequences,
  * while in C all of these are predefined escape sequences.
  * </p>
  * @return string the escaped string.
@@ -816,7 +816,7 @@ function str_replace ($search, $replace, $subject, &$count = null) {}
  * </p>
  * @param mixed $subject <p>
  * If subject is an array, then the search and
- * replace is performed with every entry of 
+ * replace is performed with every entry of
  * subject, and the return value is an array as
  * well.
  * </p>
@@ -976,7 +976,7 @@ function strip_tags ($str, $allowable_tags = null) {}
  * @param float $percent [optional] <p>
  * By passing a reference as third argument,
  * similar_text will calculate the similarity in
- * percent for you. 
+ * percent for you.
  * </p>
  * @return int the number of matching chars in both strings.
  * @since 4.0
@@ -1025,7 +1025,7 @@ function explode ($delimiter, $string, $limit = null) {}
  * implode as glue would be
  * the second parameter and thus, the bad prototype would be used.
  * </p>
- * @param array $pieces <p>
+ * @param string[] $pieces <p>
  * The array of strings to implode.
  * </p>
  * @return string a string containing a string representation of all the array
@@ -1033,7 +1033,7 @@ function explode ($delimiter, $string, $limit = null) {}
  * @since 4.0
  * @since 5.0
  */
-function implode ($glue = "", array $pieces) {}
+function implode ($glue, array $pieces) {}
 
 /**
  * &Alias; <function>implode</function>
@@ -1043,7 +1043,7 @@ function implode ($glue = "", array $pieces) {}
  * implode as glue would be
  * the second parameter and thus, the bad prototype would be used.
  * </p>
- * @param array $pieces <p>
+ * @param string[] $pieces <p>
  * The array of strings to implode.
  * </p>
  * @return string a string containing a string representation of all the array
@@ -1051,7 +1051,7 @@ function implode ($glue = "", array $pieces) {}
  * @since 4.0
  * @since 5.0
  */
-function join ($glue = "", $pieces) {}
+function join ($glue, $pieces) {}
 
 /**
  * Set locale information
@@ -1107,7 +1107,7 @@ function join ($glue = "", $pieces) {}
  * different names on different systems or for providing a fallback
  * for a possibly not available locale.
  * </p>
- * @param string $_ [optional] 
+ * @param string $_ [optional]
  * @return string|false the new current locale, or false if the locale functionality is
  * not implemented on your platform, the specified locale does not exist or
  * the category name is invalid.


### PR DESCRIPTION
Follow https://github.com/JetBrains/phpstorm-stubs/pull/728

Using no argument is actually not valid

> Warning</b>:  implode() expects at least 1 parameter, 0 given

It is also already warning in yellow in PHPStorm IDE as code smell:
![Tooltip_001](https://user-images.githubusercontent.com/39854/72522494-265e0a80-385e-11ea-816d-33c061f3147c.png)
