### PR TITLE
Fix possible return values from `readline`

### DIFF
--- a/readline/readline.php
+++ b/readline/readline.php
@@ -8,8 +8,8 @@
  * @param string $prompt [optional] <p>
  * You may specify a string with which to prompt the user.
  * </p>
- * @return string a single string from the user. The line returned has the ending
- * newline removed.
+ * @return string|false a single string from the user. The line returned has the ending newline removed. 
+ * If there is no more data to read, then FALSE is returned.
  */
 function readline ($prompt = null) {}
 


### PR DESCRIPTION
Using phpstan I got prompted that the return value of `readline()` might be false.
According to the official docs this holds true. So the stub here is not totally correct. (Even the docs are not 100% correct it seems).

https://www.php.net/manual/en/function.readline.php#refsect1-function.readline-returnvalues
Also in the source: https://github.com/php/php-src/blob/27e83d0fb87c04b61441fb77e963dd4e14ad187e/ext/readline/readline.stub.php#L3