### PR TITLE
Unprefix Generator::throw() method

### DIFF
--- a/standard/_types.php
+++ b/standard/_types.php
@@ -191,7 +191,7 @@ namespace {
          * @param Throwable $exception
          * @return mixed
          */
-        function PS_UNRESERVE_PREFIX_throw(Throwable $exception) {}
+        function throw(Throwable $exception) {}
 
         /**
          * Returns whatever was passed to return or null if nothing.


### PR DESCRIPTION
I don't know what the `PS_UNRESERVE_PREFIX_` prefix is for. Let's see if it was added to the `throw()` error by mistake or not.