### PR TITLE
Fix default value

### DIFF
--- a/standard/standard_5.php
+++ b/standard/standard_5.php
@@ -669,7 +669,7 @@ function fread ($handle, $length) {}
  * @param resource $context [optional] &note.context-support;
  * @return resource|false a file pointer resource on success, or false on error.
  */
-function fopen ($filename, $mode, $use_include_path = null, $context = null) {}
+function fopen ($filename, $mode, $use_include_path = false, $context = null) {}
 
 /**
  * Output all remaining data on a file pointer


### PR DESCRIPTION
According to [the doc](https://www.php.net/manual/en/function.fopen.php), `$use_include_path` is `false` by default.