### PR TITLE
Change uppercase NULL into lowercase null for saveHTML default value

### DIFF
--- a/dom/dom_c.php
+++ b/dom/dom_c.php
@@ -964,7 +964,7 @@ class DOMDocument extends DOMNode  {
      * @param DOMNode $node [optional] parameter to output a subset of the document.
      * @return string the HTML, or false if an error occurred.
      */
-    public function saveHTML (DOMNode $node = NULL) {}
+    public function saveHTML (DOMNode $node = null) {}
 
     /**
      * Dumps the internal document into a file using HTML formatting


### PR DESCRIPTION
This PR changes an inconsistency in the stubs for the `dom` extension.

The signature for `DOMDocument::saveHTML($node = NULL)` has the uppercase `null` as default value for its first and only `$node` argument.

The PR changes this to the lowercase `null` instead.

At the very least, this will make the file more consistent. However, I suspect that this is the cause for the PHPStan issue at https://github.com/phpstan/phpstan/issues/3478, so this will also hopefully fix that issue.