### PR TITLE
[Sodium] Update parameter name

### DIFF
--- a/sodium/sodium.php
+++ b/sodium/sodium.php
@@ -456,7 +456,7 @@ function sodium_crypto_box_publickey_from_secretkey(string $secret_key): string 
  * @throws SodiumException
  * @since 7.2
  */
-function sodium_crypto_box_seal(string $message, string $key_pair): string {}
+function sodium_crypto_box_seal(string $message, string $key): string {}
 
 /**
  * Anonymous public-key encryption (decrypt)
@@ -468,7 +468,7 @@ function sodium_crypto_box_seal(string $message, string $key_pair): string {}
  * @throws SodiumException
  * @since 7.2
  */
-function sodium_crypto_box_seal_open(string $ciphertext, string $key_pair): string|false {}
+function sodium_crypto_box_seal_open(string $ciphertext, string $key): string|false {}
 
 /**
  * Extract the X25519 secret key from an X25519 keypair

--- a/sodium/sodium.php
+++ b/sodium/sodium.php
@@ -468,7 +468,7 @@ function sodium_crypto_box_seal(string $message, string $key): string {}
  * @throws SodiumException
  * @since 7.2
  */
-function sodium_crypto_box_seal_open(string $ciphertext, string $key): string|false {}
+function sodium_crypto_box_seal_open(string $ciphertext, string $key_pair): string|false {}
 
 /**
  * Extract the X25519 secret key from an X25519 keypair


### PR DESCRIPTION
`sodium_crypto_box_seal` takes a public key. 

```php
<?php

$keypair = sodium_crypto_box_keypair();
$publicKey = sodium_crypto_box_publickey($keypair);
$privateKey = sodium_crypto_box_secretkey($keypair);

$message = 'input';
$ciphertext = sodium_crypto_box_seal($message, $publicKey);
var_dump($publicKey);

$output = sodium_crypto_box_seal_open($ciphertext, $keypair);
var_dump($output);
````