### PR TITLE
Change PHPDoc for unserialize

### DIFF
--- a/standard/standard_4.php
+++ b/standard/standard_4.php
@@ -167,7 +167,7 @@ function serialize ($value) {}
  * In case the passed string is not unserializeable, false is returned and
  * E_NOTICE is issued.
  */
-function unserialize ($str, array $options = null) {}
+function unserialize (string $str, array $options = []) {}
 
 /**
  * Dumps information about a variable


### PR DESCRIPTION
According official docs first parameter has string type and `options` parameter can't be null.

https://www.php.net/manual/en/function.unserialize.php
https://github.com/php/php-src/blob/beff93f60ddb330cc5b04d716af3ba9cba108c8e/ext/standard/basic_functions.stub.php#L1528