### PR TITLE
Fix invalid tag for CURLOPT_SSL_VERIFYPEER in curl_d.php

### DIFF
--- a/curl/curl_d.php
+++ b/curl/curl_d.php
@@ -658,7 +658,6 @@ define ('CURLOPT_CONNECTTIMEOUT_MS', 156);
  * Alternate certificates to verify against can be specified with the <b>CURLOPT_CAINFO</b> option or
  * a certificate directory can be specified with the <b>CURLOPT_CAPATH</b> option.
  * @link https://www.php.net/manual/en/function.curl-setopt.php
- * @since 7.1
  */
 define ('CURLOPT_SSL_VERIFYPEER', 64);
 /**


### PR DESCRIPTION
The option CURLOPT_SSL_VERIFYPEER is available since at least PHP 5.
The comment in the documentation is referring about cURL package for the default value.

https://www.php.net/manual/en/function.curl-setopt.php