### PR TITLE
The value of mysqli::$sqlstate can be false

### DIFF
--- a/mysqli/mysqli.php
+++ b/mysqli/mysqli.php
@@ -103,7 +103,7 @@ class mysqli  {
 	 */
 	public $server_version;
 	/**
-	 * @var string
+	 * @var string|false
 	 */
 	public $sqlstate;
 	/**


### PR DESCRIPTION
Despite the [documentation](https://www.php.net/manual/en/class.mysqli.php), `mysqli::$sqlstate` can be actually false:
```php
$conn = mysqli_init();

var_dump(get_class($conn));
var_dump($conn->sqlstate);

// string(6) "mysqli"
// bool(false)
```