### PR TITLE
Implement Traversable

### DIFF
--- a/mysqli/mysqli.php
+++ b/mysqli/mysqli.php
@@ -786,7 +786,7 @@ final class mysqli_warning  {
  * Implements Traversable since 5.4
  * @link https://php.net/manual/en/class.mysqli-result.php
  */
-class mysqli_result implements Traversable  {
+class mysqli_result implements IteratorAggregate  {
 	/**
 	 * @var int
 	 */
@@ -812,6 +812,11 @@ class mysqli_result implements Traversable  {
 	 * Constructor (no docs available)
 	 */
 	public function __construct () {}
+
+	/**
+	 * Mandatory, minimal implementation of Traversable
+	 */
+	public function getIterator () {}
 
 	/**
 	 * Frees the memory associated with a result


### PR DESCRIPTION
Classes cannot implement Traversable directly, they have to implement
either Iterator or IteratorAggregate. This fixes a crash when using this
package with PHPStan:

> PHP Fatal error:  Class mysqli_result must implement interface
> Traversable as part of either Iterator or IteratorAggregate in Unknown
> on line 0

Source to back up my claim:

>   This is an internal engine interface which cannot be implemented in PHP scripts. Either IteratorAggregate or Iterator must be used instead. When implementing an interface which extends Traversable, make sure to list IteratorAggregate or Iterator before its name in the implements clause. 

From https://www.php.net/manual/en/class.traversable.php