### PR TITLE
[apcu] apcu_key_info($key) should return array|null

### DIFF
--- a/apcu/apcu.php
+++ b/apcu/apcu.php
@@ -573,6 +573,7 @@ function apcu_enabled(){}
 
 /**
  * @param string $key
+ * @return array|null
  */
 function apcu_key_info($key){}
 


### PR DESCRIPTION
This is not documented in php.net for some reason but it returns the same array as ApcuIterator entries.