### PR TITLE
add model for inferring the type of function callback arguments

### DIFF
--- a/meta/.phpstorm.meta.php
+++ b/meta/.phpstorm.meta.php
@@ -653,6 +653,43 @@ namespace PHPSTORM_META {
     exitPoint(\wp_die());
     exitPoint(\dd());
 
+    /**
+     * @param callable $callable Class, Method or function call
+     * @see callback()
+     * @see arg()
+     * @return mixed
+     */
+    function registerCallbackTypes($callable) {
+      return "registerCallbackTypes $callable";
+    }
+
+    /**
+     * description of the callback arguments
+     * @param mixed $args
+     * @see arg()
+     * @return mixed
+     */
+    function callback(...$args) {
+      return "callback ${$args}";
+    }
+
+    /**
+     * argument type #$argNum of the caller callback
+     * @param mixed $argNum
+     * @return mixed
+     */
+    function arg($argNum) {
+      return "arg $argNum";
+    }
+
+    registerCallbackTypes(\array_walk(array(), callback(arg(0), "mixed")));
+    registerCallbackTypes(\array_walk_recursive(array(), callback(arg(0), "mixed")));
+    registerCallbackTypes(\array_filter(array(), callback(arg(0))));
+    registerCallbackTypes(\array_reduce(array(), callback(arg(0), arg(0))));
+
+    registerCallbackTypes(\usort(array(), callback(arg(0), arg(0))));
+    registerCallbackTypes(\uasort(array(), callback(arg(0), arg(0))));
+
 //  override( \ServiceLocatorInterface::get(0),
 //    map( [
 //      "A" => \Exception::class,

--- a/meta/.phpstorm.meta.php
+++ b/meta/.phpstorm.meta.php
@@ -673,22 +673,13 @@ namespace PHPSTORM_META {
       return "callback ${$args}";
     }
 
-    /**
-     * argument type #$argNum of the caller callback
-     * @param mixed $argNum
-     * @return mixed
-     */
-    function arg($argNum) {
-      return "arg $argNum";
-    }
+    registerCallbackTypes(\array_walk(array(), callback(elementType(0), "mixed")));
+    registerCallbackTypes(\array_walk_recursive(array(), callback(elementType(0), "mixed")));
+    registerCallbackTypes(\array_filter(array(), callback(elementType(0))));
+    registerCallbackTypes(\array_reduce(array(), callback(elementType(0), elementType(0))));
 
-    registerCallbackTypes(\array_walk(array(), callback(arg(0), "mixed")));
-    registerCallbackTypes(\array_walk_recursive(array(), callback(arg(0), "mixed")));
-    registerCallbackTypes(\array_filter(array(), callback(arg(0))));
-    registerCallbackTypes(\array_reduce(array(), callback(arg(0), arg(0))));
-
-    registerCallbackTypes(\usort(array(), callback(arg(0), arg(0))));
-    registerCallbackTypes(\uasort(array(), callback(arg(0), arg(0))));
+    registerCallbackTypes(\usort(array(), callback(elementType(0), elementType(0))));
+    registerCallbackTypes(\uasort(array(), callback(elementType(0), elementType(0))));
 
 //  override( \ServiceLocatorInterface::get(0),
 //    map( [


### PR DESCRIPTION
This model allows to describe the types of arguments for callback functions depending on the arguments of the calling function.
[WI-54960](https://youtrack.jetbrains.com/issue/WI-54960)