### PR TITLE
Fix for http_build_query

### DIFF
--- a/standard/standard_2.php
+++ b/standard/standard_2.php
@@ -549,7 +549,7 @@ function rawurldecode ($str) {}
  *  <p>If enc_type is PHP_QUERY_RFC3986, then encoding is performed according to » RFC 3986, and spaces will be percent encoded (%20).
  * @return string a URL-encoded string.
  */
-function http_build_query ($query_data, $numeric_prefix = "", $arg_separator = "&", $enc_type = PHP_QUERY_RFC1738){}
+function http_build_query ($query_data, string $numeric_prefix = "", string $arg_separator = "&", int $enc_type = PHP_QUERY_RFC1738){}
 
 /**
  * Returns the target of a symbolic link

--- a/standard/standard_2.php
+++ b/standard/standard_2.php
@@ -549,7 +549,7 @@ function rawurldecode ($str) {}
  *  <p>If enc_type is PHP_QUERY_RFC3986, then encoding is performed according to » RFC 3986, and spaces will be percent encoded (%20).
  * @return string a URL-encoded string.
  */
-function http_build_query ($query_data, $numeric_prefix = null, $arg_separator = null, $enc_type = PHP_QUERY_RFC1738){}
+function http_build_query ($query_data, $numeric_prefix = "", $arg_separator = "&", $enc_type = PHP_QUERY_RFC1738){}
 
 /**
  * Returns the target of a symbolic link


### PR DESCRIPTION
According to the PHP documentation. The additional parameters for `http_build_query` are defined as:

```
http_build_query ( mixed $query_data [, string $numeric_prefix [, string $arg_separator [, int $enc_type = PHP_QUERY_RFC1738 ]]] ) : string
```

We recently found out that these parameters are not nullable when strict_types enabled. This PR fixes the error below:
```
Exception 'TypeError' with message 'http_build_query() expects parameter 2 to be string, null given'
```

The second parameter is set to `arg_separator.output`. According to the default PHP.ini. That value is in almost any case `&`: arg_separator.output	"&"	PHP_INI_ALL