### PR TITLE
Fix typos

### DIFF
--- a/Core/Core_d.php
+++ b/Core/Core_d.php
@@ -13,7 +13,7 @@ define ('E_ERROR', 1);
 
 /**
  * Catchable fatal error. It indicates that a probably dangerous error
- * occured, but did not leave the Engine in an unstable state. If the error
+ * occurred, but did not leave the Engine in an unstable state. If the error
  * is not caught by a user defined handle (see also
  * <b>set_error_handler</b>), the application aborts as it
  * was an <b>E_ERROR</b>.

--- a/cassandra/cassandra.php
+++ b/cassandra/cassandra.php
@@ -41,7 +41,7 @@ namespace {
         /**
          * Consistency level ANY means the request is fulfilled as soon as the data
          * has been written on the Coordinator. Requests with this consistency level
-         * are not guranteed to make it to Replica nodes.
+         * are not guaranteed to make it to Replica nodes.
          *
          * @see \Cassandra\Session::execute()
          * @link https://docs.datastax.com/en/developer/php-driver/latest/api/class.Cassandra/#constant-CONSISTENCY_ANY
@@ -6212,7 +6212,7 @@ namespace Cassandra\Cluster {
 
         /**
          * Sets the blacklist hosts. Any host in the blacklist will be ignored and
-         * a conneciton will not be established. This is useful for ensuring that
+         * a connection will not be established. This is useful for ensuring that
          * the driver will not connection to a predefied set of hosts.
          *
          * @param string $hosts A comma delimited list of addresses.

--- a/couchbase/couchbase.php
+++ b/couchbase/couchbase.php
@@ -1590,7 +1590,7 @@ namespace Couchbase {
      * @see https://developer.couchbase.com/documentation/server/current/sdk/php/view-queries-with-sdk.html
      *   MapReduce Views
      * @see https://developer.couchbase.com/documentation/server/current/architecture/querying-data-with-views.html
-     *   Quering Data with Views
+     *   Querying Data with Views
      * @see https://developer.couchbase.com/documentation/server/current/rest-api/rest-views-get.html
      *   Getting Views Information
      */

--- a/crypto/crypto.php
+++ b/crypto/crypto.php
@@ -528,12 +528,12 @@ abstract class KDF {
 class KDFException {
     
     /**
-     * The key lenght is too low
+     * The key length is too low
      */
     const KEY_LENGTH_LOW = 1;
     
     /**
-     * The key lenght is too high
+     * The key length is too high
      */
     const KEY_LENGTH_HIGH = 2;
     
@@ -679,7 +679,7 @@ class Base64Exception extends \Exception {
     const ENCODE_UPDATE_FORBIDDEN = 1;
     
     /**
-     * The object has not been intialized for encoding
+     * The object has not been initialized for encoding
      */
     const ENCODE_FINISH_FORBIDDEN = 2;
     
@@ -689,7 +689,7 @@ class Base64Exception extends \Exception {
     const DECODE_UPDATE_FORBIDDEN = 3;
     
     /**
-     * The object has not been intialized for decoding
+     * The object has not been initialized for decoding
      */
     const DECODE_FINISH_FORBIDDEN = 4;
     

--- a/curl/curl.php
+++ b/curl/curl.php
@@ -2210,7 +2210,7 @@ function curl_share_init () {}
  * <td style="vertical-align: top;">
  * Shares SSL session IDs, reducing the time spent on the SSL
  * handshake when reconnecting to the same server. Note that SSL
- * session IDs are reused withing the same handle by default.
+ * session IDs are reused within the same handle by default.
  * </td>
  * </tr>
  *

--- a/curl/curl_d.php
+++ b/curl/curl_d.php
@@ -3319,7 +3319,7 @@ define("CURLPROTO_RTMPTE",4194304);
  */
 define("CURLPROTO_RTMPTS",16777216);
 /**
- * Return value for the <b>CURLOPT_FNMATCH_FUNCTION</b> if an error was occured.
+ * Return value for the <b>CURLOPT_FNMATCH_FUNCTION</b> if an error was occurred.
  * @link https://curl.haxx.se/libcurl/c/CURLOPT_FNMATCH_FUNCTION.html
  */
 define("CURL_FNMATCHFUNC_FAIL",2);

--- a/date/date.php
+++ b/date/date.php
@@ -634,7 +634,7 @@ function checkdate ($month, $day, $year) {}
  * </tr>
  * <tr valign="top">
  * <td>%l (lower-case 'L')</td>
- * <td>Hour in 12-hour format, with a space preceeding single digits</td>
+ * <td>Hour in 12-hour format, with a space preceding single digits</td>
  * <td> 1 through 12</td>
  * </tr>
  * <tr valign="top">

--- a/dba/dba.php
+++ b/dba/dba.php
@@ -105,7 +105,7 @@
  * <td>false</td>
  * </tr>
  * </table>
- * ok: the second call will be successfull.
+ * ok: the second call will be successful.
  * wait: the second call waits until <b>dba_close</b> is called for the first.
  * false: the second call returns false.
  * illegal: you must not mix "l" and "d" modifiers for <i>mode</i> parameter.

--- a/decimal/decimal.php
+++ b/decimal/decimal.php
@@ -350,7 +350,7 @@ namespace Decimal {
         public function toString(): string { }
 
         /**
-         * JSON conversions will automatically convert the decimal to string using all signficant figures
+         * JSON conversions will automatically convert the decimal to string using all significant figures
          *
          * @return string
          */

--- a/dom/dom_c.php
+++ b/dom/dom_c.php
@@ -658,14 +658,14 @@ class DOMDocument extends DOMNode  {
      * You can also set the value later with DOMElement->nodeValue.
      * </p>
      * @return DOMElement a new instance of class DOMElement or false
-     * if an error occured.
+     * if an error occurred.
      */
     public function createElement ($name, $value = null) {}
 
     /**
      * Create new document fragment
      * @link https://php.net/manual/domdocument.createdocumentfragment.php
-     * @return DOMDocumentFragment The new DOMDocumentFragment or false if an error occured.
+     * @return DOMDocumentFragment The new DOMDocumentFragment or false if an error occurred.
      */
     public function createDocumentFragment () {}
 
@@ -675,7 +675,7 @@ class DOMDocument extends DOMNode  {
      * @param string $content <p>
      * The content of the text.
      * </p>
-     * @return DOMText The new DOMText or false if an error occured.
+     * @return DOMText The new DOMText or false if an error occurred.
      */
     public function createTextNode ($content) {}
 
@@ -685,7 +685,7 @@ class DOMDocument extends DOMNode  {
      * @param string $data <p>
      * The content of the comment.
      * </p>
-     * @return DOMComment The new DOMComment or false if an error occured.
+     * @return DOMComment The new DOMComment or false if an error occurred.
      */
     public function createComment ($data) {}
 
@@ -695,7 +695,7 @@ class DOMDocument extends DOMNode  {
      * @param string $data <p>
      * The content of the cdata.
      * </p>
-     * @return DOMCDATASection The new DOMCDATASection or false if an error occured.
+     * @return DOMCDATASection The new DOMCDATASection or false if an error occurred.
      */
     public function createCDATASection ($data) {}
 
@@ -708,7 +708,7 @@ class DOMDocument extends DOMNode  {
      * @param string $data [optional] <p>
      * The content of the processing instruction.
      * </p>
-     * @return DOMProcessingInstruction The new DOMProcessingInstruction or false if an error occured.
+     * @return DOMProcessingInstruction The new DOMProcessingInstruction or false if an error occurred.
      */
     public function createProcessingInstruction ($target, $data = null) {}
 
@@ -718,7 +718,7 @@ class DOMDocument extends DOMNode  {
      * @param string $name <p>
      * The name of the attribute.
      * </p>
-     * @return DOMAttr The new DOMAttr or false if an error occured.
+     * @return DOMAttr The new DOMAttr or false if an error occurred.
      */
     public function createAttribute ($name) {}
 
@@ -731,7 +731,7 @@ class DOMDocument extends DOMNode  {
      * ; characters.
      * </p>
      * @return DOMEntityReference The new DOMEntityReference or false if an error
-     * occured.
+     * occurred.
      */
     public function createEntityReference ($name) {}
 
@@ -777,7 +777,7 @@ class DOMDocument extends DOMNode  {
      * The value of the element. By default, an empty element will be created.
      * You can also set the value later with DOMElement->nodeValue.
      * </p>
-     * @return DOMElement The new DOMElement or false if an error occured.
+     * @return DOMElement The new DOMElement or false if an error occurred.
      */
     public function createElementNS ($namespaceURI, $qualifiedName, $value = null) {}
 
@@ -790,7 +790,7 @@ class DOMDocument extends DOMNode  {
      * @param string $qualifiedName <p>
      * The tag name and prefix of the attribute, as prefix:tagname.
      * </p>
-     * @return DOMAttr The new DOMAttr or false if an error occured.
+     * @return DOMAttr The new DOMAttr or false if an error occurred.
      */
     public function createAttributeNS ($namespaceURI, $qualifiedName) {}
 
@@ -1379,7 +1379,7 @@ class DOMElement extends DOMNode  {
      * @param string $value <p>
      * The value of the attribute.
      * </p>
-     * @return DOMAttr The new DOMAttr or false if an error occured.
+     * @return DOMAttr The new DOMAttr or false if an error occurred.
      */
     public function setAttribute ($name, $value) {}
 

--- a/event/event.php
+++ b/event/event.php
@@ -3,7 +3,7 @@
 // The Event class
 /**
  * Event.
- * Event class represents and event firing on a file descriptor being ready to read from or write to; a file descriptor becoming ready to read from or write to(edge-triggered I/O only); a timeout expiring; a signal occuring; a user-triggered event.
+ * Event class represents and event firing on a file descriptor being ready to read from or write to; a file descriptor becoming ready to read from or write to(edge-triggered I/O only); a timeout expiring; a signal occurring; a user-triggered event.
  * Every event is associated with EventBase . However, event will never fire until it is added (via Event::add() ). An added event remains in pending state until the registered event occurs, thus turning it to active state. To handle events user may register a callback which is called when event becomes active. If event is configured persistent , it remains pending. If it is not persistent, it stops being pending when it's callback runs. Event::del() method deletes event, thus making it non-pending. By means of Event::add() method it could be added again.
  *
  * @property bool $pending

--- a/fileinfo/fileinfo.php
+++ b/fileinfo/fileinfo.php
@@ -221,7 +221,7 @@ define ('FILEINFO_PRESERVE_ATIME', 128);
 define ('FILEINFO_RAW', 256);
 
 /**
- * Returns the file extension appropiate for a the MIME type detected in the file.
+ * Returns the file extension appropriate for a the MIME type detected in the file.
  * For types that commonly have multiple file extensions, such as JPEG images, then the return value is multiple extensions speparated by a forward slash e.g.: "jpeg/jpg/jpe/jfif".
  * For unknown types not available in the magic.mime database, then return value is "???". Available since PHP 7.2.0.
  * @since 7.2

--- a/gearman/gearman.php
+++ b/gearman/gearman.php
@@ -2166,9 +2166,9 @@ class GearmanJob {
      * to specify what percentage of the job has been completed.
      *
      * @link https://php.net/manual/en/gearmanjob.sendstatus.php
-     * @param int $numerator The numerator of the precentage completed expressed as a
+     * @param int $numerator The numerator of the percentage completed expressed as a
      *        fraction
-     * @param int $denominator The denominator of the precentage completed expressed as
+     * @param int $denominator The denominator of the percentage completed expressed as
      *        a fraction
      * @return bool
      */

--- a/gmagick/gmagick.php
+++ b/gmagick/gmagick.php
@@ -1416,7 +1416,7 @@ class Gmagick
      * For example 50 results in a counter-clockwise rotation of 90 degrees,
      * 150 results in a clockwise rotation of 90 degrees, with 0 and 200 both resulting in a rotation of 180 degrees.
      *
-     * @param float $brightness The percent change in brighness (-100 thru +100).
+     * @param float $brightness The percent change in brightness (-100 thru +100).
      * @param float $saturation The percent change in saturation (-100 thru +100).
      * @param float $hue        The percent change in hue (-100 thru +100).
      *
@@ -1517,7 +1517,7 @@ class Gmagick
     /**
      * Move to the previous image in the object.
      *
-     * Assocates the previous image in an image list with the Gmagick object.
+     * Associates the previous image in an image list with the Gmagick object.
      *
      * @link https://php.net/manual/en/gmagick.previousimage.php
      *

--- a/http/http3.php
+++ b/http/http3.php
@@ -2819,7 +2819,7 @@ class Response extends \http\Message {
 	 */
 	function setCacheControl(string $cache_control) {}
 	/**
-	 * Set the reponse's content disposition parameters.
+	 * Set the response's content disposition parameters.
 	 * 
 	 * @param array $disposition_params MIME content disposition as http\Params array.
 	 * @throws \http\Exception\InvalidArgumentException

--- a/ldap/ldap.php
+++ b/ldap/ldap.php
@@ -7,7 +7,7 @@
  * @link https://www.php.net/manual/en/function.ldap-exop-passwd.php
  * @param resource $link An LDAP link identifier, returned by ldap_connect().
  * @param string $user [optional] dn of the user to change the password of.
- * @param string $oldpw [optional] The old password of this user. May be ommited depending of server configuration.
+ * @param string $oldpw [optional] The old password of this user. May be omitted depending of server configuration.
  * @param string $newpw [optional] The new password for this user. May be omitted or empty to have a generated password.
  * @param array $serverctrls [optional] If provided, a password policy request control is send with the request and this is filled with an array of LDAP Controls returned with the request.
  * @return mixed Returns the generated password if newpw is empty or omitted. Otherwise returns TRUE on success and FALSE on failure.

--- a/libevent/libevent.php
+++ b/libevent/libevent.php
@@ -86,13 +86,13 @@ define('EVLOOP_NONBLOCK', 2);
 // Buffered event error codes (second argument in buffer's error-callback)
 
 /**
- * An event occured during a read operation on the
+ * An event occurred during a read operation on the
  * bufferevent. See the other flags for which event it was.
  */
 define('EVBUFFER_READ', 1);
 
 /**
- * An event occured during a write operation on the bufferevent.
+ * An event occurred during a write operation on the bufferevent.
  * See the other flags for which event it was.
  */
 define('EVBUFFER_WRITE', 2);
@@ -210,7 +210,7 @@ function event_base_loopbreak($event_base) {}
  * Valid event base resource.
  * </p>
  * @param int $timeout [optional] <p>
- * Optional timeout parameter (in microseconds). If lower then 1,
+ * Optional timeout parameter (in microseconds). If lower than 1,
  * the event_base stops looping without a delay.
  * </p>
  *
@@ -280,7 +280,7 @@ function event_free($event) {}
  * <p>Schedules the execution of the non-pending event (makes it pending in it's
  * configured base) when the event specified in {@link event_set}() occurs or in
  * at least the time specified by the timeout argument. If timeout was not specified,
- * not timeout is set. The event must be already initalized by
+ * not timeout is set. The event must be already initialized by
  * {@link event_set}() and {@link event_base_set}() functions.
  * If the event already has a timeout set,
  * it is replaced by the new one.</p>

--- a/mongo/mongo.php
+++ b/mongo/mongo.php
@@ -1029,7 +1029,7 @@ class MongoCollection {
 	 * @param array $a An array of arrays.
 	 * @param array $options Options for the inserts.
 	 * @throws MongoCursorException
-	 * @return mixed if "safe" is set, returns an associative array with the status of the inserts ("ok") and any error that may have occured ("err"). Otherwise, returns TRUE if the batch insert was successfully sent, FALSE otherwise.
+	 * @return mixed if "safe" is set, returns an associative array with the status of the inserts ("ok") and any error that may have occurred ("err"). Otherwise, returns TRUE if the batch insert was successfully sent, FALSE otherwise.
 	 */
     public function batchInsert(array $a, array $options = array()) {}
 
@@ -1896,7 +1896,7 @@ class MongoId {
      * (PECL mongo &gt;= 0.8.0)
 	 * Creates a new id
 	 * @link https://secure.php.net/manual/en/mongoid.construct.php
-	 * @param string $id [optional] A string to use as the id. Must be 24 hexidecimal characters. If an invalid string is passed to this constructor, the constructor will ignore it and create a new id value.
+	 * @param string $id [optional] A string to use as the id. Must be 24 hexadecimal characters. If an invalid string is passed to this constructor, the constructor will ignore it and create a new id value.
      */
     public function __construct($id = NULL) {}
 
@@ -1914,7 +1914,7 @@ class MongoId {
     public static function isValid($value) {}
    /**
     * (PECL mongo &gt;= 0.8.0)
-	* Returns a hexidecimal representation of this id
+	* Returns a hexadecimal representation of this id
 	* @link https://secure.php.net/manual/en/mongoid.tostring.php
     * @return string This id.
     */

--- a/mongodb/mongodb.php
+++ b/mongodb/mongodb.php
@@ -210,7 +210,7 @@ namespace MongoDB {}
             }
 
             /**
-             * Preselect a MongoDB node based on provided readPreference. This can be useful to gurantee a command runs on a specific server when operating in a mixed version cluster.
+             * Preselect a MongoDB node based on provided readPreference. This can be useful to guarantee a command runs on a specific server when operating in a mixed version cluster.
              * https://secure.php.net/manual/en/mongodb-driver-manager.selectserver.php
              * @param ReadPreference $readPreference Optionally, a MongoDB\Driver\ReadPreference to route the command to. If none given, defaults to the Read Preferences set by the MongoDB Connection URI.
              * @throws InvalidArgumentException on argument parsing errors.
@@ -1244,7 +1244,7 @@ namespace MongoDB {}
              * element, and this array contains a "TransientTransactionError" or "UnUnknownTransactionCommitResult" value, it is safe to
              * re-try the whole transaction. In newer versions of the driver, MongoDB\Driver\Exception\RuntimeException::hasErrorLabel()
              * should be used to test for this situation instead.
-             * @throws \MongoDB\Driver\Exception\RuntimeException If the transaction could not be commited (e.g. a transaction was not started)
+             * @throws \MongoDB\Driver\Exception\RuntimeException If the transaction could not be committed (e.g. a transaction was not started)
              * @since 1.5.0
              */
             final public function commitTransaction()
@@ -2053,7 +2053,7 @@ namespace MongoDB {}
         /**
          * Returns the PHP representation of a BSON value
          * Unserializes a BSON document (i.e. binary string) to its PHP representation.
-         * The typeMap paramater may be used to control the PHP types used for converting BSON arrays and documents (both root and embedded).
+         * The typeMap parameter may be used to control the PHP types used for converting BSON arrays and documents (both root and embedded).
          * @link https://php.net/manual/en/function.mongodb.bson-tophp.php
          * @param string $bson BSON value to be unserialized.
          * @param array $typeMap
@@ -2416,7 +2416,7 @@ namespace MongoDB {}
             }
 
             /**
-             * Returns the hexidecimal representation of this ObjectId
+             * Returns the hexadecimal representation of this ObjectId
              * @link https://php.net/manual/en/mongodb-bson-objectid.tostring.php
              * @return string
              */
@@ -2970,9 +2970,9 @@ namespace MongoDB {}
             function getTimestamp();
 
             /**
-             * Returns the hexidecimal representation of this ObjectId
+             * Returns the hexadecimal representation of this ObjectId
              * @link https://www.php.net/manual/en/mongodb-bson-objectid.tostring.php
-             * @return string Returns the hexidecimal representation of this ObjectId
+             * @return string Returns the hexadecimal representation of this ObjectId
              */
             function __toString();
         }

--- a/mosquitto-php/mosquitto-php.php
+++ b/mosquitto-php/mosquitto-php.php
@@ -142,7 +142,7 @@ class Client
      *
      * @param string $host Hostname to connect to
      * @param int $port Optional. Port number to connect to. Defaults to 1883.
-     * @param int $keepalive Optional. Number of sections after which the broker should PING the client if no messages have been recieved.
+     * @param int $keepalive Optional. Number of sections after which the broker should PING the client if no messages have been received.
      * @param string|null $interface Optional. The address or hostname of a local interface to bind to for this connection.
      * @return int
      */

--- a/mysql_xdevapi/mysql_xdevapi.php
+++ b/mysql_xdevapi/mysql_xdevapi.php
@@ -198,7 +198,7 @@ class Collection  {
 
     /**
      * Remove one collection document
-     * Remove one document from the collection with the correspending ID. This is a shortcut for Collection.remove("_id = :id").bind("id", id).execute().
+     * Remove one document from the collection with the corresponding ID. This is a shortcut for Collection.remove("_id = :id").bind("id", id).execute().
      * @link https://www.php.net/manual/en/mysql-xdevapi-collection.removeone.php
      * @param string $id
      * @return \mysql_xdevapi\Result

--- a/mysqli/mysqli.php
+++ b/mysqli/mysqli.php
@@ -146,7 +146,7 @@ class mysqli  {
 	) {}
 
 	/**
-	 * Turns on or off auto-commiting database modifications
+	 * Turns on or off auto-committing database modifications
 	 * @link https://php.net/manual/en/mysqli.autocommit.php
 	 * @param bool $mode <p>
 	 * Whether to turn on auto-commit or not.
@@ -828,7 +828,7 @@ class mysqli_result implements Traversable  {
 	public function free () {}
 
 	/**
-	 * Adjusts the result pointer to an arbitary row in the result
+	 * Adjusts the result pointer to an arbitrary row in the result
 	 * @link https://php.net/manual/en/mysqli-result.data-seek.php
 	 * @param int $offset <p>
 	 * The field offset. Must be between zero and the total number of rows

--- a/ncurses/ncurses.php
+++ b/ncurses/ncurses.php
@@ -1228,7 +1228,7 @@ function ncurses_mouse_trafo (&$y, &$x, $toscreen) {}
 function ncurses_wmouse_trafo ($window, &$y, &$x, $toscreen) {}
 
 /**
- * Outputs text at current postion in window
+ * Outputs text at current position in window
  * @link https://php.net/manual/en/function.ncurses-waddstr.php
  * @param $window resource <p>
  * </p>

--- a/oci8/oci8.php
+++ b/oci8/oci8.php
@@ -433,7 +433,7 @@ function oci_define_by_name ($statement, $column_name, &$variable, $type = SQLT_
  * Binds a PHP variable to an Oracle placeholder
  * @link https://php.net/manual/en/function.oci-bind-by-name.php
  * @param resource $statement <p>
- * A valid OCI8 statement identifer.
+ * A valid OCI8 statement identifier.
  * </p>
  * @param string $bv_name <p>
  * The colon-prefixed bind variable placeholder used in the

--- a/openssl/openssl.php
+++ b/openssl/openssl.php
@@ -199,7 +199,7 @@ function openssl_spki_new(&$privkey, &$challenge, $algorithm = 0) {}
 function openssl_spki_verify(&$spkac) {}
 
 /**
- * Exports the challenge assoicated with a signed public key and challenge
+ * Exports the challenge associated with a signed public key and challenge
  * @link https://php.net/manual/en/function.openssl-spki-export-challenge.php
  * @param string $spkac <p>Expects a valid signed public key and challenge</p>
  * @return string|null Returns the associated challenge string or NULL on failure.

--- a/pq/pq.php
+++ b/pq/pq.php
@@ -523,7 +523,7 @@ class Connection  {
 	 */
 	function listen(string $channel, callable $listener) {}
 	/**
-	 * [Asynchronously](pq/Connection/: Asynchronous Usage) start listening on $channel for notifcations.
+	 * [Asynchronously](pq/Connection/: Asynchronous Usage) start listening on $channel for notifications.
 	 * See pq\Connection::listen().
 	 * 
 	 * @param string $channel The channel to listen on.

--- a/pthreads/pthreads.php
+++ b/pthreads/pthreads.php
@@ -407,7 +407,7 @@ class Stackable extends Threaded implements Traversable, Countable, ArrayAccess 
  * When the start method of a Thread is invoked, the run method code will be
  * executed in separate Thread, in parallel.<br/>
  * After the run method is executed the Thread will exit immediately, it will
- * be joined with the creating Thread at the approriate time.
+ * be joined with the creating Thread at the appropriate time.
  *
  * @link https://secure.php.net/manual/en/class.thread.php
  */

--- a/radius/radius.php
+++ b/radius/radius.php
@@ -351,7 +351,7 @@ function radius_add_server($radius_handle , $hostname, $port , $secret, $timeout
 function radius_auth_open() { }
 
 /**
- * Free all ressources. It is not needed to call this function because php frees all resources at the end of each request.
+ * Free all resources. It is not needed to call this function because php frees all resources at the end of each request.
  * @link https://secure.php.net/manual/en/function.radius-close.php
  * @param resource $radius_handle
  * @return bool Returns <b>TRUE</b> on success or <b>FALSE</b> on failure.

--- a/redis/Redis.php
+++ b/redis/Redis.php
@@ -443,7 +443,7 @@ class Redis
      * // Will set the key, if it doesn't exist, with a ttl of 10 seconds
      * $redis->set('key', 'value', ['nx', 'ex' => 10]);
      *
-     * // Will set a key, if it does exist, with a ttl of 1000 miliseconds
+     * // Will set a key, if it does exist, with a ttl of 1000 milliseconds
      * $redis->set('key', 'value', ['xx', 'px' => 1000]);
      * </pre>
      *
@@ -890,7 +890,7 @@ class Redis
      * If the second argument is filled, it will be used as the integer value of the decrement.
      *
      * @param string $key
-     * @param int    $value  that will be substracted to key (only for decrBy)
+     * @param int    $value  that will be subtracted to key (only for decrBy)
      *
      * @return int the new value
      *
@@ -1316,7 +1316,7 @@ class Redis
     }
 
     /**
-     * Removes the first count occurences of the value element from the list.
+     * Removes the first count occurrences of the value element from the list.
      * If count is zero, all the matching elements are removed. If count is negative,
      * elements are removed from tail to head.
      *
@@ -3509,7 +3509,7 @@ class Redis
      * @param string|array $key2 ...
      * @param int $timeout
      *
-     * @return array Either an array with the key member and score of the higest or lowest element or an empty array
+     * @return array Either an array with the key member and score of the highest or lowest element or an empty array
      * if the timeout was reached without an element to pop.
      *
      * @since >= 5.0
@@ -3534,7 +3534,7 @@ class Redis
      * @param string|array $key2 ...
      * @param int $timeout
      *
-     * @return array Either an array with the key member and score of the higest or lowest element or an empty array
+     * @return array Either an array with the key member and score of the highest or lowest element or an empty array
      * if the timeout was reached without an element to pop.
      *
      * @see bzPopMax
@@ -4583,7 +4583,7 @@ class Redis
     /**
      * Return the current Redis server time.
      *
-     * @return array If successfull, the time will come back as an associative array with element zero being the
+     * @return array If successful, the time will come back as an associative array with element zero being the
      * unix timestamp, and element one being microseconds.
      *
      * @link    https://redis.io/commands/time

--- a/redis/RedisCluster.php
+++ b/redis/RedisCluster.php
@@ -141,7 +141,7 @@ class RedisCluster {
      * // Will set the key, if it doesn't exist, with a ttl of 10 seconds
      * $redisCluster->set('key', 'value', Array('nx', 'ex'=>10));
      *
-     * // Will set a key, if it does exist, with a ttl of 1000 miliseconds
+     * // Will set a key, if it does exist, with a ttl of 1000 milliseconds
      * $redisCluster->set('key', 'value', Array('xx', 'px'=>1000));
      * </pre>
      */
@@ -688,7 +688,7 @@ class RedisCluster {
     public function lIndex($key, $index) { }
 
     /**
-     * Removes the first count occurences of the value element from the list.
+     * Removes the first count occurrences of the value element from the list.
      * If count is zero, all the matching elements are removed. If count is negative,
      * elements are removed from tail to head.
      *
@@ -1773,7 +1773,7 @@ class RedisCluster {
      * value of the decrement.
      *
      * @param   string $key
-     * @param   int    $value that will be substracted to key (only for decrBy)
+     * @param   int    $value that will be subtracted to key (only for decrBy)
      *
      * @return  int       the new value
      * @link    https://redis.io/commands/decrby

--- a/rrd/rrd.php
+++ b/rrd/rrd.php
@@ -65,7 +65,7 @@ function rrd_first($file, $raaindex = 0) {}
  * The filename to output the graph to. This will generally end in either .png, .svg or .eps, depending on the format you want to output.
  * </p>
  * @param array $options <p>
- * Options for generating image. See man page of rrd graph for all possible options. All options (data definitions, variable defintions, etc.) are allowed.
+ * Options for generating image. See man page of rrd graph for all possible options. All options (data definitions, variable definitions, etc.) are allowed.
  * </p>
  * @return array|false If image is created successfully an array with information about generated image is returned, FALSE when error occurs.
  * @since PECL rrd >= 0.9.0
@@ -210,7 +210,7 @@ class RRDCreator {
 
     /**
      * Adds data source definition for RRD database.<p>
-     * RRD can accept input from several data sources (DS), e.g incomming and outgoing traffic. This method adds data source by description. You need call this method for each data source.
+     * RRD can accept input from several data sources (DS), e.g incoming and outgoing traffic. This method adds data source by description. You need call this method for each data source.
      * </p>
      * @link https://php.net/manual/en/rrdcreator.adddatasource.php
      * @param string $description <p>

--- a/soap/soap.php
+++ b/soap/soap.php
@@ -349,7 +349,7 @@ class SoapClient  {
 	 * Returns list of available SOAP functions
 	 * @link https://php.net/manual/en/soapclient.getfunctions.php
 	 * @return array The array of SOAP function prototypes, detailing the return type,
-	 * the function name and type-hinted paramaters.
+	 * the function name and type-hinted parameters.
 	 * @since 5.0.1
 	 */
 	public function __getFunctions () {}

--- a/sockets/sockets.php
+++ b/sockets/sockets.php
@@ -392,7 +392,7 @@ function socket_close ($socket) {}
  * @param int $length [optional] <p>
  * The optional parameter <i>length</i> can specify an
  * alternate length of bytes written to the socket. If this length is
- * greater then the buffer length, it is silently truncated to the length
+ * greater than the buffer length, it is silently truncated to the length
  * of the buffer.
  * </p>
  * @return int|false the number of bytes successfully written to the socket or <b>FALSE</b> on failure.

--- a/solr/Queries/SolrQuery.php
+++ b/solr/Queries/SolrQuery.php
@@ -980,7 +980,7 @@ class SolrQuery extends SolrModifiableParams implements Serializable {
 
 	/**
 	 * (PECL solr &gt;= 0.9.2)<br/>
-	 * Returns the treshold frequency at which words will be ignored which do not occur in at least this many docs
+	 * Returns the threshold frequency at which words will be ignored which do not occur in at least this many docs
 	 * @link https://php.net/manual/en/solrquery.getmltmindocfrequency.php
 	 * @return int|null <p>
 	 * Returns an integer on success and <b>NULL</b> if not set
@@ -1971,7 +1971,7 @@ class SolrQuery extends SolrModifiableParams implements Serializable {
 	 * Sets the factor by which the regex fragmenter can stray from the ideal fragment size
 	 * @link https://php.net/manual/en/solrquery.sethighlightregexslop.php
 	 * @param float $factor <p>
-	 * The factor by which the regex fragmenter can stray from the ideal fragment size (specfied by
+	 * The factor by which the regex fragmenter can stray from the ideal fragment size (specified by
 	 * SolrQuery::setHighlightFragsize) to accommodate the regular expression.
 	 * </p>
 	 * @return SolrQuery <p>

--- a/solr/SolrClient.php
+++ b/solr/SolrClient.php
@@ -33,22 +33,22 @@ final class SolrClient {
 	/** @var int Used when retrieving system information from the system servlet. */
 	const SYSTEM_SERVLET_TYPE = 32;
 
-	/** @var string This is the intial value for the search servlet. */
+	/** @var string This is the initial value for the search servlet. */
 	const DEFAULT_SEARCH_SERVLET = 'select';
 
-	/** @var string This is the intial value for the update servlet. */
+	/** @var string This is the initial value for the update servlet. */
 	const DEFAULT_UPDATE_SERVLET = 'update';
 
-	/** @var string This is the intial value for the threads servlet. */
+	/** @var string This is the initial value for the threads servlet. */
 	const DEFAULT_THREADS_SERVLET = 'admin/threads';
 
-	/** @var string This is the intial value for the ping servlet. */
+	/** @var string This is the initial value for the ping servlet. */
 	const DEFAULT_PING_SERVLET = 'admin/ping';
 
-	/** @var string This is the intial value for the terms servlet used for the TermsComponent. */
+	/** @var string This is the initial value for the terms servlet used for the TermsComponent. */
 	const DEFAULT_TERMS_SERVLET = 'terms';
 
-	/** @var string This is the intial value for the system servlet used to obtain Solr Server information. */
+	/** @var string This is the initial value for the system servlet used to obtain Solr Server information. */
 	const DEFAULT_SYSTEM_SERVLET = 'admin/system';
 
 	/**

--- a/standard/password.php
+++ b/standard/password.php
@@ -29,7 +29,7 @@
  * Examples of these values can be found on the {@link "https://secure.php.net/manual/en/function.crypt.php crypt()"} page.
  * </p>
  * <p>
- * If ommitted, a default value of <em>10</em> will be used. This is a good
+ * If omitted, a default value of <em>10</em> will be used. This is a good
  * baseline cost, but you may want to consider increasing it depending on your hardware.
  * </p>
  * </li>
@@ -64,7 +64,7 @@ define("PASSWORD_BCRYPT_DEFAULT_COST", 10);
  * change. Therefore you should be aware that the length of the resulting
  * hash can change. Therefore, if you use <b>PASSWORD_DEFAULT</b>
  * you should store the resulting hash in a way that can store more than 60
- * characters (255 is the recomended width).
+ * characters (255 is the recommended width).
  * </p>
  * <p>
  * Values for this constant:

--- a/standard/standard_9.php
+++ b/standard/standard_9.php
@@ -1022,7 +1022,7 @@ function stream_isatty($name) {}
  * This method is called upon filter shutdown (typically, this is also
  * during stream shutdown), and is executed after
  * the flush method is called. If any resources
- * were allocated or initialzed during onCreate()
+ * were allocated or initialized during onCreate()
  * this would be the time to destroy or dispose of them.
  * </p>
  * @return bool true on success or false on failure.

--- a/sync/sync.php
+++ b/sync/sync.php
@@ -51,7 +51,7 @@ class SyncMutex {
 /**
  * SyncSemaphore
  *
- * A cross-platform, native implementation of named and unnamed sempahore objects.
+ * A cross-platform, native implementation of named and unnamed semaphore objects.
  * A semaphore restricts access to a limited resource to a limited number of instances. Semaphores differ from mutexes in that they can allow more than one instance to access a resource at one time while a mutex only allows one instance at a time.
  *
  * @link https://php.net/manual/en/class.syncsemaphore.php

--- a/uv/uv_functions.php
+++ b/uv/uv_functions.php
@@ -163,7 +163,7 @@ function uv_close($handle, callable $callback) {}
 /**
  * Starts read callback for uv resources.
  *
- * Note: You have to handle erorrs correctly. otherwise this will leak.
+ * Note: You have to handle errors correctly. otherwise this will leak.
  * Note: if you want to use PHP's stream or socket resource. see uv_fs_poll_init and uv_fs_read.
  *
  * @param resource $handle uv resources (uv_tcp, uv_udp, uv_pipe ...etc.)
@@ -866,7 +866,7 @@ function uv_check_stop($handle) {}
 function uv_async_init($loop, callable $callback) {}
 
 /**
- * Send async callback immidiately.
+ * Send async callback immediately.
  *
  * @param resource $handle uv async handle.
  *

--- a/winbinder/winbinder.php
+++ b/winbinder/winbinder.php
@@ -233,7 +233,7 @@ function wb_message_box($parent, $message, $title = null, $style = null)
  * Parameter source may be a sound file name or a system sound constant.
  * Parameter command may be used used to play a WAV sound synchronously or in a loop.
  * A synchronous sound stops the currently playing sound and suspends the application control until it finishes.
- * A MIDI soundtrack always stops any currenly playing MIDI soundtrack.
+ * A MIDI soundtrack always stops any currently playing MIDI soundtrack.
  * To stop one or more sounds, use function wb_stop_sound().
  *
  * Value of $source:
@@ -957,7 +957,7 @@ function wb_get_parent($wbobject, $item = null)
 /**
  * Returns a value or array with the indices or identifiers of the selected elements or items in wbobject.
  *
- * Retrives:
+ * Retrieves:
  *
  * ComboBox    The index of the currently selected item.
  * ListBox    The index of the currently selected item. If multiselected only the last on will be returned (use getText for all items text)

--- a/wincache/wincache.php
+++ b/wincache/wincache.php
@@ -225,7 +225,7 @@ function wincache_scache_meminfo() {}
  * be used as keys. This can be used to add multiple values in the cache in one
  * operation, thus avoiding race condition.</p>
  * @param mixed $value <p>Value of a variable to store. Value supports all data
- * types except resources, such as file handles. This paramter is ignored if
+ * types except resources, such as file handles. This parameter is ignored if
  * first argument is an array. A general guidance is to pass NULL as value while
  * using array as key.</p>
  * @param int $ttl [optional]
@@ -406,7 +406,7 @@ function wincache_ucache_meminfo() {}
  * cache in one operation, thus avoiding race condition.</p>
  * @param mixed $value<p>
  * Value of a variable to store. Value supports all data types except resources,
- * such as file handles. This paramter is ignored if first argument is an array.
+ * such as file handles. This parameter is ignored if first argument is an array.
  * A general guidance is to pass NULL as value while using array as key.</p>
  * @param int $ttl [optional]<p>
  * Time for the variable to live in the cache in seconds. After the value specified

--- a/zend/zend.php
+++ b/zend/zend.php
@@ -126,7 +126,7 @@ class ZendAPI_Queue {
      * @param array $filter_options Array of optional filter options to filter the jobs we want to get 
         from the queue. If not set, all jobs will be returned.<br>
      *     Options can be: priority, application_id, name, status, recurring.
-     * @param int $max_jobs  Maximum jobs to retrive. Default is -1, getting all jobs available.
+     * @param int $max_jobs  Maximum jobs to retrieve. Default is -1, getting all jobs available.
      * @param bool $with_globals_and_output. Whether gets the global variables dataand job output.
      *     Default is false.
      * @return array  Jobs that satisfies filter_options.
@@ -189,7 +189,7 @@ class ZendAPI_Queue {
 
 
     /**
-     * Return description of the last error occured in the queue object. After every
+     * Return description of the last error occurred in the queue object. After every
      *    method invoked an error string describing the error is store in the queue object.
      * @return string 
      */
@@ -596,16 +596,16 @@ function monitor_license_info() {}
  * results array is saved in the event_extra_data table.
  * @param string $event_handler_func The callback function that will be call when the event is triggered, object methods may also be invoked statically using t
 his function by passing array($objectname, $methodname) to the function parameter
- * @param string $handler_register_name [optional] The name this function is registered under - if none is supplied, the function will be registerd under it's own name
+ * @param string $handler_register_name [optional] The name this function is registered under - if none is supplied, the function will be registered under it's own name
  * @param int $event_type_mask The mask of event types that the handler should be called on by default it's set to MONITOR_EVENT_ALL.
- * @return bool TRUE on sucess and FALSE if an error occurs.
+ * @return bool TRUE on success and FALSE if an error occurs.
  */
 function register_event_handler($event_handler_func, $handler_register_name, $event_type_mask) {}
 
 /**
  * Allow you to unregister an event handler.
  * @param string $handler_name the name you registered with the handler you now wish to unregister.
- * @return bool TRUE on sucess and FALSE if no handler we registered under the given name.
+ * @return bool TRUE on success and FALSE if no handler we registered under the given name.
  */
 function unregister_event_handler($handler_name) {}
 

--- a/zip/zip.php
+++ b/zip/zip.php
@@ -410,7 +410,7 @@ class ZipArchive implements Countable {
 
 	/**
 	 * (PHP 7 &gt;= 7.2.0, PECL zip &gt;= 1.15.0)<br/>
-	 * Counts the number of files in the achive.
+	 * Counts the number of files in the archive.
 	 * @link https://www.php.net/manual/en/ziparchive.count.php
 	 * @return int
 	 * @since 7.2


### PR DESCRIPTION
Hello,

This huge PR will fix : 

- 1 typo in `Core/Core_d.php`
- 2 typos in `cassandra/cassandra.php`
- 1 typo in `couchbase/couchbase.php`
- 4 typos in `crypto/crypto.php`
- 1 typo in `curl/curl.php`
- 1 typo in `curl/curl_d.php`
- 1 typo in `date/date.php`
- 1 typo in `dba/dba.php`
- 1 typo in `decimal/decimal.php`
- 11 typos in `dom/dom_c.php`
- 1 typo in `event/event.php`
- 1 typo in `fileinfo/fileinfo.php`
- 2 typos in `gearman/gearman.php`
- 2 typos in `gmagick/gmagick.php`
- 1 typo in `http/http3.php`
- 1 typo in `ldap/ldap.php`
- 4 typos in `libevent/libevent.php`
- 3 typos in `mongo/mongo.php`
- 6 typos in `mongodb/mongodb.php`
- 1 typo in `mosquitto-php/mosquitto-php.php`
- 1 typo in `mysql_xdevapi/mysql_xdevapi.php`
- 2 typos in `mysqli/mysqli.php`
- 1 typo in `ncurses/ncurses.php`
- 1 typo in `oci8/oci8.php`
- 1 typo in `openssl/openssl.php`
- 1 typo in `pq/pq.php`
- 1 typo in `pthreads/pthreads.php`
- 1 typo in `radius/radius.php`
- 6 typos in `redis/Redis.php`
- 3 typos in `redis/RedisCluster.php`
- 2 typos in `rrd/rrd.php`
- 1 typo in `soap/soap.php`
- 1 typo in `sockets/sockets.php`
- 2 typos in `solr/Queries/SolrQuery.php`
- 6 typos in `solr/SolrClient.php`
- 2 typos in `standard/password.php`
- 1 typo in `standard/standard_9.php`
- 1 typo in `sync/sync.php`
- 2 typos in `uv/uv_functions.php`
- 2 typos in `winbinder/winbinder.php`
- 2 typos in `wincache/wincache.php`
- 5 typos in `zend/zend.php`
- 1 typo in `zip/zip.php`



Cheers! :robot: