### PR TITLE
Fix incorrect parameter name signatures for dba_open and dba_popen

### DIFF
--- a/dba/dba.php
+++ b/dba/dba.php
@@ -110,16 +110,16 @@
  * false: the second call returns false.
  * illegal: you must not mix "l" and "d" modifiers for <i>mode</i> parameter.
  * </p>
- * @param string $handler [optional] <p>
+ * @param string $handlername [optional] <p>
  * The name of the handler which
  * shall be used for accessing <i>path</i>. It is passed
  * all optional parameters given to <b>dba_open</b> and
  * can act on behalf of them.
  * </p>
- * @param mixed $_ [optional]
+ * @param mixed ...$handler_parameters [optional]
  * @return resource|false a positive handle on success or <b>FALSE</b> on failure.
  */
-function dba_open ($path, $mode, $handler = null, $_ = null) {}
+function dba_open ($path, $mode, $handlername = null, ...$handler_parameters) {}
 
 /**
  * Open database persistently
@@ -133,16 +133,16 @@ function dba_open ($path, $mode, $handler = null, $_ = null) {}
  * for read/write access and database creation if it doesn't currently exist,
  * and n for create, truncate and read/write access.
  * </p>
- * @param string $handler [optional] <p>
+ * @param string $handlername [optional] <p>
  * The name of the handler which
  * shall be used for accessing <i>path</i>. It is passed
  * all optional parameters given to <b>dba_popen</b> and
  * can act on behalf of them.
  * </p>
- * @param mixed $_ [optional]
+ * @param mixed ...$handler_parameters [optional]
  * @return resource|false a positive handle on success or <b>FALSE</b> on failure.
  */
-function dba_popen ($path, $mode, $handler = null, $_ = null) {}
+function dba_popen ($path, $mode, $handlername = null, ...$handler_parameters) {}
 
 /**
  * Close a DBA database


### PR DESCRIPTION
These are variadic functions in php 7 and 8

https://wiki.php.net/rfc/named_params will make parameter names of
internal functions part of the API, so having placeholder names instead
of matching names for methods/functions is something that
should probably be changed in many, many places.
(e.g. standard/standard_9.php)

Related to https://youtrack.jetbrains.com/issue/WI-54703 - this process of supporting named arguments should probably be automated in a script that renames parameters in signatures and doc comments