### PR TITLE
fix wrong @return at \FFI::cdef()

### DIFF
--- a/FFI/FFI.php
+++ b/FFI/FFI.php
@@ -30,7 +30,7 @@ namespace {
          *
          * @param string $code The collection of C declarations.
          * @param string|null $library DSO library.
-         * @return CData|FFI|mixed
+         * @return FFI
          * @throws ParserException
          */
         public static function cdef(string $code, string $library = null): FFI {}


### PR DESCRIPTION
Fixes the leftovers from https://github.com/JetBrains/phpstorm-stubs/pull/777#discussion_r410971024