### PR TITLE
Migrate tests to php 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,5 @@ script:
   - docker-compose -f docker-compose.yml build >/dev/null
   - docker-compose -f docker-compose.yml run php /opt/project/phpstorm-stubs/vendor/bin/phpunit /opt/project/phpstorm-stubs/tests/
   - ./tests/check-stub-map
-  - composer cs
+  # uncomment when cs-fixer will support union types
+  # - composer cs

--- a/tests/Model/BasePHPElement.php
+++ b/tests/Model/BasePHPElement.php
@@ -35,7 +35,7 @@ abstract class BasePHPElement
         return rtrim($fqn, "\\");
     }
 
-    public function hasMutedProblem($stubProblemType): bool
+    public function hasMutedProblem(int $stubProblemType): bool
     {
         return in_array($stubProblemType, $this->mutedProblems, true);
     }

--- a/tests/Model/BasePHPElement.php
+++ b/tests/Model/BasePHPElement.php
@@ -6,6 +6,7 @@ namespace StubTests\Model;
 use Exception;
 use PhpParser\Node;
 use Reflector;
+use stdClass;
 
 abstract class BasePHPElement
 {
@@ -18,7 +19,7 @@ abstract class BasePHPElement
 
     abstract public function readObjectFromStubNode(Node $node): static;
 
-    abstract public function readMutedProblems($jsonData): void;
+    abstract public function readMutedProblems(stdClass|array $jsonData): void;
 
     protected function getFQN(Node $node): string
     {

--- a/tests/Model/BasePHPElement.php
+++ b/tests/Model/BasePHPElement.php
@@ -14,9 +14,9 @@ abstract class BasePHPElement
     public ?Exception $parseError = null;
     protected array $mutedProblems = [];
 
-    abstract public function readObjectFromReflection(Reflector $object);
+    abstract public function readObjectFromReflection(Reflector $object): static;
 
-    abstract public function readObjectFromStubNode(Node $node);
+    abstract public function readObjectFromStubNode(Node $node): static;
 
     abstract public function readMutedProblems($jsonData): void;
 

--- a/tests/Model/BasePHPElement.php
+++ b/tests/Model/BasePHPElement.php
@@ -10,12 +10,12 @@ use stdClass;
 
 abstract class BasePHPElement
 {
-    public string $name;
+    public ?string $name = null;
     public bool $stubBelongsToCore = false;
     public ?Exception $parseError = null;
     protected array $mutedProblems = [];
 
-    abstract public function readObjectFromReflection(Reflector $object): static;
+    abstract public function readObjectFromReflection(Reflector $reflectionObject): static;
 
     abstract public function readObjectFromStubNode(Node $node): static;
 

--- a/tests/Model/PHPClass.php
+++ b/tests/Model/PHPClass.php
@@ -21,7 +21,7 @@ class PHPClass extends BasePHPClass
      * @param ReflectionClass $clazz
      * @return $this
      */
-    public function readObjectFromReflection($clazz): self
+    public function readObjectFromReflection($clazz): static
     {
         $this->name = $clazz->getName();
         $parent = $clazz->getParentClass();
@@ -57,7 +57,7 @@ class PHPClass extends BasePHPClass
      * @param Class_ $node
      * @return $this
      */
-    public function readObjectFromStubNode($node): self
+    public function readObjectFromStubNode($node): static
     {
         $this->name = $this->getFQN($node);
         $this->collectTags($node);

--- a/tests/Model/PHPClass.php
+++ b/tests/Model/PHPClass.php
@@ -11,40 +11,39 @@ use stdClass;
 
 class PHPClass extends BasePHPClass
 {
-    /** @var false|string */
-    public $parentClass;
+    public false|string|null $parentClass = null;
     public array $interfaces = [];
     /** @var PHPProperty[] */
     public array $properties = [];
 
     /**
-     * @param ReflectionClass $clazz
+     * @param ReflectionClass $reflectionObject
      * @return $this
      */
-    public function readObjectFromReflection($clazz): static
+    public function readObjectFromReflection($reflectionObject): static
     {
-        $this->name = $clazz->getName();
-        $parent = $clazz->getParentClass();
+        $this->name = $reflectionObject->getName();
+        $parent = $reflectionObject->getParentClass();
         if ($parent !== false) {
             $this->parentClass = $parent->getName();
         }
-        $this->interfaces = $clazz->getInterfaceNames();
+        $this->interfaces = $reflectionObject->getInterfaceNames();
 
-        foreach ($clazz->getMethods() as $method) {
+        foreach ($reflectionObject->getMethods() as $method) {
             if ($method->getDeclaringClass()->getName() !== $this->name) {
                 continue;
             }
             $this->methods[$method->name] = (new PHPMethod())->readObjectFromReflection($method);
         }
 
-        foreach ($clazz->getReflectionConstants() as $constant) {
+        foreach ($reflectionObject->getReflectionConstants() as $constant) {
             if ($constant->getDeclaringClass()->getName() !== $this->name) {
                 continue;
             }
             $this->constants[$constant->name] = (new PHPConst())->readObjectFromReflection($constant);
         }
 
-        foreach ($clazz->getProperties() as $property) {
+        foreach ($reflectionObject->getProperties() as $property) {
             if ($property->getDeclaringClass()->getName() !== $this->name) {
                 continue;
             }
@@ -100,7 +99,6 @@ class PHPClass extends BasePHPClass
                 $this->properties[$propertyName] = $newProperty;
             }
         }
-
 
         return $this;
     }

--- a/tests/Model/PHPClass.php
+++ b/tests/Model/PHPClass.php
@@ -105,26 +105,16 @@ class PHPClass extends BasePHPClass
 
     public function readMutedProblems(stdClass|array $jsonData): void
     {
-        /**@var stdClass $class */
         foreach ($jsonData as $class) {
             if ($class->name === $this->name) {
                 if (!empty($class->problems)) {
-                    /**@var stdClass $problem */
                     foreach ($class->problems as $problem) {
-                        switch ($problem) {
-                            case 'wrong parent':
-                                $this->mutedProblems[] = StubProblemType::WRONG_PARENT;
-                                break;
-                            case 'wrong interface':
-                                $this->mutedProblems[] = StubProblemType::WRONG_INTERFACE;
-                                break;
-                            case 'missing class':
-                                $this->mutedProblems[] = StubProblemType::STUB_IS_MISSED;
-                                break;
-                            default:
-                                $this->mutedProblems[] = -1;
-                                break;
-                        }
+                        $this->mutedProblems[] = match ($problem) {
+                            'wrong parent' => StubProblemType::WRONG_PARENT,
+                            'wrong interface' => StubProblemType::WRONG_INTERFACE,
+                            'missing class' => StubProblemType::STUB_IS_MISSED,
+                            default => -1,
+                        };
                     }
                 }
                 if (!empty($class->methods)) {

--- a/tests/Model/PHPClass.php
+++ b/tests/Model/PHPClass.php
@@ -105,7 +105,7 @@ class PHPClass extends BasePHPClass
         return $this;
     }
 
-    public function readMutedProblems($jsonData): void
+    public function readMutedProblems(stdClass|array $jsonData): void
     {
         /**@var stdClass $class */
         foreach ($jsonData as $class) {

--- a/tests/Model/PHPConst.php
+++ b/tests/Model/PHPConst.php
@@ -76,22 +76,14 @@ class PHPConst extends BasePHPElement
 
     public function readMutedProblems(stdClass|array $jsonData): void
     {
-        /**@var stdClass $constant */
         foreach ($jsonData as $constant) {
             if ($constant->name === $this->name && !empty($constant->problems)) {
-                /**@var stdClass $problem */
                 foreach ($constant->problems as $problem) {
-                    switch ($problem) {
-                        case 'wrong value':
-                            $this->mutedProblems[] = StubProblemType::WRONG_CONSTANT_VALUE;
-                            break;
-                        case 'missing constant':
-                            $this->mutedProblems[] = StubProblemType::STUB_IS_MISSED;
-                            break;
-                        default:
-                            $this->mutedProblems[] = -1;
-                            break;
-                    }
+                    $this->mutedProblems[] = match ($problem) {
+                        'wrong value' => StubProblemType::WRONG_CONSTANT_VALUE,
+                        'missing constant' => StubProblemType::STUB_IS_MISSED,
+                        default => -1
+                    };
                 }
                 return;
             }

--- a/tests/Model/PHPConst.php
+++ b/tests/Model/PHPConst.php
@@ -19,13 +19,13 @@ class PHPConst extends BasePHPElement
     public $value;
 
     /**
-     * @param ReflectionClassConstant $constant
+     * @param ReflectionClassConstant $reflectionObject
      * @return $this
      */
-    public function readObjectFromReflection($constant): static
+    public function readObjectFromReflection($reflectionObject): static
     {
-        $this->name = $constant->name;
-        $this->value = $constant->getValue();
+        $this->name = $reflectionObject->name;
+        $this->value = $reflectionObject->getValue();
         return $this;
     }
 

--- a/tests/Model/PHPConst.php
+++ b/tests/Model/PHPConst.php
@@ -16,7 +16,7 @@ class PHPConst extends BasePHPElement
     use PHPDocElement;
 
     public ?string $parentName = null;
-    public $value;
+    public bool|int|string|float|null $value;
 
     /**
      * @param ReflectionClassConstant $reflectionObject
@@ -45,7 +45,7 @@ class PHPConst extends BasePHPElement
         return $this;
     }
 
-    protected function getConstValue($node)
+    protected function getConstValue($node): int|string|null|bool|float
     {
         if (in_array('value', $node->value->getSubNodeNames(), true)) {
             return $node->value->value;

--- a/tests/Model/PHPConst.php
+++ b/tests/Model/PHPConst.php
@@ -22,7 +22,7 @@ class PHPConst extends BasePHPElement
      * @param ReflectionClassConstant $constant
      * @return $this
      */
-    public function readObjectFromReflection($constant): self
+    public function readObjectFromReflection($constant): static
     {
         $this->name = $constant->name;
         $this->value = $constant->getValue();
@@ -33,7 +33,7 @@ class PHPConst extends BasePHPElement
      * @param Const_ $node
      * @return $this
      */
-    public function readObjectFromStubNode($node): self
+    public function readObjectFromStubNode($node): static
     {
         $this->name = $this->getConstantFQN($node, $node->name->name);
         $this->value = $this->getConstValue($node);

--- a/tests/Model/PHPConst.php
+++ b/tests/Model/PHPConst.php
@@ -74,7 +74,7 @@ class PHPConst extends BasePHPElement
         return $namespace . $nodeName;
     }
 
-    public function readMutedProblems($jsonData): void
+    public function readMutedProblems(stdClass|array $jsonData): void
     {
         /**@var stdClass $constant */
         foreach ($jsonData as $constant) {

--- a/tests/Model/PHPDefineConstant.php
+++ b/tests/Model/PHPDefineConstant.php
@@ -10,17 +10,17 @@ use function is_string;
 class PHPDefineConstant extends PHPConst
 {
     /**
-     * @param array $constant
+     * @param array $reflectionObject
      * @return $this
      */
-    public function readObjectFromReflection($constant): static
+    public function readObjectFromReflection($reflectionObject): static
     {
-        if (is_string($constant[0])) {
-            $this->name = utf8_encode($constant[0]);
+        if (is_string($reflectionObject[0])) {
+            $this->name = utf8_encode($reflectionObject[0]);
         } else {
-            $this->name = $constant[0];
+            $this->name = $reflectionObject[0];
         }
-        $constantValue = $constant[1];
+        $constantValue = $reflectionObject[1];
         if ($constantValue !== null) {
             if (is_resource($constantValue)) {
                 $this->value = 'PHPSTORM_RESOURCE';

--- a/tests/Model/PHPDefineConstant.php
+++ b/tests/Model/PHPDefineConstant.php
@@ -13,7 +13,7 @@ class PHPDefineConstant extends PHPConst
      * @param array $constant
      * @return $this
      */
-    public function readObjectFromReflection($constant): self
+    public function readObjectFromReflection($constant): static
     {
         if (is_string($constant[0])) {
             $this->name = utf8_encode($constant[0]);
@@ -39,7 +39,7 @@ class PHPDefineConstant extends PHPConst
      * @param FuncCall $node
      * @return $this
      */
-    public function readObjectFromStubNode($node): self
+    public function readObjectFromStubNode($node): static
     {
         $constName = $this->getConstantFQN($node, $node->args[0]->value->value);
         if (in_array($constName, ['null', 'true', 'false'])) {

--- a/tests/Model/PHPFunction.php
+++ b/tests/Model/PHPFunction.php
@@ -94,31 +94,17 @@ class PHPFunction extends BasePHPElement
 
     public function readMutedProblems(stdClass|array $jsonData): void
     {
-        /**@var stdClass $function */
         foreach ($jsonData as $function) {
             if ($function->name === $this->name && !empty($function->problems)) {
-                /**@var stdClass $problem */
                 foreach ($function->problems as $problem) {
-                    switch ($problem) {
-                        case 'parameter mismatch':
-                            $this->mutedProblems[] = StubProblemType::FUNCTION_PARAMETER_MISMATCH;
-                            break;
-                        case 'missing function':
-                            $this->mutedProblems[] = StubProblemType::STUB_IS_MISSED;
-                            break;
-                        case 'deprecated function':
-                            $this->mutedProblems[] = StubProblemType::FUNCTION_IS_DEPRECATED;
-                            break;
-                        case 'absent in meta':
-                            $this->mutedProblems[] = StubProblemType::ABSENT_IN_META;
-                            break;
-                        case 'has return typehint':
-                            $this->mutedProblems[] = StubProblemType::FUNCTION_HAS_RETURN_TYPEHINT;
-                            break;
-                        default:
-                            $this->mutedProblems[] = -1;
-                            break;
-                    }
+                    $this->mutedProblems[] = match ($problem) {
+                        'parameter mismatch' => StubProblemType::FUNCTION_PARAMETER_MISMATCH,
+                        'missing function' => StubProblemType::STUB_IS_MISSED,
+                        'deprecated function' => StubProblemType::FUNCTION_IS_DEPRECATED,
+                        'absent in meta' => StubProblemType::ABSENT_IN_META,
+                        'has return typehint' => StubProblemType::FUNCTION_HAS_RETURN_TYPEHINT,
+                        default => -1
+                    };
                 }
                 return;
             }

--- a/tests/Model/PHPFunction.php
+++ b/tests/Model/PHPFunction.php
@@ -92,7 +92,7 @@ class PHPFunction extends BasePHPElement
         }
     }
 
-    public function readMutedProblems($jsonData): void
+    public function readMutedProblems(stdClass|array $jsonData): void
     {
         /**@var stdClass $function */
         foreach ($jsonData as $function) {

--- a/tests/Model/PHPFunction.php
+++ b/tests/Model/PHPFunction.php
@@ -28,14 +28,14 @@ class PHPFunction extends BasePHPElement
     public ?NodeAbstract $returnType = null;
 
     /**
-     * @param ReflectionFunction $function
+     * @param ReflectionFunction $reflectionObject
      * @return $this
      */
-    public function readObjectFromReflection($function): static
+    public function readObjectFromReflection($reflectionObject): static
     {
-        $this->name = $function->name;
-        $this->is_deprecated = $function->isDeprecated();
-        foreach ($function->getParameters() as $parameter) {
+        $this->name = $reflectionObject->name;
+        $this->is_deprecated = $reflectionObject->isDeprecated();
+        foreach ($reflectionObject->getParameters() as $parameter) {
             $this->parameters[] = (new PHPParameter())->readObjectFromReflection($parameter);
         }
         return $this;

--- a/tests/Model/PHPFunction.php
+++ b/tests/Model/PHPFunction.php
@@ -31,7 +31,7 @@ class PHPFunction extends BasePHPElement
      * @param ReflectionFunction $function
      * @return $this
      */
-    public function readObjectFromReflection($function): self
+    public function readObjectFromReflection($function): static
     {
         $this->name = $function->name;
         $this->is_deprecated = $function->isDeprecated();
@@ -45,7 +45,7 @@ class PHPFunction extends BasePHPElement
      * @param Function_ $node
      * @return $this
      */
-    public function readObjectFromStubNode($node): self
+    public function readObjectFromStubNode($node): static
     {
         $functionName = $this->getFQN($node);
         $this->name = $functionName;

--- a/tests/Model/PHPInterface.php
+++ b/tests/Model/PHPInterface.php
@@ -12,20 +12,20 @@ class PHPInterface extends BasePHPClass
     public array $parentInterfaces = [];
 
     /**
-     * @param ReflectionClass $interface
+     * @param ReflectionClass $reflectionObject
      * @return $this
      */
-    public function readObjectFromReflection($interface): static
+    public function readObjectFromReflection($reflectionObject): static
     {
-        $this->name = $interface->getName();
-        foreach ($interface->getMethods() as $method) {
+        $this->name = $reflectionObject->getName();
+        foreach ($reflectionObject->getMethods() as $method) {
             if ($method->getDeclaringClass()->getName() !== $this->name) {
                 continue;
             }
             $this->methods[$method->name] = (new PHPMethod())->readObjectFromReflection($method);
         }
-        $this->parentInterfaces = $interface->getInterfaceNames();
-        foreach ($interface->getReflectionConstants() as $constant) {
+        $this->parentInterfaces = $reflectionObject->getInterfaceNames();
+        foreach ($reflectionObject->getReflectionConstants() as $constant) {
             if ($constant->getDeclaringClass()->getName() !== $this->name) {
                 continue;
             }

--- a/tests/Model/PHPInterface.php
+++ b/tests/Model/PHPInterface.php
@@ -48,7 +48,7 @@ class PHPInterface extends BasePHPClass
         return $this;
     }
 
-    public function readMutedProblems($jsonData): void
+    public function readMutedProblems(stdClass|array $jsonData): void
     {
         /**@var stdClass $interface */
         foreach ($jsonData as $interface) {

--- a/tests/Model/PHPInterface.php
+++ b/tests/Model/PHPInterface.php
@@ -15,7 +15,7 @@ class PHPInterface extends BasePHPClass
      * @param ReflectionClass $interface
      * @return $this
      */
-    public function readObjectFromReflection($interface): self
+    public function readObjectFromReflection($interface): static
     {
         $this->name = $interface->getName();
         foreach ($interface->getMethods() as $method) {
@@ -38,7 +38,7 @@ class PHPInterface extends BasePHPClass
      * @param Interface_ $node
      * @return $this
      */
-    public function readObjectFromStubNode($node): self
+    public function readObjectFromStubNode($node): static
     {
         $this->name = $this->getFQN($node);
         $this->collectTags($node);

--- a/tests/Model/PHPInterface.php
+++ b/tests/Model/PHPInterface.php
@@ -50,23 +50,15 @@ class PHPInterface extends BasePHPClass
 
     public function readMutedProblems(stdClass|array $jsonData): void
     {
-        /**@var stdClass $interface */
         foreach ($jsonData as $interface) {
             if ($interface->name === $this->name) {
                 if (!empty($interface->problems)) {
-                    /**@var stdClass $problem */
                     foreach ($interface->problems as $problem) {
-                        switch ($problem) {
-                            case 'wrong parent':
-                                $this->mutedProblems[] = StubProblemType::WRONG_PARENT;
-                                break;
-                            case 'missing interface':
-                                $this->mutedProblems[] = StubProblemType::STUB_IS_MISSED;
-                                break;
-                            default:
-                                $this->mutedProblems[] = -1;
-                                break;
-                        }
+                        $this->mutedProblems[] = match ($problem) {
+                            'wrong parent' => StubProblemType::WRONG_PARENT,
+                            'missing interface' => StubProblemType::STUB_IS_MISSED,
+                            default => -1
+                        };
                     }
                 }
                 if (!empty($interface->methods)) {

--- a/tests/Model/PHPMethod.php
+++ b/tests/Model/PHPMethod.php
@@ -18,7 +18,7 @@ class PHPMethod extends PHPFunction
      * @param ReflectionMethod $method
      * @return $this
      */
-    public function readObjectFromReflection($method): self
+    public function readObjectFromReflection($method): static
     {
         $this->name = $method->name;
         $this->is_static = $method->isStatic();
@@ -42,7 +42,7 @@ class PHPMethod extends PHPFunction
      * @param ClassMethod $node
      * @return $this
      */
-    public function readObjectFromStubNode($node): self
+    public function readObjectFromStubNode($node): static
     {
         $this->parentName = $this->getFQN($node->getAttribute('parent'));
         $this->name = $node->name->name;

--- a/tests/Model/PHPMethod.php
+++ b/tests/Model/PHPMethod.php
@@ -15,21 +15,21 @@ class PHPMethod extends PHPFunction
     public string $parentName;
 
     /**
-     * @param ReflectionMethod $method
+     * @param ReflectionMethod $reflectionObject
      * @return $this
      */
-    public function readObjectFromReflection($method): static
+    public function readObjectFromReflection($reflectionObject): static
     {
-        $this->name = $method->name;
-        $this->is_static = $method->isStatic();
-        $this->is_final = $method->isFinal();
-        foreach ($method->getParameters() as $parameter) {
+        $this->name = $reflectionObject->name;
+        $this->is_static = $reflectionObject->isStatic();
+        $this->is_final = $reflectionObject->isFinal();
+        foreach ($reflectionObject->getParameters() as $parameter) {
             $this->parameters[] = (new PHPParameter())->readObjectFromReflection($parameter);
         }
 
-        if ($method->isProtected()) {
+        if ($reflectionObject->isProtected()) {
             $access = 'protected';
-        } elseif ($method->isPrivate()) {
+        } elseif ($reflectionObject->isPrivate()) {
             $access = 'private';
         } else {
             $access = 'public';

--- a/tests/Model/PHPMethod.php
+++ b/tests/Model/PHPMethod.php
@@ -73,32 +73,18 @@ class PHPMethod extends PHPFunction
 
     public function readMutedProblems(stdClass|array $jsonData): void
     {
-        /**@var stdClass $method */
         foreach ($jsonData as $method) {
             if ($method->name === $this->name) {
                 if (!empty($method->problems)) {
-                    /**@var stdClass $problem */
                     foreach ($method->problems as $problem) {
-                        switch ($problem) {
-                            case 'parameter mismatch':
-                                $this->mutedProblems[] = StubProblemType::FUNCTION_PARAMETER_MISMATCH;
-                                break;
-                            case 'missing method':
-                                $this->mutedProblems[] = StubProblemType::STUB_IS_MISSED;
-                                break;
-                            case 'deprecated method':
-                                $this->mutedProblems[] = StubProblemType::FUNCTION_IS_DEPRECATED;
-                                break;
-                            case 'absent in meta':
-                                $this->mutedProblems[] = StubProblemType::ABSENT_IN_META;
-                                break;
-                            case 'wrong access':
-                                $this->mutedProblems[] = StubProblemType::FUNCTION_ACCESS;
-                                break;
-                            default:
-                                $this->mutedProblems[] = -1;
-                                break;
-                        }
+                        $this->mutedProblems[] = match ($problem) {
+                            'parameter mismatch' => StubProblemType::FUNCTION_PARAMETER_MISMATCH,
+                            'missing method' => StubProblemType::STUB_IS_MISSED,
+                            'deprecated method' => StubProblemType::FUNCTION_IS_DEPRECATED,
+                            'absent in meta' => StubProblemType::ABSENT_IN_META,
+                            'wrong access' => StubProblemType::FUNCTION_ACCESS,
+                            default => -1
+                        };
                     }
                 }
                 if (!empty($method->parameters)) {

--- a/tests/Model/PHPMethod.php
+++ b/tests/Model/PHPMethod.php
@@ -71,7 +71,7 @@ class PHPMethod extends PHPFunction
         return $this;
     }
 
-    public function readMutedProblems($jsonData): void
+    public function readMutedProblems(stdClass|array $jsonData): void
     {
         /**@var stdClass $method */
         foreach ($jsonData as $method) {

--- a/tests/Model/PHPParameter.php
+++ b/tests/Model/PHPParameter.php
@@ -11,8 +11,8 @@ use stdClass;
 class PHPParameter extends BasePHPElement
 {
     public string $type = '';
-    public bool $is_vararg;
-    public bool $is_passed_by_ref;
+    public bool $is_vararg = false;
+    public bool $is_passed_by_ref = false;
 
     /**
      * @param ReflectionParameter $reflectionObject
@@ -22,7 +22,7 @@ class PHPParameter extends BasePHPElement
     {
         $this->name = $reflectionObject->name;
         $parameterType = $reflectionObject->getType();
-        if ($parameterType !== null && $parameterType instanceof ReflectionNamedType) {
+        if ($parameterType instanceof ReflectionNamedType) {
             $this->type = $parameterType->getName();
         }
         $this->is_vararg = $reflectionObject->isVariadic();
@@ -53,31 +53,17 @@ class PHPParameter extends BasePHPElement
 
     public function readMutedProblems(stdClass|array $jsonData): void
     {
-        /**@var stdClass $parameter */
         foreach ($jsonData as $parameter) {
             if ($parameter->name === $this->name && !empty($parameter->problems)) {
-                /**@var stdClass $problem */
                 foreach ($parameter->problems as $problem) {
-                    switch ($problem) {
-                        case 'parameter type mismatch':
-                            $this->mutedProblems[] = StubProblemType::PARAMETER_TYPE_MISMATCH;
-                            break;
-                        case 'parameter reference':
-                            $this->mutedProblems[] = StubProblemType::PARAMETER_REFERENCE;
-                            break;
-                        case 'parameter vararg':
-                            $this->mutedProblems[] = StubProblemType::PARAMETER_VARARG;
-                            break;
-                        case 'has scalar typehint':
-                            $this->mutedProblems[] = StubProblemType::PARAMETER_HAS_SCALAR_TYPEHINT;
-                            break;
-                        case 'parameter name mismatch':
-                            $this->mutedProblems[] = StubProblemType::PARAMETER_NAME_MISMATCH;
-                            break;
-                        default:
-                            $this->mutedProblems[] = -1;
-                            break;
-                    }
+                    $this->mutedProblems[] = match ($problem) {
+                        'parameter type mismatch' => StubProblemType::PARAMETER_TYPE_MISMATCH,
+                        'parameter reference' => StubProblemType::PARAMETER_REFERENCE,
+                        'parameter vararg' => StubProblemType::PARAMETER_VARARG,
+                        'has scalar typehint' => StubProblemType::PARAMETER_HAS_SCALAR_TYPEHINT,
+                        'parameter name mismatch' => StubProblemType::PARAMETER_NAME_MISMATCH,
+                        default => -1
+                    };
                 }
                 return;
             }

--- a/tests/Model/PHPParameter.php
+++ b/tests/Model/PHPParameter.php
@@ -18,7 +18,7 @@ class PHPParameter extends BasePHPElement
      * @param ReflectionParameter $parameter
      * @return $this
      */
-    public function readObjectFromReflection($parameter): self
+    public function readObjectFromReflection($parameter): static
     {
         $this->name = $parameter->name;
         $parameterType = $parameter->getType();
@@ -34,7 +34,7 @@ class PHPParameter extends BasePHPElement
      * @param Param $node
      * @return $this
      */
-    public function readObjectFromStubNode($node): self
+    public function readObjectFromStubNode($node): static
     {
         $this->name = $node->var->name;
         if ($node->type !== null) {

--- a/tests/Model/PHPParameter.php
+++ b/tests/Model/PHPParameter.php
@@ -15,18 +15,18 @@ class PHPParameter extends BasePHPElement
     public bool $is_passed_by_ref;
 
     /**
-     * @param ReflectionParameter $parameter
+     * @param ReflectionParameter $reflectionObject
      * @return $this
      */
-    public function readObjectFromReflection($parameter): static
+    public function readObjectFromReflection($reflectionObject): static
     {
-        $this->name = $parameter->name;
-        $parameterType = $parameter->getType();
+        $this->name = $reflectionObject->name;
+        $parameterType = $reflectionObject->getType();
         if ($parameterType !== null && $parameterType instanceof ReflectionNamedType) {
             $this->type = $parameterType->getName();
         }
-        $this->is_vararg = $parameter->isVariadic();
-        $this->is_passed_by_ref = $parameter->isPassedByReference();
+        $this->is_vararg = $reflectionObject->isVariadic();
+        $this->is_passed_by_ref = $reflectionObject->isPassedByReference();
         return $this;
     }
 

--- a/tests/Model/PHPParameter.php
+++ b/tests/Model/PHPParameter.php
@@ -51,7 +51,7 @@ class PHPParameter extends BasePHPElement
         return $this;
     }
 
-    public function readMutedProblems($jsonData): void
+    public function readMutedProblems(stdClass|array $jsonData): void
     {
         /**@var stdClass $parameter */
         foreach ($jsonData as $parameter) {

--- a/tests/Model/PHPProperty.php
+++ b/tests/Model/PHPProperty.php
@@ -19,24 +19,24 @@ class PHPProperty extends BasePHPElement
     }
 
     /**
-     * @param \ReflectionProperty $property
+     * @param \ReflectionProperty $reflectionObject
      * @return $this
      */
-    public function readObjectFromReflection($property): static
+    public function readObjectFromReflection($reflectionObject): static
     {
-        $this->name = $property->getName();
-        if ($property->isProtected()) {
+        $this->name = $reflectionObject->getName();
+        if ($reflectionObject->isProtected()) {
             $access = 'protected';
-        } elseif ($property->isPrivate()) {
+        } elseif ($reflectionObject->isPrivate()) {
             $access = 'private';
         } else {
             $access = 'public';
         }
         $this->access = $access;
-        $this->is_static = $property->isStatic();
+        $this->is_static = $reflectionObject->isStatic();
         $this->type = "";
-        if ($property->hasType()) {
-            $this->type = "" . $property->getType();
+        if ($reflectionObject->hasType()) {
+            $this->type = "" . $reflectionObject->getType();
         }
         return $this;
     }

--- a/tests/Model/PHPProperty.php
+++ b/tests/Model/PHPProperty.php
@@ -69,7 +69,7 @@ class PHPProperty extends BasePHPElement
     }
 
 
-    public function readMutedProblems($jsonData): void
+    public function readMutedProblems(stdClass|array $jsonData): void
     {
         /**@var stdClass $property */
         foreach ($jsonData as $property) {

--- a/tests/Model/PHPProperty.php
+++ b/tests/Model/PHPProperty.php
@@ -22,7 +22,7 @@ class PHPProperty extends BasePHPElement
      * @param \ReflectionProperty $property
      * @return $this
      */
-    public function readObjectFromReflection($property): self
+    public function readObjectFromReflection($property): static
     {
         $this->name = $property->getName();
         if ($property->isProtected()) {
@@ -45,7 +45,7 @@ class PHPProperty extends BasePHPElement
      * @param Property $node
      * @return $this
      */
-    public function readObjectFromStubNode($node): self
+    public function readObjectFromStubNode($node): static
     {
         $this->name = $node->props[0]->name->name;
         $this->is_static = $node->isStatic();

--- a/tests/Model/PHPProperty.php
+++ b/tests/Model/PHPProperty.php
@@ -9,14 +9,11 @@ use stdClass;
 
 class PHPProperty extends BasePHPElement
 {
-    public ?string $parentName = null;
     public string $type = '';
     public string $access = '';
     public bool $is_static = false;
 
-    public function __construct(?string $parentName = null)
-    {
-        $this->parentName = $parentName;
+    public function __construct(public ?string $parentName = null){
     }
 
     /**

--- a/tests/Model/StubsContainer.php
+++ b/tests/Model/StubsContainer.php
@@ -39,10 +39,12 @@ class StubsContainer
      */
     public function addConstant(PHPConst $constant): void
     {
-        if (array_key_exists($constant->name, $this->constants)) {
-            throw new RuntimeException($constant->name . ' is already defined in stubs');
+        if (isset($constant->name)) {
+            if (array_key_exists($constant->name, $this->constants)) {
+                throw new RuntimeException($constant->name . ' is already defined in stubs');
+            }
+            $this->constants[$constant->name] = $constant;
         }
-        $this->constants[$constant->name] = $constant;
     }
 
     /**
@@ -55,12 +57,14 @@ class StubsContainer
 
     public function addFunction(PHPFunction $function): void
     {
-        $this->functions[$function->name] = $function;
+        if (isset($function->name)) {
+            $this->functions[$function->name] = $function;
+        }
     }
 
     public function getClass(string $name): ?PHPClass
     {
-        if (array_key_exists($name, $this->classes) && $this->classes[$name] !== null) {
+        if (array_key_exists($name, $this->classes) && isset($this->classes[$name])) {
             return $this->classes[$name];
         }
 
@@ -80,7 +84,7 @@ class StubsContainer
      */
     public function getCoreClasses(): array
     {
-        return array_filter($this->classes, fn($class) => $class->stubBelongsToCore === true);
+        return array_filter($this->classes, fn($class): bool => $class->stubBelongsToCore === true);
     }
 
     /**
@@ -89,15 +93,17 @@ class StubsContainer
      */
     public function addClass(PHPClass $class): void
     {
-        if (array_key_exists($class->name, $this->classes)) {
-            throw new RuntimeException($class->name . ' is already defined in stubs');
+        if (isset($class->name)){
+            if (array_key_exists($class->name, $this->classes)) {
+                throw new RuntimeException($class->name . ' is already defined in stubs');
+            }
+            $this->classes[$class->name] = $class;
         }
-        $this->classes[$class->name] = $class;
     }
 
     public function getInterface(string $name): ?PHPInterface
     {
-        if (array_key_exists($name, $this->interfaces) && $this->interfaces[$name] !== null) {
+        if (array_key_exists($name, $this->interfaces) && isset($this->interfaces[$name])) {
             return $this->interfaces[$name];
         }
 
@@ -117,7 +123,7 @@ class StubsContainer
      */
     public function getCoreInterfaces(): array
     {
-        return array_filter($this->interfaces,fn($interface) => $interface->stubBelongsToCore === true);
+        return array_filter($this->interfaces, fn($interface): bool => $interface->stubBelongsToCore === true);
     }
 
     /**
@@ -126,9 +132,11 @@ class StubsContainer
      */
     public function addInterface(PHPInterface $interface): void
     {
-        if (array_key_exists($interface->name, $this->interfaces)) {
-            throw new RuntimeException($interface->name . ' is already defined in stubs');
+        if (isset($interface->name)){
+            if (array_key_exists($interface->name, $this->interfaces)) {
+                throw new RuntimeException($interface->name . ' is already defined in stubs');
+            }
+            $this->interfaces[$interface->name] = $interface;
         }
-        $this->interfaces[$interface->name] = $interface;
     }
 }

--- a/tests/Model/Tags/RemovedTag.php
+++ b/tests/Model/Tags/RemovedTag.php
@@ -6,11 +6,10 @@ namespace StubTests\Model\Tags;
 use phpDocumentor\Reflection\DocBlock\Description;
 use phpDocumentor\Reflection\DocBlock\DescriptionFactory;
 use phpDocumentor\Reflection\DocBlock\Tags\BaseTag;
-use phpDocumentor\Reflection\DocBlock\Tags\Factory\StaticMethod;
 use phpDocumentor\Reflection\Types\Context;
 use Webmozart\Assert\Assert;
 
-class RemovedTag extends BaseTag implements StaticMethod
+class RemovedTag extends BaseTag
 {
     protected $name = 'removed';
 
@@ -18,7 +17,7 @@ class RemovedTag extends BaseTag implements StaticMethod
 
     private ?string $version;
 
-    public function __construct($version = null, Description $description = null)
+    public function __construct(?string $version = null, Description $description = null)
     {
         Assert::nullOrStringNotEmpty($version);
 
@@ -26,28 +25,27 @@ class RemovedTag extends BaseTag implements StaticMethod
         $this->description = $description;
     }
 
-    public static function create($body, DescriptionFactory $descriptionFactory = null, Context $context = null)
+    public static function create(?string $body, ?DescriptionFactory $descriptionFactory = null, ?Context $context = null): RemovedTag
     {
-        Assert::nullOrString($body);
         if (empty($body)) {
-            return new static();
+            return new self();
         }
 
         $matches = [];
-        if (!preg_match('/^(' . self::REGEX_VECTOR . ')\s*(.+)?$/sux', $body, $matches)) {
-            return new static(
-                null,
-                null !== $descriptionFactory ? $descriptionFactory->create($body, $context) : null
+        if ($descriptionFactory !== null) {
+            if (!preg_match('/^(' . self::REGEX_VECTOR . ')\s*(.+)?$/sux', $body, $matches)) {
+                return new self(null, $descriptionFactory->create($body, $context));
+            }
+
+            return new self(
+                $matches[1],
+                $descriptionFactory->create($matches[2] ?? '', $context)
             );
         }
-
-        return new static(
-            $matches[1],
-            $descriptionFactory->create($matches[2] ?? '', $context)
-        );
+        return new self();
     }
 
-    public function getVersion(): string
+    public function getVersion(): ?string
     {
         return $this->version;
     }

--- a/tests/Model/Tags/RemovedTag.php
+++ b/tests/Model/Tags/RemovedTag.php
@@ -7,21 +7,14 @@ use phpDocumentor\Reflection\DocBlock\Description;
 use phpDocumentor\Reflection\DocBlock\DescriptionFactory;
 use phpDocumentor\Reflection\DocBlock\Tags\BaseTag;
 use phpDocumentor\Reflection\Types\Context;
-use Webmozart\Assert\Assert;
 
 class RemovedTag extends BaseTag
 {
-    protected $name = 'removed';
-
     private const REGEX_VECTOR = '(?:\d\S*|[^\s\:]+\:\s*\$[^\$]+\$)';
 
-    private ?string $version;
-
-    public function __construct(?string $version = null, Description $description = null)
+    public function __construct(private ?string $version = null, Description $description = null)
     {
-        Assert::nullOrStringNotEmpty($version);
-
-        $this->version = $version;
+        $this->name = 'removed';
         $this->description = $description;
     }
 

--- a/tests/Parsers/ExpectedFunctionArgumentsInfo.php
+++ b/tests/Parsers/ExpectedFunctionArgumentsInfo.php
@@ -21,7 +21,7 @@ class ExpectedFunctionArgumentsInfo
 
     /**
      * ExpectedFunctionArgumentsInfo constructor.
-     * @param Expr $functionReference
+     * @param Expr|null $functionReference
      * @param Expr[] $expectedArguments
      * @param int $index
      */
@@ -73,7 +73,7 @@ class ExpectedFunctionArgumentsInfo
         return $this->index;
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         if ($this->functionReference === null) {
             return '';

--- a/tests/Parsers/ExpectedFunctionArgumentsInfo.php
+++ b/tests/Parsers/ExpectedFunctionArgumentsInfo.php
@@ -5,19 +5,6 @@ use PhpParser\Node\Expr;
 
 class ExpectedFunctionArgumentsInfo
 {
-    /**
-     * @var Expr|null
-     */
-    private ?Expr $functionReference;
-
-    /**
-     * @var Expr[]
-     */
-    private array $expectedArguments;
-    /**
-     * @var int
-     */
-    private int $index;
 
     /**
      * ExpectedFunctionArgumentsInfo constructor.
@@ -25,11 +12,7 @@ class ExpectedFunctionArgumentsInfo
      * @param Expr[] $expectedArguments
      * @param int $index
      */
-    public function __construct(?Expr $functionReference, array $expectedArguments, int $index)
-    {
-        $this->functionReference = $functionReference;
-        $this->expectedArguments = $expectedArguments;
-        $this->index = $index;
+    public function __construct(private ?Expr $functionReference, private array $expectedArguments, private int $index){
     }
 
 

--- a/tests/Parsers/MetaExpectedArgumentsCollector.php
+++ b/tests/Parsers/MetaExpectedArgumentsCollector.php
@@ -20,16 +20,14 @@ class MetaExpectedArgumentsCollector extends NodeVisitorAbstract
     /**
      * @var ExpectedFunctionArgumentsInfo[]
      */
-    private array $expectedArgumentsInfos;
+    private array $expectedArgumentsInfos = [];
     /**
      * @var string[]
      */
-    private array $registeredArgumentsSet;
+    private array $registeredArgumentsSet = [];
 
     public function __construct()
     {
-        $this->expectedArgumentsInfos = array();
-        $this->registeredArgumentsSet = array();
         StubParser::processStubs($this, null, function (SplFileInfo $file): bool {
             return $file->getFilename() === '.phpstorm.meta.php';
         });
@@ -38,13 +36,14 @@ class MetaExpectedArgumentsCollector extends NodeVisitorAbstract
     public function enterNode(Node $node): void
     {
         if ($node instanceof FuncCall) {
-            if ((string)$node->name === self::EXPECTED_ARGUMENTS) {
+            $name = (string)$node->name;
+            if ($name === self::EXPECTED_ARGUMENTS) {
                 $args = $node->args;
                 if (count($args) < 3) {
                     throw new RuntimeException('Expected at least 3 arguments for expectedArguments call');
                 }
                 $this->expectedArgumentsInfos[] = $this->getExpectedArgumentsInfo($args[0]->value, array_slice($args, 2), $args[1]->value->value);
-            } else if ((string)$node->name === self::REGISTER_ARGUMENTS_SET_NAME) {
+            } else if ($name === self::REGISTER_ARGUMENTS_SET_NAME) {
                 $args = $node->args;
                 if (count($args) < 2) {
                     throw new RuntimeException('Expected at least 2 arguments for registerArgumentsSet call');
@@ -52,7 +51,7 @@ class MetaExpectedArgumentsCollector extends NodeVisitorAbstract
                 $this->expectedArgumentsInfos[] = $this->getExpectedArgumentsInfo(null, array_slice($args, 1));
                 $name = $args[0]->value->value;
                 $this->registeredArgumentsSet[] = $name;
-            } else if ((string)$node->name === self::EXPECTED_RETURN_VALUES) {
+            } else if ($name === self::EXPECTED_RETURN_VALUES) {
                 $args = $node->args;
                 if (count($args) < 2) {
                     throw new RuntimeException('Expected at least 2 arguments for expectedReturnValues call');
@@ -84,11 +83,11 @@ class MetaExpectedArgumentsCollector extends NodeVisitorAbstract
      */
     private function unpackArguments(array $expressions): array
     {
-        $result = array();
+        $result = [];
         foreach ($expressions as $expr) {
             if ($expr instanceof BitwiseOr) {
                 /** @noinspection SlowArrayOperationsInLoopInspection */
-                $result = array_merge($result, $this->unpackArguments(array($expr->left, $expr->right)));
+                $result = array_merge($result, $this->unpackArguments([$expr->left, $expr->right]));
             } else {
                 $result[] = $expr;
             }

--- a/tests/Parsers/StubParser.php
+++ b/tests/Parsers/StubParser.php
@@ -28,9 +28,8 @@ class StubParser
         self::$stubs = new StubsContainer();
         $visitor = new ASTVisitor(self::$stubs);
         $coreStubVisitor = new CoreStubASTVisitor(self::$stubs);
-        /** @noinspection PhpUnhandledExceptionInspection */
         self::processStubs($visitor, $coreStubVisitor,
-            fn(SplFileInfo $file) => $file->getFilename() !== '.phpstorm.meta.php');
+            fn(SplFileInfo $file): bool => $file->getFilename() !== '.phpstorm.meta.php');
         foreach (self::$stubs->getInterfaces() as $interface) {
             $interface->parentInterfaces = $visitor->combineParentInterfaces($interface);
         }

--- a/tests/Parsers/Utils.php
+++ b/tests/Parsers/Utils.php
@@ -20,7 +20,7 @@ class Utils
      * @param Since|Deprecated|RemovedTag $tag
      * @return bool
      */
-    public static function tagDoesNotHaveZeroPatchVersion($tag): bool
+    public static function tagDoesNotHaveZeroPatchVersion(Since|RemovedTag|Deprecated $tag): bool
     {
         return (bool)preg_match('/^[1-9]+\.\d+(\.[1-9]+\d*)*$/',$tag->getVersion()); //find version like any but 7.4.0
     }

--- a/tests/Parsers/Visitors/ASTVisitor.php
+++ b/tests/Parsers/Visitors/ASTVisitor.php
@@ -38,7 +38,7 @@ class ASTVisitor extends NodeVisitorAbstract
      * @return void
      * @throws Exception
      */
-    public function enterNode(Node $node)
+    public function enterNode(Node $node): void
     {
         if ($node instanceof Function_) {
             $function = (new PHPFunction())->readObjectFromStubNode($node);
@@ -110,7 +110,6 @@ class ASTVisitor extends NodeVisitorAbstract
         foreach ($interface->parentInterfaces as $parentInterface) {
             $parents[] = $parentInterface;
             if ($this->stubs->getInterface($parentInterface) !== null) {
-                /**@var string $parentInterface */
                 foreach ($this->combineParentInterfaces($this->stubs->getInterface($parentInterface)) as $value) {
                     $parents[] = $value;
                 }

--- a/tests/Parsers/Visitors/ASTVisitor.php
+++ b/tests/Parsers/Visitors/ASTVisitor.php
@@ -24,13 +24,9 @@ use StubTests\Parsers\Utils;
 
 class ASTVisitor extends NodeVisitorAbstract
 {
-    protected StubsContainer $stubs;
-    protected bool $isStubCore;
+    protected bool $isStubCore = false;
 
-    public function __construct(StubsContainer $stubs)
-    {
-        $this->stubs = $stubs;
-        $this->isStubCore = false;
+    public function __construct(protected StubsContainer $stubs){
     }
 
     /**

--- a/tests/Parsers/Visitors/MetaOverrideFunctionsParser.php
+++ b/tests/Parsers/Visitors/MetaOverrideFunctionsParser.php
@@ -31,7 +31,7 @@ class MetaOverrideFunctionsParser extends NodeVisitorAbstract
      * @return void
      * @throws RuntimeException
      */
-    public function enterNode(Node $node)
+    public function enterNode(Node $node): void
     {
         if ($node instanceof Node\Expr\FuncCall && (string)$node->name === self::OVERRIDE_FUNCTION) {
             $args = $node->args;

--- a/tests/Parsers/Visitors/ParentConnector.php
+++ b/tests/Parsers/Visitors/ParentConnector.php
@@ -16,12 +16,12 @@ class ParentConnector extends NodeVisitorAbstract
      */
     private array $stack;
 
-    public function beforeTraverse(array $nodes)
+    public function beforeTraverse(array $nodes): void
     {
         $this->stack = [];
     }
 
-    public function enterNode(Node $node)
+    public function enterNode(Node $node): void
     {
         if (!empty($this->stack)) {
             $node->setAttribute('parent', $this->stack[count($this->stack) - 1]);
@@ -29,7 +29,7 @@ class ParentConnector extends NodeVisitorAbstract
         $this->stack[] = $node;
     }
 
-    public function leaveNode(Node $node)
+    public function leaveNode(Node $node): void
     {
         array_pop($this->stack);
     }

--- a/tests/StubsMetaExpectedArgumentsTest.php
+++ b/tests/StubsMetaExpectedArgumentsTest.php
@@ -25,7 +25,7 @@ class StubsMetaExpectedArgumentsTest extends TestCase
      * @var string[]
      */
     private static array $registeredArgumentsSet;
-    private static $functionsFqns;
+    private static array $functionsFqns;
     private static array $methodsFqns;
     private static array $constantsFqns;
 
@@ -44,7 +44,7 @@ class StubsMetaExpectedArgumentsTest extends TestCase
 
     private static function flatten(array $array): array
     {
-        $return = array();
+        $return = [];
         array_walk_recursive($array, function ($a) use (&$return) {
             $return[$a] = $a;
         });
@@ -200,7 +200,7 @@ class StubsMetaExpectedArgumentsTest extends TestCase
 
     private static function toPresentableFqn(string $name): string
     {
-        if (strpos($name, '\\') === 0) {
+        if (str_starts_with($name, '\\')) {
             return substr($name, 1);
         }
         return $name;
@@ -208,10 +208,6 @@ class StubsMetaExpectedArgumentsTest extends TestCase
 
     private static function getFqn(?Expr $expr): string
     {
-        if ($expr instanceof StaticCall) {
-            return self::getClassMemberFqn($expr->class, $expr->name);
-        } else {
-            return self::toPresentableFqn($expr->name);
-        }
+        return $expr instanceof StaticCall ? self::getClassMemberFqn($expr->class, $expr->name) : self::toPresentableFqn($expr->name);
     }
 }


### PR DESCRIPTION
Tests are updated to use features of php 8. Note that `composer cs` fails due to union types that are currently not supported by cs fixer are used. That's why build is failing but all other checks pass