### PR TITLE
Fix phpDoc for setEncryptionIndex

### DIFF
--- a/zip/zip.php
+++ b/zip/zip.php
@@ -881,7 +881,7 @@ class ZipArchive implements Countable {
      * Set the encryption method of an entry defined by its index
      * @link https://php.net/manual/en/ziparchive.setencryptionindex.php
      * @param int $index Index of the entry.
-     * @param string $method The encryption method defined by one of the ZipArchive::EM_ constants.
+     * @param int $method The encryption method defined by one of the ZipArchive::EM_ constants.
      * @param string $password [optional] Optional password, default used when missing.
      * @return bool Returns TRUE on success or FALSE on failure.
      * @since 7.2


### PR DESCRIPTION
The `$method` property should be `int` since all `ZipArchive::EM_` constants are `int`.

Possible `EM_` values are:

```php
	/**
	 * No encryption
	 * @link https://secure.php.net/manual/en/zip.constants.php
	 * @since 7.2
	 */
	const EM_NONE = 0;

	/**
	 * AES 128 encryption
	 * @link https://secure.php.net/manual/en/zip.constants.php
	 * @since 7.2
	 */
	const EM_AES_128 = 257;

	/**
	 * AES 192 encryption
	 * @link https://secure.php.net/manual/en/zip.constants.php
	 * @since 7.2
	 */
	const EM_AES_192 = 258;

	/**
	 * AES 256 encryption
	 * @link https://secure.php.net/manual/en/zip.constants.php
	 * @since 7.2
	 */
	const EM_AES_256 = 259;
```