### PR TITLE
dev-master is missing on packagist.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # phpstorm-stubs 
 
+
 [![official JetBrains project](http://jb.gg/badges/official.svg)](https://confluence.jetbrains.com/display/ALL/JetBrains+on+GitHub) 
 [![Build Status](https://travis-ci.org/JetBrains/phpstorm-stubs.svg?branch=master)](https://travis-ci.org/JetBrains/phpstorm-stubs)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0.html)


### PR DESCRIPTION
Hi, it's no longer possible to require this package by the `dev-master` constraint. Although the master branch is here on GitHub, it's missing on packagist.org: https://packagist.org/packages/jetbrains/phpstorm-stubs

I'm opening this because the issue tracker here is closed.