### PR TITLE
grpc: Fix ChannelCredentials::createInsecure @return hint

### DIFF
--- a/grpc/grpc.php
+++ b/grpc/grpc.php
@@ -535,7 +535,7 @@ namespace Grpc
         /**
          * Create insecure channel credentials
          *
-         * @return null
+         * @return ChannelCredentials The new composite credentials object
          */
         public static function createInsecure() {}
     }


### PR DESCRIPTION
`ChannelCredentials::createInsecure` returns a `ChannelCredentials` instance, not `null`.