### PR TITLE
SimpleXMLElement::asXML() is not pure

### DIFF
--- a/SimpleXML/SimpleXML.php
+++ b/SimpleXML/SimpleXML.php
@@ -44,7 +44,6 @@ class SimpleXMLElement implements Traversable, ArrayAccess, Countable, Iterator,
 	 * successfully and <b>FALSE</b> otherwise.
 	 * @since 5.0.1
 	 */
-    #[Pure]
 	public function asXML ($filename = null) {}
 
 	/**


### PR DESCRIPTION
When the $filename is passed, it saves XML to disk. See https://github.com/phpstan/phpstan/issues/4113#issuecomment-732128847 for details. Thank you.