### PR TITLE
Add false return type to saveXML

### DIFF
--- a/dom/dom_c.php
+++ b/dom/dom_c.php
@@ -895,7 +895,7 @@ class DOMDocument extends DOMNode  {
      * @param int $options [optional] <p>
      * Additional Options. Currently only LIBXML_NOEMPTYTAG is supported.
      * </p>
-     * @return string the XML, or false if an error occurred.
+     * @return string|false the XML, or false if an error occurred.
      */
     public function saveXML (DOMNode $node = null , $options = null) {}
 


### PR DESCRIPTION
The return description of `saveXML` explains that false can be returned if an error occured, but the actual return type did not yet include false.