### PR TITLE
Fix ImagickPixel::getColor() default value

### DIFF
--- a/imagick/imagick.php
+++ b/imagick/imagick.php
@@ -6759,7 +6759,7 @@ class ImagickPixel  {
 	 * @throws ImagickPixelException on error.
 	 */
 	#[Pure]
-	public function getColor ($normalized = false) {}
+	public function getColor ($normalized = 0) {}
 
 	/**
 	 * (PECL imagick 2.1.0)<br/>


### PR DESCRIPTION
`$normalized` is an int:

https://www.php.net/manual/en/imagickpixel.getcolor.php

```php
ImagickPixel::getColor ([ int $normalized = 0 ] ) : array
```