### PR TITLE
Correct \Phar::decompress() return data type

### DIFF
--- a/Phar/Phar.php
+++ b/Phar/Phar.php
@@ -167,7 +167,7 @@ class Phar extends RecursiveDirectoryIterator implements RecursiveIterator, Seek
 	 * compressing tar archives. For decompressing, the default file extensions
 	 * are .phar and .phar.tar.
 	 * </p>
-	 * @return object a <b>Phar</b> object.
+	 * @return Phar a <b>Phar</b> object.
 	 */
 	public function compress ($compression, $extension = null) {}
 
@@ -182,7 +182,7 @@ class Phar extends RecursiveDirectoryIterator implements RecursiveIterator, Seek
 	 * that all executable phar archives must contain .phar
 	 * in their filename.
 	 * </p>
-	 * @return object A <b>Phar</b> object is returned.
+	 * @return Phar A <b>Phar</b> object is returned.
 	 */
 	public function decompress ($extension = null) {}
 


### PR DESCRIPTION
Correct `\Phar::compress()`, `\Phar::decompress()`, `\PharData::compress()` and `\PharData::decompress()` return data type.

Fix https://youtrack.jetbrains.com/issue/WI-50953