### PR TITLE
add tests that scalar type hints/return typehints used with correct since version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM php:7.4-alpine
-RUN echo 'memory_limit = 256M' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini;
+RUN echo 'memory_limit = 256M' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 
 RUN set -eux; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM php:7.4-alpine
-
+RUN echo 'memory_limit = 256M' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini;
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 
 RUN set -eux; \

--- a/intl/intl.php
+++ b/intl/intl.php
@@ -6591,7 +6591,10 @@ class IntlPartsIterator extends IntlIterator implements Iterator {
     const KEY_LEFT = 1 ;
     const KEY_RIGHT = 2 ;
 
-    public function getBreakIterator() : IntlBreakIterator { }
+    /**
+     * @return IntlBreakIterator
+     */
+    public function getBreakIterator() { }
 }
 
 class IntlCodePointBreakIterator extends IntlBreakIterator implements Traversable {

--- a/mysqli/mysqli.php
+++ b/mysqli/mysqli.php
@@ -731,7 +731,7 @@ class mysqli  {
 	 * <b>mysqli_field_count</b> returns a non-zero value, the
 	 * statement should have produced a non-empty result set.
 	 */
-	public function store_result (int $option = null) {}
+	public function store_result ($option = null) {}
 
 	/**
 	 * Returns whether thread safety is given or not

--- a/tests/Model/PHPDocElement.php
+++ b/tests/Model/PHPDocElement.php
@@ -40,6 +40,8 @@ trait PHPDocElement
      */
     public array $tagNames = [];
 
+    public bool $hasInheritDocTag = false;
+
     public bool $hasInternalMetaTag = false;
 
     protected function collectTags(Node $node): void{
@@ -47,7 +49,7 @@ trait PHPDocElement
             try {
                 $phpDoc = DocFactoryProvider::getDocFactory()->create($node->getDocComment()->getText());
                 $tags = $phpDoc->getTags();
-                foreach ($tags as $tag){
+                foreach ($tags as $tag) {
                     $this->tagNames[] = $tag->getName();
                 }
                 $this->links = $phpDoc->getTagsByName('link');
@@ -56,6 +58,8 @@ trait PHPDocElement
                 $this->deprecatedTags = $phpDoc->getTagsByName('deprecated');
                 $this->removedTags = $phpDoc->getTagsByName('removed');
                 $this->hasInternalMetaTag = $phpDoc->hasTag('meta');
+                $this->hasInheritDocTag = $phpDoc->hasTag('inheritdoc') || $phpDoc->hasTag('inheritDoc') ||
+                    stripos($phpDoc->getSummary(), "inheritdoc") > 0;
             } catch (Exception $e) {
                 $this->parseError = $e;
             }

--- a/tests/Model/PHPFunction.php
+++ b/tests/Model/PHPFunction.php
@@ -8,6 +8,7 @@ use phpDocumentor\Reflection\DocBlock\Tags\Return_;
 use phpDocumentor\Reflection\Type;
 use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Stmt\Function_;
+use PhpParser\NodeAbstract;
 use ReflectionFunction;
 use stdClass;
 use StubTests\Parsers\DocFactoryProvider;
@@ -23,6 +24,8 @@ class PHPFunction extends BasePHPElement
     public array $parameters = [];
 
     public ?Type $returnTag = null;
+
+    public ?NodeAbstract $returnType = null;
 
     /**
      * @param ReflectionFunction $function
@@ -51,6 +54,7 @@ class PHPFunction extends BasePHPElement
             $this->parameters[] = (new PHPParameter())->readObjectFromStubNode($parameter);
         }
 
+        $this->returnType = $node->getReturnType();
         $this->collectTags($node);
         $this->checkDeprecationTag($node);
         $this->checkReturnTag($node);
@@ -107,6 +111,9 @@ class PHPFunction extends BasePHPElement
                             break;
                         case 'absent in meta':
                             $this->mutedProblems[] = StubProblemType::ABSENT_IN_META;
+                            break;
+                        case 'has return typehint':
+                            $this->mutedProblems[] = StubProblemType::FUNCTION_HAS_RETURN_TYPEHINT;
                             break;
                         default:
                             $this->mutedProblems[] = -1;

--- a/tests/Model/PHPMethod.php
+++ b/tests/Model/PHPMethod.php
@@ -47,6 +47,7 @@ class PHPMethod extends PHPFunction
         $this->parentName = $this->getFQN($node->getAttribute('parent'));
         $this->name = $node->name->name;
 
+        $this->returnType = $node->getReturnType();
         $this->collectTags($node);
         $this->checkDeprecationTag($node);
         $this->checkReturnTag($node);
@@ -74,25 +75,32 @@ class PHPMethod extends PHPFunction
     {
         /**@var stdClass $method */
         foreach ($jsonData as $method) {
-            if ($method->name === $this->name && !empty($method->problems)) {
-                /**@var stdClass $problem */
-                foreach ($method->problems as $problem) {
-                    switch ($problem) {
-                        case 'parameter mismatch':
-                            $this->mutedProblems[] = StubProblemType::FUNCTION_PARAMETER_MISMATCH;
-                            break;
-                        case 'missing method':
-                            $this->mutedProblems[] = StubProblemType::STUB_IS_MISSED;
-                            break;
-                        case 'deprecated method':
-                            $this->mutedProblems[] = StubProblemType::FUNCTION_IS_DEPRECATED;
-                            break;
-                        case 'absent in meta':
-                            $this->mutedProblems[] = StubProblemType::ABSENT_IN_META;
-                            break;
-                        default:
-                            $this->mutedProblems[] = -1;
-                            break;
+            if ($method->name === $this->name) {
+                if (!empty($method->problems)) {
+                    /**@var stdClass $problem */
+                    foreach ($method->problems as $problem) {
+                        switch ($problem) {
+                            case 'parameter mismatch':
+                                $this->mutedProblems[] = StubProblemType::FUNCTION_PARAMETER_MISMATCH;
+                                break;
+                            case 'missing method':
+                                $this->mutedProblems[] = StubProblemType::STUB_IS_MISSED;
+                                break;
+                            case 'deprecated method':
+                                $this->mutedProblems[] = StubProblemType::FUNCTION_IS_DEPRECATED;
+                                break;
+                            case 'absent in meta':
+                                $this->mutedProblems[] = StubProblemType::ABSENT_IN_META;
+                                break;
+                            default:
+                                $this->mutedProblems[] = -1;
+                                break;
+                        }
+                    }
+                }
+                if (!empty($method->parameters)) {
+                    foreach ($this->parameters as $parameter) {
+                        $parameter->readMutedProblems($method->parameters);
                     }
                 }
                 return;

--- a/tests/Model/PHPParameter.php
+++ b/tests/Model/PHPParameter.php
@@ -68,6 +68,9 @@ class PHPParameter extends BasePHPElement
                         case 'parameter vararg':
                             $this->mutedProblems[] = StubProblemType::PARAMETER_VARARG;
                             break;
+                        case 'has scalar typehint':
+                            $this->mutedProblems[] = StubProblemType::PARAMETER_HAS_SCALAR_TYPEHINT;
+                            break;
                         default:
                             $this->mutedProblems[] = -1;
                             break;

--- a/tests/Model/StubProblemType.php
+++ b/tests/Model/StubProblemType.php
@@ -21,4 +21,6 @@ interface StubProblemType
     public const PROPERTY_IS_STATIC = 13;
     public const PROPERTY_ACCESS = 14;
     public const PROPERTY_TYPE = 15;
+    public const PARAMETER_HAS_SCALAR_TYPEHINT = 16;
+    public const FUNCTION_HAS_RETURN_TYPEHINT = 17;
 }

--- a/tests/Model/StubsContainer.php
+++ b/tests/Model/StubsContainer.php
@@ -76,6 +76,14 @@ class StubsContainer
     }
 
     /**
+     * @return PHPClass[]
+     */
+    public function getCoreClasses(): array
+    {
+        return array_filter($this->classes, fn($class) => $class->stubBelongsToCore === true);
+    }
+
+    /**
      * @param PHPClass $class
      * @throws RuntimeException
      */
@@ -102,6 +110,14 @@ class StubsContainer
     public function getInterfaces(): array
     {
         return $this->interfaces;
+    }
+
+    /**
+     * @return PHPInterface[]
+     */
+    public function getCoreInterfaces(): array
+    {
+        return array_filter($this->interfaces,fn($interface) => $interface->stubBelongsToCore === true);
     }
 
     /**

--- a/tests/Parsers/StubParser.php
+++ b/tests/Parsers/StubParser.php
@@ -39,6 +39,19 @@ class StubParser
             $class->interfaces =
                 Utils::flattenArray($visitor->combineImplementedInterfaces($class), false);
         }
+        $jsonData = json_decode(file_get_contents(__DIR__ . '/../TestData/mutedProblems.json'));
+        foreach (self::$stubs->getClasses() as $class) {
+            $class->readMutedProblems($jsonData->classes);
+        }
+        foreach (self::$stubs->getInterfaces() as $interface) {
+            $interface->readMutedProblems($jsonData->interfaces);
+        }
+        foreach (self::$stubs->getFunctions() as $function) {
+            $function->readMutedProblems($jsonData->functions);
+        }
+        foreach (self::$stubs->getConstants() as $constant) {
+            $constant->readMutedProblems($jsonData->constants);
+        }
         return self::$stubs;
     }
 

--- a/tests/StubsTest.php
+++ b/tests/StubsTest.php
@@ -296,6 +296,24 @@ class StubsTest extends TestCase
     }
 
     /**
+     * @dataProvider \StubTests\TestData\Providers\StubsTestDataProviders::coreStubMethodProvider
+     */
+    public function testCoreMethodsTypeHints(string $methodName, PHPMethod $stubFunction): void
+    {
+        if (!empty($stubFunction->sinceTags)) {
+            $sinceVersions = array_map(fn(Since $tag) => (int)$tag->getVersion(), $stubFunction->sinceTags);
+            sort($sinceVersions, SORT_DESC);
+            $firstSinceVersion = array_pop($sinceVersions);
+        } elseif ($stubFunction->hasInheritDocTag) {
+            self::markTestSkipped("Function contains inheritdoc.");
+        } else {
+            $firstSinceVersion = 5;
+        }
+        self::checkFunctionDoesNotHaveScalarTypeHints($firstSinceVersion, $stubFunction);
+        self::checkFunctionDoesNotHaveReturnTypeHints($firstSinceVersion, $stubFunction);
+    }
+
+    /**
      * @dataProvider \StubTests\TestData\Providers\StubsTestDataProviders::stubConstantProvider
      */
     public function testConstantsPHPDocs(PHPConst $constant): void
@@ -445,6 +463,43 @@ class StubsTest extends TestCase
                     should have X.X format for the case when patch version is '0'.");
                 }
             }
+        }
+    }
+
+    private static function checkFunctionDoesNotHaveScalarTypeHints(int $sinceVersion, PHPFunction $function)
+    {
+        if ($sinceVersion < 7) {
+            if (empty($function->parameters)) {
+                self::assertTrue(true, "Parameters list empty");
+            } else {
+                foreach ($function->parameters as $parameter) {
+                    if (!$parameter->hasMutedProblem(StubProblemType::PARAMETER_HAS_SCALAR_TYPEHINT)) {
+                        self::assertFalse($parameter->type === 'int' || $parameter->type === 'float' ||
+                            $parameter->type === 'string' || $parameter->type === 'bool',
+                            "Function '{$function->name}' with @since '$sinceVersion'  
+                has parameter '{$parameter->name}' with typehint '{$parameter->type}' but typehints available only since php 7");
+                    } else {
+                        self::markTestSkipped("Skipped");
+                    }
+                }
+            }
+        } else {
+            self::assertTrue(true, "Function has since version > 7");
+        }
+    }
+
+    private static function checkFunctionDoesNotHaveReturnTypeHints(int $sinceVersion, PHPFunction $function)
+    {
+        $returnTypeHint = $function->returnType === null ? $function->returnType : $function->returnType->getType();
+        if ($sinceVersion < 7) {
+            if (!$function->hasMutedProblem(StubProblemType::FUNCTION_HAS_RETURN_TYPEHINT)) {
+                self::assertNull($returnTypeHint, "Function '$function->name' has since version '$sinceVersion'
+            but has return typehint '$returnTypeHint' that supported only since PHP 7. Please declare return type via PhpDoc");
+            } else {
+                self::markTestSkipped("Skipped");
+            }
+        } else {
+            self::assertTrue(true, "Function has since version > 7");
         }
     }
 }

--- a/tests/StubsTest.php
+++ b/tests/StubsTest.php
@@ -306,7 +306,7 @@ class StubsTest extends TestCase
             sort($sinceVersions, SORT_DESC);
             $firstSinceVersion = array_pop($sinceVersions);
         } elseif ($stubFunction->hasInheritDocTag) {
-            self::markTestSkipped("Function $methodName contains inheritdoc.");
+            self::markTestSkipped("Function '$methodName' contains inheritdoc.");
         }
         self::checkFunctionDoesNotHaveScalarTypeHints($firstSinceVersion, $stubFunction);
         self::checkFunctionDoesNotHaveReturnTypeHints($firstSinceVersion, $stubFunction);
@@ -469,7 +469,7 @@ class StubsTest extends TestCase
     {
         if ($sinceVersion < 7) {
             if (empty($function->parameters)) {
-                self::markTestSkipped("Parameters list empty");
+                self::assertTrue(true, 'Parameters list empty');
             } else {
                 foreach ($function->parameters as $parameter) {
                     if (!$parameter->hasMutedProblem(StubProblemType::PARAMETER_HAS_SCALAR_TYPEHINT)) {
@@ -483,7 +483,7 @@ class StubsTest extends TestCase
                 }
             }
         } else {
-            self::markTestSkipped("Function has since version > 7");
+            self::assertTrue(true, "Function '{$function->name}' has since version > 7");
         }
     }
 
@@ -498,7 +498,7 @@ class StubsTest extends TestCase
                 self::markTestSkipped("Skipped");
             }
         } else {
-            self::markTestSkipped("Function has since version > 7");
+            self::assertTrue(true, "Function '{$function->name}' has since version > 7");
         }
     }
 }

--- a/tests/StubsTest.php
+++ b/tests/StubsTest.php
@@ -300,14 +300,13 @@ class StubsTest extends TestCase
      */
     public function testCoreMethodsTypeHints(string $methodName, PHPMethod $stubFunction): void
     {
+        $firstSinceVersion = 5;
         if (!empty($stubFunction->sinceTags)) {
             $sinceVersions = array_map(fn(Since $tag) => (int)$tag->getVersion(), $stubFunction->sinceTags);
             sort($sinceVersions, SORT_DESC);
             $firstSinceVersion = array_pop($sinceVersions);
         } elseif ($stubFunction->hasInheritDocTag) {
-            self::markTestSkipped("Function contains inheritdoc.");
-        } else {
-            $firstSinceVersion = 5;
+            self::markTestSkipped("Function $methodName contains inheritdoc.");
         }
         self::checkFunctionDoesNotHaveScalarTypeHints($firstSinceVersion, $stubFunction);
         self::checkFunctionDoesNotHaveReturnTypeHints($firstSinceVersion, $stubFunction);
@@ -470,7 +469,7 @@ class StubsTest extends TestCase
     {
         if ($sinceVersion < 7) {
             if (empty($function->parameters)) {
-                self::assertTrue(true, "Parameters list empty");
+                self::markTestSkipped("Parameters list empty");
             } else {
                 foreach ($function->parameters as $parameter) {
                     if (!$parameter->hasMutedProblem(StubProblemType::PARAMETER_HAS_SCALAR_TYPEHINT)) {
@@ -484,7 +483,7 @@ class StubsTest extends TestCase
                 }
             }
         } else {
-            self::assertTrue(true, "Function has since version > 7");
+            self::markTestSkipped("Function has since version > 7");
         }
     }
 
@@ -499,7 +498,7 @@ class StubsTest extends TestCase
                 self::markTestSkipped("Skipped");
             }
         } else {
-            self::assertTrue(true, "Function has since version > 7");
+            self::markTestSkipped("Function has since version > 7");
         }
     }
 }

--- a/tests/TestData/Providers/StubsTestDataProviders.php
+++ b/tests/TestData/Providers/StubsTestDataProviders.php
@@ -47,6 +47,21 @@ class StubsTestDataProviders
         }
     }
 
+    public static function coreStubMethodProvider(): ?Generator
+    {
+        foreach (PhpStormStubsSingleton::getPhpStormStubs()->getCoreClasses() as $className => $class) {
+            foreach ($class->methods as $methodName => $method) {
+                yield "method {$className}::{$methodName}" => [$methodName, $method];
+            }
+        }
+
+        foreach (PhpStormStubsSingleton::getPhpStormStubs()->getCoreInterfaces() as $interfaceName => $interface) {
+            foreach ($interface->methods as $methodName => $method) {
+                yield "method {$interfaceName}::{$methodName}" => [$methodName, $method];
+            }
+        }
+    }
+
     public static function stubMethodProvider(): ?Generator
     {
         foreach (PhpStormStubsSingleton::getPhpStormStubs()->getClasses() as $className => $class) {
@@ -57,7 +72,7 @@ class StubsTestDataProviders
 
         foreach (PhpStormStubsSingleton::getPhpStormStubs()->getInterfaces() as $interfaceName => $interface) {
             foreach ($interface->methods as $methodName => $method) {
-                yield "interface {$interfaceName}::{$methodName}" => [$methodName, $method];
+                yield "method {$interfaceName}::{$methodName}" => [$methodName, $method];
             }
         }
     }

--- a/tests/TestData/mutedProblems.json
+++ b/tests/TestData/mutedProblems.json
@@ -772,37 +772,37 @@
       ]
     },
     {
-      "name":"session_set_save_handler",
+      "name": "session_set_save_handler",
       "problems": [
         "parameter mismatch"
       ]
     },
     {
-      "name":"stream_context_set_option",
+      "name": "stream_context_set_option",
       "problems": [
         "parameter mismatch"
       ]
     },
     {
-      "name":"setcookie",
+      "name": "setcookie",
       "problems": [
         "parameter mismatch"
       ]
     },
     {
-      "name":"setrawcookie",
+      "name": "setrawcookie",
       "problems": [
         "parameter mismatch"
       ]
     },
     {
-      "name":"sodium_memzero",
+      "name": "sodium_memzero",
       "problems": [
         "parameter mismatch"
       ]
     },
     {
-      "name":"strtr",
+      "name": "strtr",
       "problems": [
         "parameter mismatch"
       ]
@@ -820,19 +820,19 @@
       ]
     },
     {
-      "name":"mysqli_escape_string",
+      "name": "mysqli_escape_string",
       "problems": [
         "parameter mismatch"
       ]
     },
     {
-      "name":"mysqli_set_opt",
+      "name": "mysqli_set_opt",
       "problems": [
         "parameter mismatch"
       ]
     },
     {
-      "name":"socket_cmsg_space",
+      "name": "socket_cmsg_space",
       "problems": [
         "parameter mismatch"
       ]
@@ -840,7 +840,7 @@
   ],
   "classes": [
     {
-      "name" : "AMQPBasicProperties",
+      "name": "AMQPBasicProperties",
       "methods": [
         {
           "name": "__construct",
@@ -865,7 +865,7 @@
       "name": "Phar",
       "methods": [
         {
-          "name":"getPath",
+          "name": "getPath",
           "problems": [
             "missing method"
           ]
@@ -888,91 +888,91 @@
           ]
         },
         {
-          "name":"addFile",
+          "name": "addFile",
           "problems": [
             "missing method"
           ]
         },
         {
-          "name":"addFromString",
+          "name": "addFromString",
           "problems": [
             "missing method"
           ]
         },
         {
-          "name":"buildFromDirectory",
+          "name": "buildFromDirectory",
           "problems": [
             "missing method"
           ]
         },
         {
-          "name":"buildFromIterator",
+          "name": "buildFromIterator",
           "problems": [
             "missing method"
           ]
         },
         {
-          "name":"compressFiles",
+          "name": "compressFiles",
           "problems": [
             "missing method"
           ]
         },
         {
-          "name":"decompressFiles",
+          "name": "decompressFiles",
           "problems": [
             "missing method"
           ]
         },
         {
-          "name":"compress",
+          "name": "compress",
           "problems": [
             "missing method"
           ]
         },
         {
-          "name":"decompress",
+          "name": "decompress",
           "problems": [
             "missing method"
           ]
         },
         {
-          "name":"convertToExecutable",
+          "name": "convertToExecutable",
           "problems": [
             "missing method"
           ]
         },
         {
-          "name":"convertToData",
+          "name": "convertToData",
           "problems": [
             "missing method"
           ]
         },
         {
-          "name":"copy",
+          "name": "copy",
           "problems": [
             "missing method"
           ]
         },
         {
-          "name":"count",
+          "name": "count",
           "problems": [
             "missing method"
           ]
         },
         {
-          "name":"delete",
+          "name": "delete",
           "problems": [
             "missing method"
           ]
         },
         {
-          "name":"delMetadata",
+          "name": "delMetadata",
           "problems": [
             "missing method"
           ]
         },
         {
-          "name":"extractTo",
+          "name": "extractTo",
           "problems": [
             "missing method"
           ]
@@ -984,207 +984,205 @@
           ]
         },
         {
-          "name":"getPath",
+          "name": "getPath",
           "problems": [
             "missing method"
           ]
         },
         {
-          "name":"getMetadata",
+          "name": "getMetadata",
           "problems": [
             "missing method"
           ]
         },
         {
-          "name":"getModified",
+          "name": "getModified",
           "problems": [
             "missing method"
           ]
         },
         {
-          "name":"getSignature",
+          "name": "getSignature",
           "problems": [
             "missing method"
           ]
         },
         {
-          "name":"getStub",
+          "name": "getStub",
           "problems": [
             "missing method"
           ]
         },
         {
-          "name":"getVersion",
+          "name": "getVersion",
           "problems": [
             "missing method"
           ]
         },
         {
-          "name":"hasMetadata",
+          "name": "hasMetadata",
           "problems": [
             "missing method"
           ]
         },
         {
-          "name":"isBuffering",
+          "name": "isBuffering",
           "problems": [
             "missing method"
           ]
         },
         {
-          "name":"isCompressed",
+          "name": "isCompressed",
           "problems": [
             "missing method"
           ]
         },
         {
-          "name":"isFileFormat",
+          "name": "isFileFormat",
           "problems": [
             "missing method"
           ]
         },
         {
-          "name":"isWritable",
-          "problems": [
-            "missing method"
-         ]
-        },
-        {
-          "name":"setAlias",
+          "name": "isWritable",
           "problems": [
             "missing method"
           ]
         },
         {
-          "name":"setDefaultStub",
+          "name": "setAlias",
           "problems": [
             "missing method"
           ]
         },
         {
-          "name":"setMetadata",
+          "name": "setDefaultStub",
           "problems": [
             "missing method"
           ]
         },
         {
-          "name":"setSignatureAlgorithm",
+          "name": "setMetadata",
           "problems": [
             "missing method"
           ]
         },
         {
-          "name":"setStub",
+          "name": "setSignatureAlgorithm",
           "problems": [
             "missing method"
           ]
         },
         {
-          "name":"startBuffering",
+          "name": "setStub",
           "problems": [
             "missing method"
           ]
         },
         {
-          "name":"stopBuffering",
+          "name": "startBuffering",
           "problems": [
             "missing method"
           ]
         },
         {
-          "name":"apiVersion",
-          "problems": [
-            "missing method"
-          ]
-        },
-
-        {
-          "name":"canCompress",
+          "name": "stopBuffering",
           "problems": [
             "missing method"
           ]
         },
         {
-          "name":"canWrite",
+          "name": "apiVersion",
           "problems": [
             "missing method"
           ]
         },
         {
-          "name":"createDefaultStub",
+          "name": "canCompress",
           "problems": [
             "missing method"
           ]
         },
         {
-          "name":"getSupportedCompression",
-          "problems": [
-            "missing method"
-          ]
-        },{
-          "name":"getSupportedSignatures",
-          "problems": [
-            "missing method"
-          ]
-        },
-
-        {
-          "name":"interceptFileFunc",
+          "name": "canWrite",
           "problems": [
             "missing method"
           ]
         },
         {
-          "name":"isValidPharFilename",
+          "name": "createDefaultStub",
           "problems": [
             "missing method"
           ]
         },
         {
-          "name":"loadPhar",
+          "name": "getSupportedCompression",
           "problems": [
             "missing method"
           ]
         },
         {
-          "name":"mapPhar",
-          "problems": [
-            "missing method"
-          ]
-        },
-
-        {
-          "name":"running",
+          "name": "getSupportedSignatures",
           "problems": [
             "missing method"
           ]
         },
         {
-          "name":"mount",
+          "name": "interceptFileFunc",
           "problems": [
             "missing method"
           ]
         },
         {
-          "name":"mungServer",
+          "name": "isValidPharFilename",
           "problems": [
             "missing method"
           ]
         },
         {
-          "name":"unlinkArchive",
+          "name": "loadPhar",
           "problems": [
             "missing method"
           ]
         },
         {
-          "name":"webPhar",
+          "name": "mapPhar",
           "problems": [
             "missing method"
           ]
         },
         {
-          "name":"interceptFileFuncs",
+          "name": "running",
+          "problems": [
+            "missing method"
+          ]
+        },
+        {
+          "name": "mount",
+          "problems": [
+            "missing method"
+          ]
+        },
+        {
+          "name": "mungServer",
+          "problems": [
+            "missing method"
+          ]
+        },
+        {
+          "name": "unlinkArchive",
+          "problems": [
+            "missing method"
+          ]
+        },
+        {
+          "name": "webPhar",
+          "problems": [
+            "missing method"
+          ]
+        },
+        {
+          "name": "interceptFileFuncs",
           "problems": [
             "missing method"
           ]
@@ -1222,7 +1220,7 @@
           ]
         },
         {
-          "name":"getSignature",
+          "name": "getSignature",
           "problems": [
             "missing method"
           ]
@@ -1475,6 +1473,33 @@
           "name": "bind_result",
           "problems": [
             "parameter mismatch"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "SQLite3",
+      "methods": [
+        {
+          "name": "createFunction",
+          "parameters": [
+            {
+              "name": "flags",
+              "problems": [
+                "has scalar typehint"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "openBlob",
+          "parameters": [
+            {
+              "name": "flags",
+              "problems": [
+                "has scalar typehint"
+              ]
+            }
           ]
         }
       ]

--- a/zip/zip.php
+++ b/zip/zip.php
@@ -1133,7 +1133,7 @@ class ZipArchive implements Countable {
 	 * @param int $flags [optional] Optional flags. Currently unused.
 	 * @return bool Returns <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
-	public function setExternalAttributesName(string $name, int $opsys, int $attr, int $flags = null): bool {}
+	public function setExternalAttributesName($name, $opsys, $attr, $flags = null) {}
 
     /**
      * Retrieve the external attributes of an entry defined by its name
@@ -1144,7 +1144,7 @@ class ZipArchive implements Countable {
      * @param int $flags [optional] If flags is set to ZipArchive::FL_UNCHANGED, the original unchanged attributes are returned.
      * @return bool Returns <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
-    public function getExternalAttributesName(string $name, int &$opsys, int &$attr, int $flags = null): bool {}
+    public function getExternalAttributesName($name, &$opsys, &$attr, $flags = null) {}
 
     /**
      * Set the external attributes of an entry defined by its index
@@ -1155,7 +1155,7 @@ class ZipArchive implements Countable {
      * @param int $flags [optional] Optional flags. Currently unused.
      * @return bool Returns <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
-	public function setExternalAttributesIndex(int $index, int $opsys, int $attr, int $flags = null): bool {}
+	public function setExternalAttributesIndex($index, $opsys, $attr, $flags = null) {}
 
     /**
      * Retrieve the external attributes of an entry defined by its index
@@ -1166,7 +1166,7 @@ class ZipArchive implements Countable {
      * @param int $flags [optional] If flags is set to ZipArchive::FL_UNCHANGED, the original unchanged attributes are returned.
      * @return bool Returns <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
-    public function getExternalAttributesIndex(int $index, int &$opsys, int &$attr, int $flags = null): bool {}
+    public function getExternalAttributesIndex($index, &$opsys, &$attr, $flags = null) {}
 }
 
 /**


### PR DESCRIPTION
This PR adds test that checks that methods that has `@since` version < 7 don't have parameters with scalar type hints and return type hints. 
Why was it done?
If public method in stubs has `@since` version < 7 and at the same time has scalar type hints or return typehint, then overriden by user (that use php 5.6) method will show error that method signature should be compatible with basic one (if one will remove typehints) or error that typehints are not supported. In any case such errors will be false positive and noisy.

Note that I've increased memory_limit. It was required due to all stubs are loaded to the memory by data providers and as far as new tests use data providers more data should be loaded into the memory. Current usage of memory is 132.00 MB