### PR TITLE
IntlBreakIterator::createCharacterInstance - optional argument

### DIFF
--- a/intl/intl.php
+++ b/intl/intl.php
@@ -6340,7 +6340,7 @@ class IntlBreakIterator implements IteratorAggregate
      * @param string $locale
      * @return IntlBreakIterator
      */
-    public static function  createCharacterInstance($locale) { }
+    public static function  createCharacterInstance($locale = null) { }
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>


### PR DESCRIPTION
The argument of IntlBreakIterator::createCharacterInstance is optional. See https://www.php.net/manual/en/intlbreakiterator.createcharacterinstance.php and https://github.com/php/php-src/blob/f78a09101496d05b4fb50fe37b7dbf5d038452ec/ext/intl/breakiterator/breakiterator_arginfo.h#L5