### PR TITLE
Fix getopt() return type

### DIFF
--- a/standard/standard_3.php
+++ b/standard/standard_3.php
@@ -719,7 +719,7 @@ function putenv ($setting) {}
  * option --opt.
  * Prior to PHP5.3.0 this parameter was only available on few systems
  * @param int $optind If the optind parameter is present, then the index where argument parsing stopped will be written to this variable.
- * @return array|false This function will return an array of option / argument pairs or false on
+ * @return string[]|false[]|false This function will return an array of option / argument pairs or false on
  * failure.
  */
 function getopt ($options, array $longopts = null, &$optind = null) {}

--- a/standard/standard_3.php
+++ b/standard/standard_3.php
@@ -719,7 +719,7 @@ function putenv ($setting) {}
  * option --opt.
  * Prior to PHP5.3.0 this parameter was only available on few systems
  * @param int $optind If the optind parameter is present, then the index where argument parsing stopped will be written to this variable.
- * @return array This function will return an array of option / argument pairs or false on
+ * @return array|false This function will return an array of option / argument pairs or false on
  * failure.
  */
 function getopt ($options, array $longopts = null, &$optind = null) {}


### PR DESCRIPTION
I doubt if it can be specified as `string[]|false[]|false`? I'm not sure.