### PR TITLE
use versions range to search for duplicated functions

### DIFF
--- a/bcmath/bcmath.php
+++ b/bcmath/bcmath.php
@@ -87,7 +87,7 @@ function bcmul (string $num1, string $num2, ?int $scale = 0): string
  */
 #[Pure]
 #[LanguageLevelTypeAware(["8.0" => "string"], default: "?string")]
-#[PhpStormStubsElementAvailable(to: '8.0')]
+#[PhpStormStubsElementAvailable(to: '7.4')]
 function bcdiv (string $num1, string $num2, ?int $scale = 0)
 {}
 
@@ -135,7 +135,7 @@ function bcdiv (string $num1, string $num2, ?int $scale = 0)
  */
 #[Pure]
 #[LanguageLevelTypeAware(["8.0" => "string"], default: "?string")]
-#[PhpStormStubsElementAvailable(to: '8.0')]
+#[PhpStormStubsElementAvailable(to: '7.4')]
 function bcmod (string $num1, string $num2, ?int $scale = 0)
 {}
 

--- a/bcmath/bcmath.php
+++ b/bcmath/bcmath.php
@@ -208,6 +208,7 @@ function bcsqrt (string $num, ?int $scale)
  * @return int|bool
  */
 #[LanguageLevelTypeAware(['7.3'=>'int'], default: 'bool')]
+#[PhpStormStubsElementAvailable(to: '7.4')]
 function bcscale (int $scale)
 {}
 

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,7 @@
     "php": "^8.0",
     "nikic/php-parser": "@stable",
     "phpdocumentor/reflection-docblock": "@stable",
-    "phpunit/phpunit": "@stable",
-    "jetbrains/phpstorm-attributes": "@stable"
+    "phpunit/phpunit": "@stable"
   },
   "autoload": {
     "files": ["PhpStormStubsMap.php"]

--- a/tests/Model/BasePHPElement.php
+++ b/tests/Model/BasePHPElement.php
@@ -135,8 +135,8 @@ abstract class BasePHPElement
                         } else {
                             $rangeName = $attr->args[0]->name;
                             return $rangeName === null || $rangeName->name == 'from' ?
-                                ['from' => $arg->value, 'to' => '8.0'] :
-                                ['from' => '5.3', 'to' => $arg->value];
+                                ['from' => $arg->value, 'to' => (string)(new PhpVersions())->latestSupported] :
+                                ['from' => (string)(new PhpVersions())->firstSupported, 'to' => $arg->value];
                         }
                     }
                 }

--- a/tests/Model/PHPClass.php
+++ b/tests/Model/PHPClass.php
@@ -18,7 +18,7 @@ class PHPClass extends BasePHPClass
 
     /**
      * @param ReflectionClass $reflectionObject
-     * @return $this
+     * @return static
      */
     public function readObjectFromReflection($reflectionObject): static
     {
@@ -54,13 +54,13 @@ class PHPClass extends BasePHPClass
 
     /**
      * @param Class_ $node
-     * @return $this
+     * @return static
      */
     public function readObjectFromStubNode($node): static
     {
         $this->name = $this->getFQN($node);
         $this->isFinal = $node->isFinal();
-        $this->sinceVersionFromAttribute = self::findSinceVersionFromAttribute($node->attrGroups);
+        $this->availableVersionsRangeFromAttribute = self::findAvailableVersionsRangeFromAttribute($node->attrGroups);
         $this->collectTags($node);
         if (!empty($node->extends)) {
             $this->parentClass = '';

--- a/tests/Model/PHPConst.php
+++ b/tests/Model/PHPConst.php
@@ -20,7 +20,7 @@ class PHPConst extends BasePHPElement
 
     /**
      * @param ReflectionClassConstant $reflectionObject
-     * @return $this
+     * @return static
      */
     public function readObjectFromReflection($reflectionObject): static
     {
@@ -31,7 +31,7 @@ class PHPConst extends BasePHPElement
 
     /**
      * @param Const_ $node
-     * @return $this
+     * @return static
      */
     public function readObjectFromStubNode($node): static
     {
@@ -40,7 +40,7 @@ class PHPConst extends BasePHPElement
         $this->collectTags($node);
         $parentNode = $node->getAttribute('parent');
         if (property_exists($parentNode, 'attrGroups')) {
-            $this->sinceVersionFromAttribute = self::findSinceVersionFromAttribute($parentNode->attrGroups);
+            $this->availableVersionsRangeFromAttribute = self::findAvailableVersionsRangeFromAttribute($parentNode->attrGroups);
         }
         if ($parentNode instanceof ClassConst) {
             $this->parentName = $this->getFQN($parentNode->getAttribute('parent'));

--- a/tests/Model/PHPDefineConstant.php
+++ b/tests/Model/PHPDefineConstant.php
@@ -11,7 +11,7 @@ class PHPDefineConstant extends PHPConst
 {
     /**
      * @param array $reflectionObject
-     * @return $this
+     * @return static
      */
     public function readObjectFromReflection($reflectionObject): static
     {
@@ -37,7 +37,7 @@ class PHPDefineConstant extends PHPConst
 
     /**
      * @param FuncCall $node
-     * @return $this
+     * @return static
      */
     public function readObjectFromStubNode($node): static
     {

--- a/tests/Model/PHPFunction.php
+++ b/tests/Model/PHPFunction.php
@@ -30,7 +30,7 @@ class PHPFunction extends BasePHPElement
 
     /**
      * @param ReflectionFunction $reflectionObject
-     * @return $this
+     * @return static
      */
     public function readObjectFromReflection($reflectionObject): static
     {
@@ -45,14 +45,14 @@ class PHPFunction extends BasePHPElement
 
     /**
      * @param Function_ $node
-     * @return $this
+     * @return static
      */
     public function readObjectFromStubNode($node): static
     {
         $functionName = $this->getFQN($node);
         $this->name = $functionName;
         $typeFromAttribute = self::findTypeFromAttribute($node->attrGroups);
-        $this->sinceVersionFromAttribute = self::findSinceVersionFromAttribute($node->attrGroups);
+        $this->availableVersionsRangeFromAttribute = self::findAvailableVersionsRangeFromAttribute($node->attrGroups);
         if ($typeFromAttribute != null) {
             $this->returnType = $typeFromAttribute;
         } else {

--- a/tests/Model/PHPInterface.php
+++ b/tests/Model/PHPInterface.php
@@ -13,7 +13,7 @@ class PHPInterface extends BasePHPClass
 
     /**
      * @param ReflectionClass $reflectionObject
-     * @return $this
+     * @return static
      */
     public function readObjectFromReflection($reflectionObject): static
     {
@@ -36,13 +36,13 @@ class PHPInterface extends BasePHPClass
 
     /**
      * @param Interface_ $node
-     * @return $this
+     * @return static
      */
     public function readObjectFromStubNode($node): static
     {
         $this->name = $this->getFQN($node);
         $this->collectTags($node);
-        $this->sinceVersionFromAttribute = self::findSinceVersionFromAttribute($node->attrGroups);
+        $this->availableVersionsRangeFromAttribute = self::findAvailableVersionsRangeFromAttribute($node->attrGroups);
         if (!empty($node->extends)) {
             foreach ($node->extends as $extend) {
                 $this->parentInterfaces[] = implode('\\', $extend->parts);

--- a/tests/Model/PHPMethod.php
+++ b/tests/Model/PHPMethod.php
@@ -16,7 +16,7 @@ class PHPMethod extends PHPFunction
 
     /**
      * @param ReflectionMethod $reflectionObject
-     * @return $this
+     * @return static
      */
     public function readObjectFromReflection($reflectionObject): static
     {
@@ -40,13 +40,13 @@ class PHPMethod extends PHPFunction
 
     /**
      * @param ClassMethod $node
-     * @return $this
+     * @return static
      */
     public function readObjectFromStubNode($node): static
     {
         $this->parentName = $this->getFQN($node->getAttribute('parent'));
         $this->name = $node->name->name;
-        $this->sinceVersionFromAttribute = self::findSinceVersionFromAttribute($node->attrGroups);
+        $this->availableVersionsRangeFromAttribute = self::findAvailableVersionsRangeFromAttribute($node->attrGroups);
         $this->returnType = self::convertParsedTypeToString($node->getReturnType());
         $this->collectTags($node);
         $this->checkDeprecationTag($node);

--- a/tests/Model/PHPParameter.php
+++ b/tests/Model/PHPParameter.php
@@ -17,7 +17,7 @@ class PHPParameter extends BasePHPElement
 
     /**
      * @param ReflectionParameter $reflectionObject
-     * @return $this
+     * @return static
      */
     public function readObjectFromReflection($reflectionObject): static
     {
@@ -30,7 +30,7 @@ class PHPParameter extends BasePHPElement
 
     /**
      * @param Param $node
-     * @return $this
+     * @return static
      */
     public function readObjectFromStubNode($node): static
     {

--- a/tests/Model/PHPProperty.php
+++ b/tests/Model/PHPProperty.php
@@ -18,7 +18,7 @@ class PHPProperty extends BasePHPElement
 
     /**
      * @param ReflectionProperty $reflectionObject
-     * @return $this
+     * @return static
      */
     public function readObjectFromReflection($reflectionObject): static
     {
@@ -44,7 +44,7 @@ class PHPProperty extends BasePHPElement
 
     /**
      * @param Property $node
-     * @return $this
+     * @return static
      */
     public function readObjectFromStubNode($node): static
     {

--- a/tests/Model/PhpVersions.php
+++ b/tests/Model/PhpVersions.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+
+namespace StubTests\Model;
+
+use ArrayAccess;
+use ArrayIterator;
+use IteratorAggregate;
+use RuntimeException;
+
+/**
+ * @property-read $firstSupported
+ * @property-read $latestSupported
+ */
+class PhpVersions implements ArrayAccess, IteratorAggregate
+{
+    private array $versions = [5.3, 5.4, 5.5, 5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0];
+
+    public function __get(string $name)
+    {
+        return match ($name) {
+            'firstSupported' => $this->versions[0],
+            'latestSupported' => end($this->versions),
+            default => throw new RuntimeException('Incorrect php version')
+        };
+    }
+
+    public function offsetExists($offset): bool
+    {
+        return isset($this->versions[$offset]);
+    }
+
+    public function offsetGet($offset)
+    {
+        return $this->offsetExists($offset) ? $this->versions[$offset] : null;
+    }
+
+    public function offsetSet($offset, $value)
+    {
+        if (is_null($offset)) {
+            $this->versions[] = $value;
+        } else {
+            $this->versions[$offset] = $value;
+        }
+    }
+
+    public function offsetUnset($offset)
+    {
+        unset($this->versions[$offset]);
+    }
+
+    public function getIterator(): ArrayIterator
+    {
+        return new ArrayIterator($this->versions);
+    }
+}

--- a/tests/Parsers/Utils.php
+++ b/tests/Parsers/Utils.php
@@ -10,6 +10,7 @@ use RecursiveIteratorIterator;
 use StubTests\Model\BasePHPElement;
 use StubTests\Model\PHPConst;
 use StubTests\Model\PHPMethod;
+use StubTests\Model\PhpVersions;
 use StubTests\Model\Tags\RemovedTag;
 use StubTests\TestData\Providers\PhpStormStubsSingleton;
 
@@ -65,16 +66,16 @@ class Utils
 
     public static function getAvailableInVersions(BasePHPElement $element): array
     {
-        $versions = [5.3, 5.4, 5.5, 5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0];
         $firstSinceVersion = self::getDeclaredSinceVersion($element);
         if ($firstSinceVersion === null) {
-            $firstSinceVersion = 5.3;
+            $firstSinceVersion = (new PhpVersions())->firstSupported;
         }
         $lastAvailableVersion = self::getLatestAvailableVersion($element);
         if ($lastAvailableVersion === null) {
-            $lastAvailableVersion = 8.0;
+            $lastAvailableVersion = (new PhpVersions())->latestSupported;
         }
-        return array_filter($versions, fn($version) => $version >= (float)$firstSinceVersion && $version <= (float)$lastAvailableVersion);
+        return array_filter(iterator_to_array(new PhpVersions()), fn($version) =>
+            $version >= (float)$firstSinceVersion && $version <= (float)$lastAvailableVersion);
     }
 
     /**
@@ -150,7 +151,7 @@ class Utils
     {
         $latestAvailableVersions = [];
         if (!empty($element->availableVersionsRangeFromAttribute)) {
-            $latestAvailableVersions[] = (string)($element->availableVersionsRangeFromAttribute['to'] - 0.1);
+            $latestAvailableVersions[] = (string)($element->availableVersionsRangeFromAttribute['to']);
         }
         return $latestAvailableVersions;
     }


### PR DESCRIPTION
Find duplicated functions based on versions intersection like
```
#[PhpStormStubsElementAvailable(from: '7.1', to: '7.4')]
function bcmod (string $num1, string $num2, ?int $scale = 0)
{}
#[PhpStormStubsElementAvailable(from: '7.2', to: '8.0')]
function bcmod (string $num1, string $num2, ?int $scale = 0)
{}
```