### PR TITLE
getName() to ReflectionType

### DIFF
--- a/Reflection/Reflection.php
+++ b/Reflection/Reflection.php
@@ -1875,6 +1875,17 @@ class ReflectionType
 	public function allowsNull()
 	{
 	}
+	
+	/**
+	 * @todo Update documentation once it's released in the offical PHP docs.
+	 * Get name of the property type
+	 * @link https://php.net/manual/en/reflectiontype.tostring.php (not yet documented)
+	 * @return string Returns the type of the parameter.
+	 * @since 7.1
+	 */
+	public function getName()
+	{
+	}
 
 	/**
 	 * Checks if it is a built-in type


### PR DESCRIPTION
Adds getName() to ReflectionType even though the official documentation has not yet been updated. Unsure how this should be implemented so suggestions are appreciated, seeing as it's not documented. Should it just contain the empty function for now? Or should I use the stub to attempt explaining it similar to other methods in the Reflection API?

Appreciate some feedback, Brgds