### PR TITLE
Moved getallheaders() and fastcgi_finish_request()

### DIFF
--- a/apache/apache.php
+++ b/apache/apache.php
@@ -105,14 +105,6 @@ function apache_response_headers () {}
 function apache_setenv ( $variable, $value, $walk_to_top = false ) {}
 
 /**
- * Fetches all HTTP headers from the current request.
- * This function is an alias for apache_request_headers(). Please read the apache_request_headers() documentation for more information on how this function works.
- * @link https://php.net/manual/en/function.getallheaders.php
- * @return array|false An associative array of all the HTTP headers in the current request, or <b>FALSE</b> on failure.
- */
-function getallheaders () {}
-
-/**
  * Perform an Apache sub-request
  * virtual() is an Apache-specific function which is similar to <!--#include virtual...--> in mod_include. It performs an Apache sub-request. It is useful for including CGI scripts or .shtml files, or anything else that you would parse through Apache. Note that for a CGI script, the script must generate valid CGI headers. At the minimum that means it must generate a Content-Type header.
  * To run the sub-request, all buffers are terminated and flushed to the browser, pending headers are sent too.

--- a/fpm/fpm.php
+++ b/fpm/fpm.php
@@ -1,5 +1,14 @@
 <?php
 /**
+ * This function flushes all response data to the client and finishes the request.
+ * This allows for time consuming tasks to be performed without leaving the connection to the client open.
+ * @return bool Returns TRUE on success or FALSE on failure.
+ * @link https://php.net/manual/en/install.fpm.php
+ * @since 5.3.3
+ */
+function fastcgi_finish_request() {};
+
+/**
  * Returns FPM status info array
  * @since 7.3
  * @return array

--- a/standard/_standard_manual.php
+++ b/standard/_standard_manual.php
@@ -35,15 +35,6 @@ define("__COMPILER_HALT_OFFSET__",0);
 function hex2bin($data) {};
 
 /**
- * This function flushes all response data to the client and finishes the request.
- * This allows for time consuming tasks to be performed without leaving the connection to the client open.
- * @return bool Returns TRUE on success or FALSE on failure.
- * @link https://php.net/manual/en/install.fpm.php
- * @since 5.3.3
- */
-function fastcgi_finish_request() {};
-
-/**
  * Get or Set the HTTP response code
  * @param int $response_code [optional] The optional response_code will set the response code.
  * @return int The current response code. By default the return value is int(200).

--- a/standard/_standard_manual.php
+++ b/standard/_standard_manual.php
@@ -49,3 +49,11 @@ function fastcgi_finish_request() {};
  * @return int The current response code. By default the return value is int(200).
  */
 function http_response_code($response_code = null) {}
+
+/**
+ * Fetches all HTTP headers from the current request.
+ * This function is an alias for apache_request_headers(). Please read the apache_request_headers() documentation for more information on how this function works.
+ * @link https://php.net/manual/en/function.getallheaders.php
+ * @return array|false An associative array of all the HTTP headers in the current request, or <b>FALSE</b> on failure.
+ */
+function getallheaders () {}


### PR DESCRIPTION
Hello,

this pull request moves `getallheaders()` from ext-apache to PHP core as `getallheaders()` is no longer Apache-specific and is available in both PHP FastCGI Process Manager and CLI Development Server as well (for more information, please take a look [here](https://www.php.net/manual/en/function.getallheaders.php)).

`fastcgi_finish_request()` is also moved from PHP core to PHP-FPM as it's only available with the PHP FastCGI Process Manager SAPI (for more information, please take a look [here](https://www.php.net/manual/en/function.fastcgi-finish-request.php) and [here](https://www.php.net/manual/en/book.fpm.php)).

Best regards,
Ben.