### PR TITLE
Correct return value for PHP internal functions on failure

### DIFF
--- a/cubrid/cubrid.php
+++ b/cubrid/cubrid.php
@@ -33,7 +33,7 @@
  * a new connection, even if cubrid_connect() was called
  * before with the same parameters.
  * </p>
- * @return resource <p>
+ * @return resource|false <p>
  * a CUBRID connection identifier on success or false on failure.
  * </p>
  */
@@ -65,7 +65,7 @@ function cubrid_connect ($host, $port, $dbname, $userid = 'PUBLIC', $passwd = ''
  * a new connection, even if cubrid_connect() was called
  * before with the same parameters.
  * </p>
- * @return resource <p>
+ * @return resource|false <p>
  * a CUBRID connection identifier on success or false on failure.
  * </p>
  */
@@ -92,7 +92,7 @@ function cubrid_connect_with_url ($conn_url, $userid = 'PUBLIC', $passwd = '', $
  * User password. Default value is empty string, i.e. no
  * password is defined.
  * </p>
- * @return resource <p>
+ * @return resource|false <p>
  * Connection identifier, when process is successful.
  * FALSE, when process is unsuccessful.
  * </p>
@@ -115,7 +115,7 @@ function cubrid_pconnect ($host, $port, $dbname, $userid = 'PUBLIC', $passwd = '
  * User password. Default value is empty string, i.e. no
  * password is defined.
  * </p>
- * @return resource <p>
+ * @return resource|false <p>
  * Connection identifier, when process is successful.
  * FALSE, when process is unsuccessful.
  * </p>
@@ -161,7 +161,7 @@ function cubrid_disconnect ($conn_identifier = null) {}
  * is not specified, the last connection opened by
  * cubrid_connect() is assumed.
  * </p>
- * @return resource <ul><li>
+ * @return resource|bool <ul><li>
  * For SELECT, SHOW, DESCRIBE, EXPLAIN and other statements
  * returning resultset, cubrid_query() returns a resource
  * on success, or false on error.
@@ -207,7 +207,7 @@ function cubrid_query ($query, $conn_identifier = null) {}
  * Query execution option CUBRID_INCLUDE_OID, CUBRID_ASYNC,
  * CUBRID_EXEC_QUERY_ALL.
  * </p>
- * @return resource <p>
+ * @return resource|bool <p>
  * Request identifier, when process is successful,
  * or FALSE, when process is unsuccessful.
  * </p>
@@ -341,7 +341,7 @@ function cubrid_col_size ($conn_identifier, $oid, $attr_name) {}
  * The CUBRID connection. If the connection identifier is not
  * specified, the last connection opened by cubrid_connect() is assumed.
  * </p>
- * @return resource <p>
+ * @return resource|bool <p>
  * For SELECT, SHOW, DESCRIBE or EXPLAIN statements,
  * cubrid_unbuffered_query() returns a resource on success, or false on
  * error.
@@ -1427,7 +1427,7 @@ function cubrid_lob2_import ($lob_identifier, $file_name) {}
  * It may be "BLOB" or "CLOB", it won't be case-sensitive.
  * The default value is "BLOB".
  * </p>
- * @return resource <p>
+ * @return resource|false <p>
  * Lob identifier when it is successful. FALSE on failure.
  * </p>
  */
@@ -1649,7 +1649,7 @@ function cubrid_next_result ($result) {}
  * @param int $option [optional] <p>
  * OID return option CUBRID_INCLUDE_OID.
  * </p>
- * @return resource <p>
+ * @return resource|false <p>
  * Request identifier, if process is successful;
  * FALSE, if process is unsuccessful.
  * </p>

--- a/enchant/enchant.php
+++ b/enchant/enchant.php
@@ -6,7 +6,7 @@
  * (PHP 5 &gt;= 5.3.0, PECL enchant &gt;= 0.1.0 )<br/>
  * create a new broker object capable of requesting
  * @link https://php.net/manual/en/function.enchant-broker-init.php
- * @return resource a broker resource on success or <b>FALSE</b>.
+ * @return resource|false a broker resource on success or <b>FALSE</b>.
  */
 function enchant_broker_init () {}
 
@@ -66,7 +66,7 @@ function enchant_broker_list_dicts ($broker) {}
  * @param string $tag <p>
  * A tag describing the locale, for example en_US, de_DE
  * </p>
- * @return resource a dictionary resource on success or <b>FALSE</b> on failure.
+ * @return resource|false a dictionary resource on success or <b>FALSE</b> on failure.
  */
 function enchant_broker_request_dict ($broker, $tag) {}
 
@@ -80,7 +80,7 @@ function enchant_broker_request_dict ($broker, $tag) {}
  * @param string $filename <p>
  * Path to the PWL file.
  * </p>
- * @return resource a dictionary resource on success or <b>FALSE</b> on failure.
+ * @return resource|false a dictionary resource on success or <b>FALSE</b> on failure.
  */
 function enchant_broker_request_pwl_dict ($broker, $filename) {}
 

--- a/fann/fann.php
+++ b/fann/fann.php
@@ -123,7 +123,7 @@ function fann_copy($ann)
  *
  * @param string $configuration_file
  *
- * @return resource
+ * @return resource|false
  */
 function fann_create_from_file($configuration_file)
 {
@@ -223,7 +223,7 @@ function fann_create_standard($num_layers, $num_neurons1, $num_neurons2, $_ = nu
  * @param int $num_output
  * @param callable $user_function
  *
- * @return resource
+ * @return resource|false
  */
 function fann_create_train_from_callback($num_data, $num_input, $num_output, $user_function)
 {
@@ -237,7 +237,7 @@ function fann_create_train_from_callback($num_data, $num_input, $num_output, $us
  * @param int $num_input
  * @param int $num_output
  *
- * @return resource
+ * @return resource|false
  */
 function fann_create_train($num_data, $num_input, $num_output)
 {
@@ -312,7 +312,7 @@ function fann_destroy_train($train_data)
  *
  * @param resource $data
  *
- * @return resource
+ * @return resource|false
  */
 function fann_duplicate_train_data($data)
 {
@@ -1004,7 +1004,7 @@ function fann_randomize_weights($ann, $min_weight, $max_weight)
  *
  * @param string $filename
  *
- * @return resource
+ * @return resource|false
  */
 function fann_read_train_from_file($filename)
 {
@@ -1787,7 +1787,7 @@ function fann_shuffle_train_data($train_data)
  * @param int $pos
  * @param int $length
  *
- * @return resource
+ * @return resource|false
  */
 function fann_subset_train_data($data, $pos, $length)
 {

--- a/interbase/interbase.php
+++ b/interbase/interbase.php
@@ -437,7 +437,7 @@ function ibase_blob_info ($link_identifier, $blob_id) {}
  * An InterBase link identifier. If omitted, the last opened link is
  * assumed.
  * </p>
- * @return resource a BLOB handle for later use with
+ * @return resource|false a BLOB handle for later use with
  * ibase_blob_add or false on failure.
  */
 function ibase_blob_create ($link_identifier = null) {}
@@ -489,7 +489,7 @@ function ibase_blob_close ($blob_handle) {}
  * @param string $blob_id <p>
  * A BLOB id.
  * </p>
- * @return resource a BLOB handle for later use with
+ * @return resource|false a BLOB handle for later use with
  * ibase_blob_get or false on failure.
  */
 function ibase_blob_open ($link_identifier, $blob_id) {}
@@ -586,7 +586,7 @@ function ibase_delete_user ($service_handle, $user_name) {}
  * @param string $host
  * @param string $dba_username
  * @param string $dba_password
- * @return resource
+ * @return resource|false
  */
 function ibase_service_attach ($host, $dba_username, $dba_password) {}
 
@@ -1163,7 +1163,7 @@ function fbird_blob_info ($link_identifier, $blob_id) {}
  * An InterBase link identifier. If omitted, the last opened link is
  * assumed.
  * </p>
- * @return resource a BLOB handle for later use with
+ * @return resource|false a BLOB handle for later use with
  * fbird_blob_add or false on failure.
  */
 function fbird_blob_create ($link_identifier = null) {}
@@ -1219,7 +1219,7 @@ function fbird_blob_close ($blob_handle) {}
  * @param string $blob_id <p>
  * A BLOB id.
  * </p>
- * @return resource a BLOB handle for later use with
+ * @return resource|false a BLOB handle for later use with
  * fbird_blob_get or false on failure.
  */
 function fbird_blob_open ($link_identifier, $blob_id) {}
@@ -1325,7 +1325,7 @@ function fbird_delete_user ($service_handle, $user_name) {}
  * @param string $host
  * @param string $dba_username
  * @param string $dba_password
- * @return resource
+ * @return resource|false
  */
 function fbird_service_attach ($host, $dba_username, $dba_password) {}
 

--- a/ldap/ldap.php
+++ b/ldap/ldap.php
@@ -131,7 +131,7 @@ function ldap_bind ($link_identifier, $bind_rdn = null, $bind_password = null) {
  * @param string $bind_rdn [optional]
  * @param string $bind_password [optional]
  * @param array $serverctrls [optional] Array of LDAP Controls to send with the request.
- * @return resource
+ * @return resource|false
  * @since 7.3
  */
 function ldap_bind_ext ($link_identifier, $bind_rdn = null, $bind_password = null, $serverctrls = []) {}
@@ -374,7 +374,7 @@ function ldap_count_entries ($link_identifier, $result_identifier) {}
  * An LDAP link identifier, returned by <b>ldap_connect</b>.
  * </p>
  * @param resource $result_identifier
- * @return resource the result entry identifier for the first entry on success and
+ * @return resource|false the result entry identifier for the first entry on success and
  * <b>FALSE</b> on error.
  */
 function ldap_first_entry ($link_identifier, $result_identifier) {}
@@ -581,7 +581,7 @@ function ldap_add ($link_identifier, $dn, array $entry, $serverctrls = []) {}
  * </code>
  * </p>
  * @param array $serverctrls [optional] Array of LDAP Controls to send with the request.
- * @return resource
+ * @return resource|false
  * @since 7.4
  */
 function ldap_add_ext ($link_identifier, $dn, array $entry, $serverctrls = []) {}
@@ -611,7 +611,7 @@ function ldap_delete ($link_identifier, $dn, $serverctrls = []) {}
  * The distinguished name of an LDAP entity.
  * </p>
  * @param array $serverctrls [optional] Array of LDAP Controls to send with the request.
- * @return resource
+ * @return resource|false
  * @since 7.3
  */
 function ldap_delete_ext ($link_identifier, $dn, $serverctrls = []) {}
@@ -660,7 +660,7 @@ function ldap_mod_add ($link_identifier, $dn, array $entry, $serverctrls = []) {
  * </p>
  * @param array $entry
  * @param array $serverctrls [optional] Array of LDAP Controls to send with the request.
- * @return resource
+ * @return resource|false
  */
 function ldap_mod_add_ext ($link_identifier, $dn, array $entry, $serverctrls = []) {}
 
@@ -691,7 +691,7 @@ function ldap_mod_replace ($link_identifier, $dn, array $entry, $serverctrls = [
  * </p>
  * @param array $entry
  * @param array $serverctrls [optional] Array of LDAP Controls to send with the request.
- * @return resource
+ * @return resource|false
  * @since 7.3
  */
 function ldap_mod_replace_ext ($link_identifier, $dn, array $entry, $serverctrls = []) {}
@@ -723,7 +723,7 @@ function ldap_mod_del ($link_identifier, $dn, array $entry, $serverctrls = []) {
  * </p>
  * @param array $entry
  * @param array $serverctrls [optional] Array of LDAP Controls to send with the request.
- * @return resource
+ * @return resource|false
  * @since 7.3
  */
 function ldap_mod_del_ext ($link_identifier, $dn, array $entry, $serverctrls = []) {}
@@ -843,7 +843,7 @@ function ldap_rename ($link_identifier, $dn, $newrdn, $newparent, $deleteoldrdn,
  * is retained as non-distinguished values of the entry.
  * </p>
  * @param array $serverctrls [optional] Array of LDAP Controls to send with the request.
- * @return resource
+ * @return resource|false
  * @since 7.3
  */
 function ldap_rename_ext ($link_identifier, $dn, $newrdn, $newparent, $deleteoldrdn, $serverctrls = []) {}

--- a/mssql/mssql.php
+++ b/mssql/mssql.php
@@ -53,7 +53,7 @@ function mssql_connect ($servername = null, $username = null, $password = null, 
  * mssql_pconnect was called before with the same
  * parameters.
  * </p>
- * @return resource a positive MS SQL persistent link identifier on success, or
+ * @return resource|false a positive MS SQL persistent link identifier on success, or
  * false on error.
  * @removed 7.0
  */
@@ -447,7 +447,7 @@ function mssql_min_message_severity ($severity) {}
  * A MS SQL link identifier, returned by
  * mssql_connect.
  * </p>
- * @return resource a resource identifier "statement", used in subsequent calls to
+ * @return resource|false a resource identifier "statement", used in subsequent calls to
  * mssql_bind and mssql_execute,
  * or false on errors.
  * @removed 7.0

--- a/mysql/mysql.php
+++ b/mysql/mysql.php
@@ -165,7 +165,7 @@ function mysql_query ($query, $link_identifier = null) {}
  * Data inside the query should be properly escaped.
  * </p>
  * @param resource $link_identifier [optional]
- * @return resource For SELECT, SHOW, DESCRIBE or EXPLAIN statements,
+ * @return resource|bool For SELECT, SHOW, DESCRIBE or EXPLAIN statements,
  * <b>mysql_unbuffered_query</b>
  * returns a resource on success, or false on
  * error.
@@ -192,7 +192,7 @@ function mysql_unbuffered_query ($query, $link_identifier = null) {}
  * Data inside the query should be properly escaped.
  * </p>
  * @param resource $link_identifier [optional]
- * @return resource a positive MySQL result resource to the query result,
+ * @return resource|bool a positive MySQL result resource to the query result,
  * or false on error. The function also returns true/false for
  * INSERT/UPDATE/DELETE
  * queries to indicate success/failure.

--- a/odbc/odbc.php
+++ b/odbc/odbc.php
@@ -227,7 +227,7 @@ function odbc_errormsg ($connection_id = null) {}
  * @param int $flags [optional] <p>
  * This parameter is currently not used.
  * </p>
- * @return resource an ODBC result identifier if the SQL command was executed
+ * @return resource|false an ODBC result identifier if the SQL command was executed
  * successfully, or <b>FALSE</b> on error.
  */
 function odbc_exec ($connection_id, $query_string, $flags = null) {}
@@ -390,7 +390,7 @@ function odbc_free_result ($result_id) {}
  * The data type, which can be used to restrict the information to a
  * single data type.
  * </p>
- * @return resource an ODBC result identifier or
+ * @return resource|false an ODBC result identifier or
  * <b>FALSE</b> on failure.
  * </p>
  * <p>
@@ -656,7 +656,7 @@ function odbc_statistics ($connection_id, $qualifier, $owner, $table_name, $uniq
  * <b>odbc_tables</b> does not return any results for
  * that type.
  * </p>
- * @return resource an ODBC result identifier containing the information
+ * @return resource|false an ODBC result identifier containing the information
  * or <b>FALSE</b> on failure.
  * </p>
  * <p>
@@ -822,7 +822,7 @@ function odbc_foreignkeys ($connection_id, $pk_qualifier, $pk_owner, $pk_table, 
  * @link https://php.net/manual/en/function.odbc-procedures.php
  * @param resource $connection_id The ODBC connection identifier,
  * see <b>odbc_connect</b> for details.</p>
- * @return resource an ODBC
+ * @return resource|false an ODBC
  * result identifier containing the information or <b>FALSE</b> on failure.
  * </p>
  * <p>

--- a/sockets/sockets.php
+++ b/sockets/sockets.php
@@ -28,7 +28,7 @@ function socket_addrinfo_lookup($host, $service, $hints) {}
  * @param resource $addr <p>
  * Resource created from {@see socket_addrinfo_lookup()}
  * </p>
- * @return resource Socket resource on success or NULL on failure.
+ * @return resource|null Socket resource on success or NULL on failure.
  * @since 7.2
  */
 function socket_addrinfo_connect($addr) {}
@@ -41,7 +41,7 @@ function socket_addrinfo_connect($addr) {}
  * @param resource $addr <p>
  * Resource created from {@see socket_addrinfo_lookup()}
  * </p>
- * @return resource Socket resource on success or NULL on failure.
+ * @return resource|null Socket resource on success or NULL on failure.
  * @since 7.2
  */
 function socket_addrinfo_bind($addr) {}

--- a/ssh2/ssh2.php
+++ b/ssh2/ssh2.php
@@ -452,7 +452,7 @@ function ssh2_poll (&$var1) {}
  * An SSH connection link identifier, obtained from a call to
  * ssh2_connect.
  * </p>
- * @return resource This method returns an SSH2 SFTP resource for use with
+ * @return resource|false This method returns an SSH2 SFTP resource for use with
  * all other ssh2_sftp_*() methods and the
  * ssh2.sftp:// fopen wrapper.
  */
@@ -599,7 +599,7 @@ function ssh2_sftp_realpath ($sftp, $filename) {}
  * @link https://php.net/manual/en/function.ssh2-publickey-init.php
  * @param resource $session <p>
  * </p>
- * @return resource an SSH2 Publickey Subsystem resource for use
+ * @return resource|false an SSH2 Publickey Subsystem resource for use
  * with all other ssh2_publickey_*() methods or false on failure.
  */
 function ssh2_publickey_init ($session) {}

--- a/standard/standard_6.php
+++ b/standard/standard_6.php
@@ -214,7 +214,7 @@ function stream_context_set_default (array $options) {}
  * called first during stream operations. To add a filter to the end of the
  * list, use stream_filter_append.
  * </p>
- * @return resource a resource which can be used to refer to this filter
+ * @return resource|false a resource which can be used to refer to this filter
  * instance during a call to stream_filter_remove.
  */
 function stream_filter_prepend ($stream, $filtername, $read_write = null, $params = null) {}
@@ -248,7 +248,7 @@ function stream_filter_prepend ($stream, $filtername, $read_write = null, $param
  * To add a filter to the beginning of the list, use
  * stream_filter_prepend.
  * </p>
- * @return resource a resource which can be used to refer to this filter
+ * @return resource|false a resource which can be used to refer to this filter
  * instance during a call to stream_filter_remove.
  */
 function stream_filter_append ($stream, $filtername, $read_write = null, $params = null) {}

--- a/sybase/sybase_ct.php
+++ b/sybase/sybase_ct.php
@@ -20,7 +20,7 @@ function sybase_connect ($servername = null, $username = null, $password = null,
  * @param $password string[optional]
  * @param $charset string[optional]
  * @param $appname string[optional]
- * @return resource a positive Sybase persistent link identifier on success
+ * @return resource|false a positive Sybase persistent link identifier on success
  * @removed 7.0
  */
 function sybase_pconnect ($servername = null, $username = null, $password = null, $charset = null, $appname = null) {}

--- a/xml/xml.php
+++ b/xml/xml.php
@@ -18,7 +18,7 @@
  * encodings are ISO-8859-1, UTF-8 and
  * US-ASCII.
  * </p>
- * @return resource a resource handle for the new XML parser.
+ * @return resource|false a resource handle for the new XML parser.
  */
 function xml_parser_create ($encoding = null) {}
 
@@ -41,7 +41,7 @@ function xml_parser_create ($encoding = null) {}
  * handler functions will consist of namespace and tag name separated by
  * the string specified in <i>separator</i>.
  * </p>
- * @return resource a resource handle for the new XML parser.
+ * @return resource|false a resource handle for the new XML parser.
  */
 function xml_parser_create_ns ($encoding = null, $separator = ':') {}
 

--- a/zip/zip.php
+++ b/zip/zip.php
@@ -1034,7 +1034,7 @@ function zip_close ($zip) {}
  * @param resource $zip <p>
  * A ZIP file previously opened with <b>zip_open</b>.
  * </p>
- * @return resource a directory entry resource for later use with the
+ * @return resource|false a directory entry resource for later use with the
  * zip_entry_... functions, or <b>FALSE</b> if
  * there are no more entries to read, or an error code if an error
  * occurred.

--- a/zlib/zlib.php
+++ b/zlib/zlib.php
@@ -410,7 +410,7 @@ function ob_gzhandler ($buffer, $mode) {}
  * <b>ZLIB_RLE</b>, <b>ZLIB_FIXED</b> or <b>ZLIB_DEFAULT_STRATEGY</b> (the
  * default). <b>dictionary</b>A string or an array of strings of the preset
  * dictionary (default: no preset dictionary).</p>
- * @return resource <p>
+ * @return resource|false <p>
  * Returns a deflate context resource (zlib.deflate) on success, or
  * <b>FALSE</b> on failure.
  * </p>
@@ -456,7 +456,7 @@ function deflate_add ($context, $data, $flush_mode = ZLIB_SYNC_FLUSH) {}
  * <b>ZLIB_RLE</b>, <b>ZLIB_FIXED</b> or <b>ZLIB_DEFAULT_STRATEGY</b> (the
  * default). <b>dictionary</b>A string or an array of strings of the preset
  * dictionary (default: no preset dictionary).</p>
- * @return resource <p>
+ * @return resource|false <p>
  * Returns an inflate context resource (zlib.inflate) on success, or
  * <b>FALSE</b> on failure.
  * </p>


### PR DESCRIPTION
Simular of #853

Correct return value for functions:

* [`cubrid_connect()`](https://www.php.net/manual/en/function.cubrid-connect.php#refsect1-function.cubrid-connect-returnvalues)
* [`cubrid_connect_with_url()`](https://www.php.net/manual/en/function.cubrid-connect-with-url.php#refsect1-function.cubrid-connect-with-url-returnvalues)
* [`cubrid_pconnect()`](https://www.php.net/manual/en/function.cubrid-pconnect.php#refsect1-function.cubrid-pconnect-returnvalues)
* [`cubrid_pconnect_with_url()`](https://www.php.net/manual/en/function.cubrid-pconnect-with-url.php#refsect1-function.cubrid-pconnect-with-url-returnvalues)
* [`cubrid_query()`](https://www.php.net/manual/en/function.cubrid-query.php#refsect1-function.cubrid-query-returnvalues)
* [`cubrid_execute()`](https://www.php.net/manual/en/function.cubrid-execute.php#refsect1-function.cubrid-execute-returnvalues)
* [`cubrid_unbuffered_query()`](https://www.php.net/manual/en/function.cubrid-unbuffered-query.php#refsect1-function.cubrid-unbuffered-query-returnvalues)
* [`cubrid_lob2_new()`](https://www.php.net/manual/en/function.cubrid-lob2-new.php#refsect1-function.cubrid-lob2-new-returnvalues)
* [`cubrid_prepare()`](https://www.php.net/manual/en/function.cubrid-prepare.php#refsect1-function.cubrid-prepare-returnvalues)
* [`enchant_broker_init()`](https://www.php.net/manual/en/function.enchant-broker-init.php#refsect1-function.enchant-broker-init-returnvalues)
* [`enchant_broker_request_dict()`](https://www.php.net/manual/en/function.enchant-broker-request-dict.php#refsect1-function.enchant-broker-request-dict-returnvalues)
* [`enchant_broker_request_pwl_dict()`](https://www.php.net/manual/en/function.enchant-broker-request-pwl-dict.php#refsect1-function.enchant-broker-request-pwl-dict-returnvalues)
* [`fann_create_from_file()`](https://www.php.net/manual/en/function.fann-create-from-file.php#refsect1-function.fann-create-from-file-returnvalues)
* [`fann_create_train_from_callback()`](https://www.php.net/manual/en/function.fann-create-train-from-callback.php#refsect1-function.fann-create-train-from-callback-returnvalues)
* [`fann_create_train()`](https://www.php.net/manual/en/function.fann-create-train.php#refsect1-function.fann-create-train-returnvalues)
* [`fann_duplicate_train_data()`](https://www.php.net/manual/en/function.fann-duplicate-train-data.php#refsect1-function.fann-duplicate-train-data-returnvalues)
* [`fann_read_train_from_file()`](https://www.php.net/manual/en/function.fann-read-train-from-file.php#refsect1-function.fann-read-train-from-file-returnvalues)
* [`fann_subset_train_data()`](https://www.php.net/manual/en/function.fann-subset-train-data.php#refsect1-function.fann-subset-train-data-returnvalues)
* [`ibase_blob_create()`](https://www.php.net/manual/en/function.ibase-blob-create.php#refsect1-function.ibase-blob-create-returnvalues)
* [`ibase_blob_open()`](https://www.php.net/manual/en/function.ibase-blob-open.php#refsect1-function.ibase-blob-open-returnvalues)
* [`ibase_service_attach()`](https://www.php.net/manual/en/function.ibase-service-attach.php#refsect1-function.ibase-service-attach-returnvalues)
* [`fbird_blob_create()`](https://www.php.net/manual/en/function.fbird-blob-create.php)
* [`fbird_blob_open()`](https://www.php.net/manual/en/function.fbird-blob-open.php)
* [`fbird_service_attach()`](https://www.php.net/manual/en/function.fbird-service-attach)
* [`ldap_bind_ext()`](https://www.php.net/manual/en/function.ldap-bind-ext.php#refsect1-function.ldap-bind-ext-returnvalues)
* [`ldap_first_entry()`](https://www.php.net/manual/en/function.ldap-first-entry.php#refsect1-function.ldap-first-entry-returnvalues)
* [`ldap_add_ext()`](https://www.php.net/manual/en/function.ldap-add-ext.php#refsect1-function.ldap-add-ext-returnvalues)
* [`ldap_delete_ext()`](https://www.php.net/manual/en/function.ldap-delete-ext.php#refsect1-function.ldap-delete-ext-returnvalues)
* [`ldap_mod_add_ext()`](https://www.php.net/manual/en/function.ldap-mod_add-ext.php#refsect1-function.ldap-mod_add-ext-returnvalues)
* [`ldap_mod_replace_ext()`](https://www.php.net/manual/en/function.ldap-mod_replace-ext.php#refsect1-function.ldap-mod_replace-ext-returnvalues)
* [`ldap_mod_del_ext()`](https://www.php.net/manual/en/function.ldap-mod_del-ext.php#refsect1-function.ldap-mod_del-ext-returnvalues)
* [`ldap_rename_ext()`](https://www.php.net/manual/en/function.ldap-rename-ext.php#refsect1-function.ldap-rename-ext-returnvalues)
* [`mssql_pconnect()`](https://www.php.net/manual/en/function.mssql-pconnect.php#refsect1-function.mssql-pconnect-returnvalues)
* [`mssql_init()`](https://www.php.net/manual/en/function.mssql-init.php#refsect1-function.mssql-init-returnvalues)
* [`mysql_unbuffered_query()`](https://www.php.net/manual/en/function.mysql-unbuffered-query.php#refsect1-function.mysql-unbuffered-query-returnvalues)
* [`mysql_db_query()`](https://www.php.net/manual/en/function.mysql-db-query.php#refsect1-function.mysql-db-query-returnvalues)
* [`odbc_exec()`](https://www.php.net/manual/en/function.odbc-exec.php#refsect1-function.odbc-exec-returnvalues)
* [`odbc_gettypeinfo()`](https://www.php.net/manual/en/function.odbc-gettypeinfo.php#refsect1-function.odbc-gettypeinfo-returnvalues)
* [`odbc_tables()`](https://www.php.net/manual/en/function.odbc-tables.php#refsect1-function.odbc-tables-returnvalues)
* [`odbc_procedures()`](https://www.php.net/manual/en/function.odbc-procedures.php#refsect1-function.odbc-procedures-returnvalues)
* [`socket_addrinfo_connect()`](https://www.php.net/manual/en/function.socket-addrinfo-connect.php#refsect1-function.socket-addrinfo-connect-returnvalues)
* [`socket_addrinfo_bind()`](https://www.php.net/manual/en/function.socket-addrinfo-bind.php#refsect1-function.socket-addrinfo-bind-returnvalues)
* [`ssh2_sftp()`](https://www.php.net/manual/en/function.ssh2-sftp.php#refsect1-function.ssh2-sftp-returnvalues)
* [`ssh2_publickey_init()`](https://www.php.net/manual/en/function.ssh2-publickey-init.php#refsect1-function.ssh2-publickey-init-returnvalues)
* [`stream_filter_prepend()`](https://www.php.net/manual/en/function.stream-filter-prepend.php#refsect1-function.stream-filter-prepend-returnvalues)
* [`stream_filter_append()`](https://www.php.net/manual/en/function.stream-filter-append.php#refsect1-function.stream-filter-append-returnvalues)
* [`sybase_pconnect()`](https://www.php.net/manual/en/function.sybase-pconnect.php#refsect1-function.sybase-pconnect-returnvalues)
* [`xml_parser_create()`](https://www.php.net/manual/en/function.xml-parser-create.php#refsect1-function.xml-parser-create-returnvalues)
* [`xml_parser_create_ns()`](https://www.php.net/manual/en/function.xml-parser-create-ns.php#refsect1-function.xml-parser-create-ns-returnvalues)
* [`zip_read()`](https://www.php.net/manual/en/function.zip-read.php#refsect1-function.zip-read-returnvalues)
* [`deflate_init()`](https://www.php.net/manual/en/function.deflate-init.php#refsect1-function.deflate-init-returnvalues)
* [`inflate_init()`](https://www.php.net/manual/en/function.inflate-init.php#refsect1-function.inflate-init-returnvalues)

Return type declared as `resource`, but `false` returned on failure.