### PR TITLE
WI-55725: make second argument to imagexbm optional

### DIFF
--- a/gd/gd.php
+++ b/gd/gd.php
@@ -2062,7 +2062,7 @@ function imagecolormatch ($image1, $image2) {}
  * Output XBM image to browser or file
  * @link https://php.net/manual/en/function.imagexbm.php
  * @param resource $image
- * @param string $filename <p>
+ * @param string $filename [optional] <p>
  * The path to save the file to. If not set or null, the raw image stream
  * will be outputted directly.
  * </p>
@@ -2073,7 +2073,7 @@ function imagecolormatch ($image1, $image2) {}
  * </p>
  * @return bool true on success or false on failure.
  */
-function imagexbm ($image, $filename, $foreground = null) {}
+function imagexbm ($image, $filename = null, $foreground = null) {}
 
 /**
  * Applies a filter to an image


### PR DESCRIPTION
Closes https://youtrack.jetbrains.com/issue/WI-55725

Per the [PHP Doc](https://www.php.net/manual/en/function.imagexbm.php), the second argument is defined as `[$filename = NULL]` and where if not set, will cause the function to output the stream versus sending it to the set filename.