### PR TITLE
Properly add newrelic_record_datastore_segment to newrelic

### DIFF
--- a/PhpStormStubsMap.php
+++ b/PhpStormStubsMap.php
@@ -3648,6 +3648,7 @@ const FUNCTIONS = array (
   'newrelic_name_transaction' => 'newrelic/newrelic.php',
   'newrelic_notice_error' => 'newrelic/newrelic.php',
   'newrelic_record_custom_event' => 'newrelic/newrelic.php',
+  'newrelic_record_datastore_segment' => 'newrelic/newrelic.php',
   'newrelic_set_appname' => 'newrelic/newrelic.php',
   'newrelic_set_user_attributes' => 'newrelic/newrelic.php',
   'newrelic_start_transaction' => 'newrelic/newrelic.php',

--- a/newrelic/newrelic.php
+++ b/newrelic/newrelic.php
@@ -449,3 +449,4 @@ function newrelic_start_transaction($appName, $license = null) {}
  * @return mixed|false The return value of $callback is returned. If an error occurs, false is returned, and
  * an error at the E_WARNING level will be triggered
  */
+function newrelic_record_datastore_segment(callable $func, array $parameters) {}


### PR DESCRIPTION
Most of the definition was added in #411, but the second commit removed the actual function definition