### PR TITLE
Correct return value for bzopen(), dba_open(), finfo_open() and shmop_open() functions

### DIFF
--- a/bz2/bz2.php
+++ b/bz2/bz2.php
@@ -11,7 +11,7 @@
  * and 'w' (write) are supported. Everything else will cause bzopen
  * to return <b>FALSE</b>.
  * </p>
- * @return resource If the open fails, <b>bzopen</b> returns <b>FALSE</b>, otherwise
+ * @return resource|false If the open fails, <b>bzopen</b> returns <b>FALSE</b>, otherwise
  * it returns a pointer to the newly opened file.
  */
 function bzopen ($filename, $mode) {}

--- a/dba/dba.php
+++ b/dba/dba.php
@@ -117,7 +117,7 @@
  * can act on behalf of them.
  * </p>
  * @param mixed $_ [optional]
- * @return resource a positive handle on success or <b>FALSE</b> on failure.
+ * @return resource|false a positive handle on success or <b>FALSE</b> on failure.
  */
 function dba_open ($path, $mode, $handler = null, $_ = null) {}
 
@@ -140,7 +140,7 @@ function dba_open ($path, $mode, $handler = null, $_ = null) {}
  * can act on behalf of them.
  * </p>
  * @param mixed $_ [optional]
- * @return resource a positive handle on success or <b>FALSE</b> on failure.
+ * @return resource|false a positive handle on success or <b>FALSE</b> on failure.
  */
 function dba_popen ($path, $mode, $handler = null, $_ = null) {}
 

--- a/fileinfo/fileinfo.php
+++ b/fileinfo/fileinfo.php
@@ -76,7 +76,7 @@ class finfo  {
  * A .mime and/or .mgc suffix is added if
  * needed.
  * </p>
- * @return resource a magic database resource on success or <b>FALSE</b> on failure.
+ * @return resource|false a magic database resource on success or <b>FALSE</b> on failure.
  */
 function finfo_open ($options = null, $magic_file = null) {}
 

--- a/shmop/shmop.php
+++ b/shmop/shmop.php
@@ -22,7 +22,7 @@
  * @param int $size <p>
  * The size of the shared memory block you wish to create in bytes
  * </p>
- * @return resource On success <b>shmop_open</b> will return an id that you can
+ * @return resource|false On success <b>shmop_open</b> will return an id that you can
  * use to access the shared memory segment you've created. <b>FALSE</b> is
  * returned on failure.
  */


### PR DESCRIPTION
Correct return value for [`bzopen()`](https://www.php.net/manual/en/function.bzopen.php#refsect1-function.bzopen-returnvalues), [`dba_open()`](https://www.php.net/manual/en/function.dba-open.php#refsect1-function.dba-open-returnvalues), [`finfo_open()`](https://www.php.net/manual/en/function.finfo-open.php#refsect1-function.finfo-open-returnvalues) and [`shmop_open()`](https://www.php.net/manual/en/function.shmop-open.php#refsect1-function.shmop-open-returnvalues) functions.

Return type declared as `resource`, but `false` returned on failure.