### PR TITLE
Stubs for ext-decimal 1.3.0

### DIFF
--- a/PhpStormStubsMap.php
+++ b/PhpStormStubsMap.php
@@ -254,6 +254,7 @@ const CLASSES = array (
   'DateTimeImmutable' => 'date/date_c.php',
   'DateTimeInterface' => 'date/date_c.php',
   'DateTimeZone' => 'date/date_c.php',
+  'Decimal\\Decimal' => 'decimal/decimal.php',
   'Directory' => 'standard/standard_0.php',
   'DirectoryIterator' => 'SPL/SPL_c1.php',
   'DivisionByZeroError' => 'Core/Core_c.php',

--- a/decimal/decimal.php
+++ b/decimal/decimal.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Decimal {
 
+    use ArithmeticError;
+    use DivisionByZeroError;
     use Traversable;
     use TypeError;
 
@@ -44,7 +46,7 @@ namespace Decimal {
          *
          * @throws TypeError
          *
-         * @link http://php-decimal.io/#add
+         * @link https://php-decimal.io/#add
          */
         public function add($value): Decimal { }
 
@@ -57,7 +59,7 @@ namespace Decimal {
          *
          * @throws TypeError
          *
-         * @link http://php-decimal.io/#sub
+         * @link https://php-decimal.io/#sub
          */
         public function sub($value): Decimal { }
 
@@ -70,7 +72,7 @@ namespace Decimal {
          *
          * @throws TypeError
          *
-         * @link http://php-decimal.io/#mul
+         * @link https://php-decimal.io/#mul
          */
         public function mul($value): Decimal { }
 
@@ -83,7 +85,7 @@ namespace Decimal {
          *
          * @throws TypeError
          *
-         * @link http://php-decimal.io/#div
+         * @link https://php-decimal.io/#div
          */
         public function div($value): Decimal { }
 
@@ -98,7 +100,7 @@ namespace Decimal {
          * @throws DivisionByZeroError
          * @throws ArithmeticError
          *
-         * @link http://php-decimal.io/#mod
+         * @link https://php-decimal.io/#mod
          */
         public function mod($value): Decimal { }
 
@@ -111,7 +113,7 @@ namespace Decimal {
          *
          * @throws TypeError
          *
-         * @link http://php-decimal.io/#pow
+         * @link https://php-decimal.io/#pow
          */
         public function pow($value): Decimal { }
 
@@ -124,7 +126,7 @@ namespace Decimal {
          * @throws DivisionByZeroError
          * @throws ArithmeticError
          *
-         * @link http://php-decimal.io/#rem
+         * @link https://php-decimal.io/#rem
          */
         public function rem($value): Decimal { }
 
@@ -133,7 +135,7 @@ namespace Decimal {
          *
          * @return Decimal
          *
-         * @link http://php-decimal.io/#ln
+         * @link https://php-decimal.io/#ln
          */
         public function ln(): Decimal { }
 
@@ -142,28 +144,28 @@ namespace Decimal {
          *
          * @return Decimal
          *
-         * @link http://php-decimal.io/#ln
+         * @link https://php-decimal.io/#ln
          */
         public function log(): Decimal { }
 
         /**
          * @return Decimal
          *
-         * @link http://php-decimal.io/#exp
+         * @link https://php-decimal.io/#exp
          */
         public function exp(): Decimal { }
 
         /**
          * @return Decimal
          *
-         * @link http://php-decimal.io/#log10
+         * @link https://php-decimal.io/#log10
          */
         public function log10(): Decimal { }
 
         /**
          * @return Decimal
          *
-         * @link http://php-decimal.io/#sqrt
+         * @link https://php-decimal.io/#sqrt
          */
         public function sqrt(): Decimal { }
 
@@ -177,7 +179,7 @@ namespace Decimal {
          *
          * @return Decimal
          *
-         * @link http://php-decimal.io/#round
+         * @link https://php-decimal.io/#round
          */
         public function round(int $places = 0, int $mode = Decimal::ROUND_HALF_EVEN): Decimal { }
 
@@ -186,7 +188,7 @@ namespace Decimal {
          *
          * @return Decimal
          *
-         * @link http://php-decimal.io/#floor
+         * @link https://php-decimal.io/#floor
          */
         public function floor(): Decimal { }
 
@@ -195,7 +197,7 @@ namespace Decimal {
          *
          * @return Decimal
          *
-         * @link http://php-decimal.io/#ceil
+         * @link https://php-decimal.io/#ceil
          */
         public function ceil(): Decimal { }
 
@@ -204,7 +206,7 @@ namespace Decimal {
          *
          * @return Decimal
          *
-         * @link http://php-decimal.io/#truncate
+         * @link https://php-decimal.io/#truncate
          */
         public function truncate(): Decimal { }
 
@@ -213,7 +215,7 @@ namespace Decimal {
          *
          * @return Decimal
          *
-         * @link http://php-decimal.io/#shift
+         * @link https://php-decimal.io/#shift
          */
         public function shift(): Decimal { }
 
@@ -224,7 +226,7 @@ namespace Decimal {
          *
          * @return Decimal
          *
-         * @link http://php-decimal.io/#trim
+         * @link https://php-decimal.io/#trim
          */
         public function trim(): Decimal { }
 
@@ -233,7 +235,7 @@ namespace Decimal {
          *
          * @return int
          *
-         * @link http://php-decimal.io/#precision
+         * @link https://php-decimal.io/#precision
          */
         public function precision(): int { }
 
@@ -242,7 +244,7 @@ namespace Decimal {
          *
          * @return int
          *
-         * @link http://php-decimal.io/#signum
+         * @link https://php-decimal.io/#signum
          */
         public function signum(): int { }
 
@@ -251,7 +253,7 @@ namespace Decimal {
          *
          * @return int
          *
-         * @link http://php-decimal.io/#parity
+         * @link https://php-decimal.io/#parity
          */
         public function parity(): int { }
 
@@ -260,7 +262,7 @@ namespace Decimal {
          *
          * @return Decimal
          *
-         * @link http://php-decimal.io/#abs
+         * @link https://php-decimal.io/#abs
          */
         public function abs(): Decimal { }
 
@@ -269,63 +271,63 @@ namespace Decimal {
          *
          * @return Decimal
          *
-         * @link http://php-decimal.io/#negate
+         * @link https://php-decimal.io/#negate
          */
         public function negate(): Decimal { }
 
         /**
          * @return bool
          *
-         * @link http://php-decimal.io/#isEven
+         * @link https://php-decimal.io/#isEven
          */
         public function isEven(): bool { }
 
         /**
          * @return bool
          *
-         * @link http://php-decimal.io/#isOdd
+         * @link https://php-decimal.io/#isOdd
          */
         public function isOdd(): bool { }
 
         /**
          * @return bool
          *
-         * @link http://php-decimal.io/#isPositive
+         * @link https://php-decimal.io/#isPositive
          */
         public function isPositive(): bool { }
 
         /**
          * @return bool
          *
-         * @link http://php-decimal.io/#isNegative
+         * @link https://php-decimal.io/#isNegative
          */
         public function isNegative(): bool { }
 
         /**
          * @return bool
          *
-         * @link http://php-decimal.io/#isNan
+         * @link https://php-decimal.io/#isNan
          */
         public function isNaN(): bool { }
 
         /**
          * @return bool
          *
-         * @link http://php-decimal.io/#isInf
+         * @link https://php-decimal.io/#isInf
          */
         public function isInf(): bool { }
 
         /**
          * @return bool
          *
-         * @link http://php-decimal.io/#isInteger
+         * @link https://php-decimal.io/#isInteger
          */
         public function isInteger(): bool { }
 
         /**
          * @return bool
          *
-         * @link http://php-decimal.io/#isZero
+         * @link https://php-decimal.io/#isZero
          */
         public function isZero(): bool { }
 
@@ -338,7 +340,7 @@ namespace Decimal {
          *
          * @return Decimal
          *
-         * @link http://php-decimal.io/#toFixed
+         * @link https://php-decimal.io/#toFixed
          */
         public function toFixed(int $places = 0, bool $commas = false, int $mode = Decimal::ROUND_HALF_EVEN): Decimal { }
 
@@ -387,7 +389,7 @@ namespace Decimal {
          *
          * @return bool TRUE if this decimal is considered equal to the given value.
          *
-         * @link http://php-decimal.io/#equals
+         * @link https://php-decimal.io/#equals
          */
         public function equals($value): bool { }
 
@@ -402,7 +404,7 @@ namespace Decimal {
          *
          * @return int
          *
-         * @link http://php-decimal.io/#compareTo
+         * @link https://php-decimal.io/#compareTo
          */
         public function compareTo($value): int { }
 
@@ -428,7 +430,7 @@ namespace Decimal {
          *
          * @return Decimal
          *
-         * @link http://php-decimal.io/#sum
+         * @link https://php-decimal.io/#sum
          */
         public function sum(array $values): Decimal { }
 
@@ -442,7 +444,7 @@ namespace Decimal {
          *
          * @return Decimal
          *
-         * @link http://php-decimal.io/#avg
+         * @link https://php-decimal.io/#avg
          */
         public function avg(array $values): Decimal { }
     }

--- a/decimal/decimal.php
+++ b/decimal/decimal.php
@@ -138,15 +138,6 @@ namespace Decimal {
         public function ln(): Decimal { }
 
         /**
-         * Alias of ln()
-         *
-         * @return Decimal
-         *
-         * @link https://php-decimal.io/#ln
-         */
-        public function log(): Decimal { }
-
-        /**
          * @return Decimal
          *
          * @link https://php-decimal.io/#exp

--- a/decimal/decimal.php
+++ b/decimal/decimal.php
@@ -1,0 +1,449 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Decimal {
+
+    use Traversable;
+    use TypeError;
+
+    class Decimal {
+    public const ROUND_UP = 101;
+    public const ROUND_DOWN = 102;
+    public const ROUND_CEILING = 103;
+    public const ROUND_FLOOR = 104;
+    public const ROUND_HALF_UP = 105;
+    public const ROUND_HALF_DOWN = 106;
+    public const ROUND_HALF_EVEN = 107;
+    public const ROUND_HALF_ODD = 108;
+    public const ROUND_TRUNCATE = 109;
+
+    public const DEFAULT_PRECISION = 28;
+    public const DEFAULT_ROUNDING = self::ROUND_HALF_EVEN;
+
+    public const MIN_PRECISION = 1;
+
+    /**
+     * 425000000 for 32 bits systems
+     * 999999999999999999 for 64 bits systems
+     */
+    public const MAX_PRECISION = 999999999999999999;
+
+        /**
+         * @param string $value
+         * @param int $precision
+         */
+        public function __construct(string $value, int $precision = self::DEFAULT_PRECISION) { }
+
+        /**
+         * This method is equivalent to the + operator
+         *
+         * @param Decimal|string|int $value
+         *
+         * @return Decimal
+         *
+         * @throws TypeError
+         *
+         * @link http://php-decimal.io/#add
+         */
+        public function add($value): Decimal { }
+
+        /**
+         * This method is equivalent to the - operator
+         *
+         * @param Decimal|string|int $value
+         *
+         * @return Decimal
+         *
+         * @throws TypeError
+         *
+         * @link http://php-decimal.io/#sub
+         */
+        public function sub($value): Decimal { }
+
+        /**
+         * This method is equivalent to the * operator
+         *
+         * @param Decimal|string|int $value
+         *
+         * @return Decimal
+         *
+         * @throws TypeError
+         *
+         * @link http://php-decimal.io/#mul
+         */
+        public function mul($value): Decimal { }
+
+        /**
+         * This method is equivalent to the / operator
+         *
+         * @param Decimal|string|int $value
+         *
+         * @return Decimal
+         *
+         * @throws TypeError
+         *
+         * @link http://php-decimal.io/#div
+         */
+        public function div($value): Decimal { }
+
+        /**
+         * This method is equivalent to the % operator
+         *
+         * @param Decimal|string|int $value
+         *
+         * @return Decimal
+         *
+         * @throws TypeError
+         * @throws DivisionByZeroError
+         * @throws ArithmeticError
+         *
+         * @link http://php-decimal.io/#mod
+         */
+        public function mod($value): Decimal { }
+
+        /**
+         * This method is equivalent to the ** operator
+         *
+         * @param Decimal|string|int $value
+         *
+         * @return Decimal
+         *
+         * @throws TypeError
+         *
+         * @link http://php-decimal.io/#pow
+         */
+        public function pow($value): Decimal { }
+
+        /**
+         * @param Decimal|string|int $value
+         *
+         * @return Decimal
+         *
+         * @throws TypeError
+         * @throws DivisionByZeroError
+         * @throws ArithmeticError
+         *
+         * @link http://php-decimal.io/#rem
+         */
+        public function rem($value): Decimal { }
+
+        /**
+         * This method is equivalent in function to PHP's log
+         *
+         * @return Decimal
+         *
+         * @link http://php-decimal.io/#ln
+         */
+        public function ln(): Decimal { }
+
+        /**
+         * Alias of ln()
+         *
+         * @return Decimal
+         *
+         * @link http://php-decimal.io/#ln
+         */
+        public function log(): Decimal { }
+
+        /**
+         * @return Decimal
+         *
+         * @link http://php-decimal.io/#exp
+         */
+        public function exp(): Decimal { }
+
+        /**
+         * @return Decimal
+         *
+         * @link http://php-decimal.io/#log10
+         */
+        public function log10(): Decimal { }
+
+        /**
+         * @return Decimal
+         *
+         * @link http://php-decimal.io/#sqrt
+         */
+        public function sqrt(): Decimal { }
+
+        /**
+         * Returns the value of this decimal with the same precision
+         *
+         * Rounded according to the specified number of decimal places and rounding mode
+         *
+         * @param int $places
+         * @param int $mode
+         *
+         * @return Decimal
+         *
+         * @link http://php-decimal.io/#round
+         */
+        public function round(int $places = 0, int $mode = Decimal::ROUND_HALF_EVEN): Decimal { }
+
+        /**
+         * Returns the closest integer towards negative infinity
+         *
+         * @return Decimal
+         *
+         * @link http://php-decimal.io/#floor
+         */
+        public function floor(): Decimal { }
+
+        /**
+         * Returns the closest integer towards positive infinity
+         *
+         * @return Decimal
+         *
+         * @link http://php-decimal.io/#ceil
+         */
+        public function ceil(): Decimal { }
+
+        /**
+         * Returns the result of discarding all digits behind the decimal point
+         *
+         * @return Decimal
+         *
+         * @link http://php-decimal.io/#truncate
+         */
+        public function truncate(): Decimal { }
+
+        /**
+         * Returns a copy of this decimal with its decimal place shifted
+         *
+         * @return Decimal
+         *
+         * @link http://php-decimal.io/#shift
+         */
+        public function shift(): Decimal { }
+
+        /**
+         * @since 1.1.0
+         *
+         * Returns a copy of this decimal without trailing zeroes
+         *
+         * @return Decimal
+         *
+         * @link http://php-decimal.io/#trim
+         */
+        public function trim(): Decimal { }
+
+        /**
+         * Returns the precision of this decimal
+         *
+         * @return int
+         *
+         * @link http://php-decimal.io/#precision
+         */
+        public function precision(): int { }
+
+        /**
+         * Returns  0 if zero, -1 if negative, or 1 if positive
+         *
+         * @return int
+         *
+         * @link http://php-decimal.io/#signum
+         */
+        public function signum(): int { }
+
+        /**
+         * Returns 0 if the integer value of this decimal is even, 1 if odd. Special numbers like NAN and INF will return 1
+         *
+         * @return int
+         *
+         * @link http://php-decimal.io/#parity
+         */
+        public function parity(): int { }
+
+        /**
+         * Returns the absolute (positive) value of this decimal
+         *
+         * @return Decimal
+         *
+         * @link http://php-decimal.io/#abs
+         */
+        public function abs(): Decimal { }
+
+        /**
+         * Returns the same value as this decimal, but the sign inverted
+         *
+         * @return Decimal
+         *
+         * @link http://php-decimal.io/#negate
+         */
+        public function negate(): Decimal { }
+
+        /**
+         * @return bool
+         *
+         * @link http://php-decimal.io/#isEven
+         */
+        public function isEven(): bool { }
+
+        /**
+         * @return bool
+         *
+         * @link http://php-decimal.io/#isOdd
+         */
+        public function isOdd(): bool { }
+
+        /**
+         * @return bool
+         *
+         * @link http://php-decimal.io/#isPositive
+         */
+        public function isPositive(): bool { }
+
+        /**
+         * @return bool
+         *
+         * @link http://php-decimal.io/#isNegative
+         */
+        public function isNegative(): bool { }
+
+        /**
+         * @return bool
+         *
+         * @link http://php-decimal.io/#isNan
+         */
+        public function isNaN(): bool { }
+
+        /**
+         * @return bool
+         *
+         * @link http://php-decimal.io/#isInf
+         */
+        public function isInf(): bool { }
+
+        /**
+         * @return bool
+         *
+         * @link http://php-decimal.io/#isInteger
+         */
+        public function isInteger(): bool { }
+
+        /**
+         * @return bool
+         *
+         * @link http://php-decimal.io/#isZero
+         */
+        public function isZero(): bool { }
+
+        /**
+         * Returns the value of this decimal formatted to a fixed number of decimal places, with thousands comma-separated, using a given rounding mode.
+         *
+         * @param int $places
+         * @param bool $commas
+         * @param int $mode
+         *
+         * @return Decimal
+         *
+         * @link http://php-decimal.io/#toFixed
+         */
+        public function toFixed(int $places = 0, bool $commas = false, int $mode = Decimal::ROUND_HALF_EVEN): Decimal { }
+
+        /**
+         * Returns the value of this decimal represented exactly, in either fixed or scientific form, depending on the value
+         *
+         * @return string
+         */
+        public function __toString(): string { }
+
+        /**
+         * This method is equivalent to a cast to string
+         *
+         * Returns the value of this decimal represented exactly, in either fixed or scientific form, depending on the value
+         *
+         * @return string
+         */
+        public function toString(): string { }
+
+        /**
+         * JSON conversions will automatically convert the decimal to string using all signficant figures
+         *
+         * @return string
+         */
+        public function jsonSerialize(): string { }
+
+        /**
+         * @return int
+         */
+        public function toInt(): int { }
+
+        /**
+         * @return float
+         */
+        public function toFloat(): float { }
+
+        /**
+         * @return Decimal
+         */
+        public function copy(): Decimal { }
+
+        /**
+         * This method is equivalent to the == operator.
+         *
+         * @param mixed $value
+         *
+         * @return bool TRUE if this decimal is considered equal to the given value.
+         *
+         * @link http://php-decimal.io/#equals
+         */
+        public function equals($value): bool { }
+
+        /**
+         * This method is equivalent to the <=> operator.
+         * 
+         * Returns 0 if this decimal is considered equal to $other,
+         * -1 if this decimal should be placed before $other,
+         * 1 if this decimal should be placed after $other.
+         *
+         * @param $value
+         *
+         * @return int
+         *
+         * @link http://php-decimal.io/#compareTo
+         */
+        public function compareTo($value): int { }
+
+        /**
+         * Returns TRUE if the value is between the two operands
+         *
+         * @param Decimam|string|int $value
+         * @param Decimam|string|int $leftOp
+         * @param Decimam|string|int $rightOp
+         *
+         * @return bool
+         */
+        public function between($value, $leftOp, $rightOp): bool { }
+
+        /**
+         * Returns the sum of all given values
+         *
+         * The precision of the result will be the max of all precisions that were encountered during the calculation.
+         * The given precision should therefore be considered the minimum precision of the result.
+         * This method is equivalent to adding each value individually
+         *
+         * @param array|Traversable $values
+         *
+         * @return Decimal
+         *
+         * @link http://php-decimal.io/#sum
+         */
+        public function sum(array $values): Decimal { }
+
+        /**
+         * Returns the average of all given values
+         *
+         * The precision of the result will be the max of all precisions that were encountered during the calculation.
+         * The given precision should therefore be considered the minimum precision of the result.
+         * This method is equivalent to adding each value individually, then dividing by the number of values
+         * @param array $values
+         *
+         * @return Decimal
+         *
+         * @link http://php-decimal.io/#avg
+         */
+        public function avg(array $values): Decimal { }
+    }
+}

--- a/decimal/decimal.php
+++ b/decimal/decimal.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Decimal {
 
     use ArithmeticError;
@@ -10,26 +8,26 @@ namespace Decimal {
     use TypeError;
 
     class Decimal {
-    public const ROUND_UP = 101;
-    public const ROUND_DOWN = 102;
-    public const ROUND_CEILING = 103;
-    public const ROUND_FLOOR = 104;
-    public const ROUND_HALF_UP = 105;
-    public const ROUND_HALF_DOWN = 106;
-    public const ROUND_HALF_EVEN = 107;
-    public const ROUND_HALF_ODD = 108;
-    public const ROUND_TRUNCATE = 109;
+        public const ROUND_UP = 101;
+        public const ROUND_DOWN = 102;
+        public const ROUND_CEILING = 103;
+        public const ROUND_FLOOR = 104;
+        public const ROUND_HALF_UP = 105;
+        public const ROUND_HALF_DOWN = 106;
+        public const ROUND_HALF_EVEN = 107;
+        public const ROUND_HALF_ODD = 108;
+        public const ROUND_TRUNCATE = 109;
 
-    public const DEFAULT_PRECISION = 28;
-    public const DEFAULT_ROUNDING = self::ROUND_HALF_EVEN;
+        public const DEFAULT_PRECISION = 28;
+        public const DEFAULT_ROUNDING = self::ROUND_HALF_EVEN;
 
-    public const MIN_PRECISION = 1;
+        public const MIN_PRECISION = 1;
 
-    /**
-     * 425000000 for 32 bits systems
-     * 999999999999999999 for 64 bits systems
-     */
-    public const MAX_PRECISION = 999999999999999999;
+        /**
+         * 425000000 for 32 bits systems
+         * 999999999999999999 for 64 bits systems
+         */
+        public const MAX_PRECISION = 999999999999999999;
 
         /**
          * @param string $value


### PR DESCRIPTION
Stubs for the decimal  extension (https://php-decimal.io).

I started using this extension but there was no stub for it.

The PR is about version 1.3.0 of the extension.