### PR TITLE
Added `ZipArchive::LIBZIP_VERSION`

### DIFF
--- a/zip/zip.php
+++ b/zip/zip.php
@@ -7,6 +7,11 @@
  * @link https://php.net/manual/en/class.ziparchive.php
  */
 class ZipArchive implements Countable {
+	/**
+	 * Zip library version
+	 * @link https://php.net/manual/en/zip.constants.php
+	 */
+	const LIBZIP_VERSION = '1.5.1';
 
 	/**
 	 * Create the archive if it does not exist.

--- a/zip/zip.php
+++ b/zip/zip.php
@@ -10,6 +10,7 @@ class ZipArchive implements Countable {
 	/**
 	 * Zip library version
 	 * @link https://php.net/manual/en/zip.constants.php
+	 * @since 7.4.3
 	 */
 	const LIBZIP_VERSION = '1.5.1';
 


### PR DESCRIPTION
not sure what the correct value for such a version-dependent constant would be, but for static analysis or autocompletion purposes having it defined at all is usefull in itself.