### PR TITLE
IntlBreakIterator::next - optional argument

### DIFF
--- a/intl/intl.php
+++ b/intl/intl.php
@@ -6471,7 +6471,7 @@ class IntlBreakIterator implements IteratorAggregate
      * @param string $offset [optional]
      * @return int
      */
-    public function next($offset) { }
+    public function next($offset = null) { }
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>


### PR DESCRIPTION
The argument of IntlBreakIterator::next is optional - see https://www.php.net/manual/en/intlbreakiterator.next.php and https://github.com/php/php-src/blob/f78a09101496d05b4fb50fe37b7dbf5d038452ec/ext/intl/breakiterator/breakiterator_arginfo.h#L48