### PR TITLE
Improve assertions

### DIFF
--- a/tests/StubsTest.php
+++ b/tests/StubsTest.php
@@ -133,7 +133,7 @@ class StubsTest extends TestCase
             PhpStormStubsSingleton::getPhpStormStubs()->getFunctions(), problemTypes:  StubProblemType::HAS_DUPLICATION
         );
         $duplicates = self::getDuplicatedFunctions($filtered);
-        self::assertEquals(0, sizeof($duplicates),
+        self::assertCount(0, $duplicates,
             "Functions \"" . implode(', ', $duplicates) .
             "\" have duplicates in stubs.\nPlease use #[LanguageLevelTypeAware] or #[PhpStormStubsElementAvailable] if possible"
         );

--- a/tests/StubsTypeHintsTest.php
+++ b/tests/StubsTypeHintsTest.php
@@ -159,7 +159,7 @@ class StubsTypeHintsTest extends TestCase
     public function testMethodDoesNotHaveUnionReturnTypeHint(PHPMethod $stubMethod)
     {
         $sinceVersion = Utils::getDeclaredSinceVersion($stubMethod);
-        self::assertFalse(str_contains($stubMethod->returnType, '|'),
+        self::assertStringNotContainsString('|', $stubMethod->returnType,
             "Method '{$stubMethod->parentName}::{$stubMethod->name}' has since version '$sinceVersion'
             but has union return typehint '$stubMethod->returnType' that supported only since PHP 8.0. 
             Please declare return type via PhpDoc");


### PR DESCRIPTION
# Changed log

- Using the `assertCount` to assert expected is same as result count.
- Using the `assertStringNotContainsString` to assert expected string is not contains specific string.