### PR TITLE
Parameter $message is optional.

### DIFF
--- a/redis/Redis.php
+++ b/redis/Redis.php
@@ -385,7 +385,7 @@ class Redis
      * @throws RedisException
      * @link    https://redis.io/commands/ping
      */
-    public function ping($message)
+    public function ping($message=null)
     {
     }
 

--- a/redis/Redis.php
+++ b/redis/Redis.php
@@ -378,7 +378,7 @@ class Redis
     /**
      * Check the current connection status
      *
-     * @param string $message
+     * @param string $message [optional]
      *
      * @return bool|string TRUE if the command is successful or returns message
      * Throws a RedisException object on connectivity error, as described above.


### PR DESCRIPTION
See first example in [examples](https://github.com/phpredis/phpredis#example-8) of [PING](https://github.com/phpredis/phpredis#ping) section.
```
/* When called without an argument, PING returns `TRUE` */
$redis->ping();
```