### PR TITLE
Try to fix Redis::zadd

### DIFF
--- a/redis/Redis.php
+++ b/redis/Redis.php
@@ -2918,14 +2918,14 @@ class Redis
     /**
      * Adds the specified member with a given score to the sorted set stored at key
      *
-     * @param string       $key     Required key
-     * @param array        $options Options if needed
-     * @param float        $score1  Required score
-     * @param string|mixed $value1  Required value
-     * @param float        $score2  Optional score
-     * @param string|mixed $value2  Optional value
-     * @param float        $scoreN  Optional score
-     * @param string|mixed $valueN  Optional value
+     * @param string                $key     Required key
+     * @param array|float           $options Options if needed or score if omitted
+     * @param float|string|mixed    $score1  Required score or value if options omitted
+     * @param string|float|mixed    $value1  Required value or optional score if options omitted
+     * @param float|string|mixed    $score2  Optional score or value if options omitted
+     * @param string|float|mixed    $value2  Optional value or score if options omitted
+     * @param float|string|mixed    $scoreN  Optional score or value if options omitted
+     * @param string|float|mixed    $valueN  Optional value or score if options omitted
      *
      * @return int Number of values added
      *
@@ -2959,7 +2959,7 @@ class Redis
      * </pre>
      * </pre>
      */
-    public function zAdd($key, $options, $score1, $value1, $score2 = null, $value2 = null, $scoreN = null, $valueN = null)
+    public function zAdd($key, $options, $score1, $value1 = null, $score2 = null, $value2 = null, $scoreN = null, $valueN = null)
     {
     }
 

--- a/redis/Redis.php
+++ b/redis/Redis.php
@@ -2919,7 +2919,6 @@ class Redis
      * Adds the specified member with a given score to the sorted set stored at key
      *
      * @param string       $key     Required key
-     * @param array        $options Options if needed
      * @param float        $score1  Required score
      * @param string|mixed $value1  Required value
      * @param float        $score2  Optional score

--- a/redis/Redis.php
+++ b/redis/Redis.php
@@ -2919,6 +2919,7 @@ class Redis
      * Adds the specified member with a given score to the sorted set stored at key
      *
      * @param string       $key     Required key
+     * @param array        $options Options if needed
      * @param float        $score1  Required score
      * @param string|mixed $value1  Required value
      * @param float        $score2  Optional score


### PR DESCRIPTION
**WARNING** This PR is wrong but:

1. your issues are not open
2. I don't know how to fix that.

The current spec does not validate you own example.

The [PECL allows use to write](https://github.com/phpredis/phpredis#zadd):

```
$redis->zAdd('key', 1, 'val1');
```

But the current stub doesn't.

---

I'm sorry, I'm not able to go further. Please let me know what I can do