### PR TITLE
Make bcscale unpure

### DIFF
--- a/bcmath/bcmath.php
+++ b/bcmath/bcmath.php
@@ -147,7 +147,6 @@ function bcsqrt ($num, $scale = null) {}
  * </p>
  * @return int|true <b>INT</b> since 7.3.0 and <b>TRUE</b> before.
  */
-#[Pure]
 function bcscale ($scale = null) {}
 
 /**


### PR DESCRIPTION
bcscale() sets scaling globally, it is not pure.