### PR TITLE
ReflectionProperty::getType() returns ReflectionType

### DIFF
--- a/Reflection/ReflectionProperty.php
+++ b/Reflection/ReflectionProperty.php
@@ -213,7 +213,7 @@ class ReflectionProperty implements Reflector
      * Gets property type
      *
      * @link https://php.net/manual/en/reflectionproperty.gettype.php
-     * @return ReflectionNamedType|null Returns a {@see ReflectionNamedType} if the
+     * @return ReflectionType|null Returns a {@see ReflectionType} if the
      * property has a type, and {@see null} otherwise.
      * @since 7.4
      */


### PR DESCRIPTION
In PHP 8, `ReflectionProperty::getType()` returns either a `ReflectionNamedType` or a `ReflectionUnionType`:

https://3v4l.org/3X0Rp

So the correct return value is `ReflectionType`, just like [ReflectionParameter::getType()](https://github.com/JetBrains/phpstorm-stubs/blob/874def36f96dbb7db2eb2ff5e47ff54ac3ea34fc/Reflection/ReflectionParameter.php#L129-L139).