### PR TITLE
Set correct return type for SimpleXMLElement::__get()

### DIFF
--- a/SimpleXML/SimpleXML.php
+++ b/SimpleXML/SimpleXML.php
@@ -25,7 +25,7 @@ class SimpleXMLElement implements Traversable, ArrayAccess, Countable, Iterator,
      * Provides access to element's children
      * private Method not callable directly, stub exists for typehint only
      * @param string $name child name
-     * @return SimpleXMLElement
+     * @return static
      */
     private function __get($name) {}
 


### PR DESCRIPTION
If SimpleXMLElement is extended, it's children are also instances of the extending class.