### PR TITLE
Typehint mismatch in signature and phpdoc

### DIFF
--- a/Core/Core.php
+++ b/Core/Core.php
@@ -786,7 +786,7 @@ function get_defined_vars (): array
  * @removed 8.0
  */
 #[Deprecated(reason: "Use anonymous functions instead", since: "7.2")]
-function create_function (string $args, string $code): bool|string
+function create_function (string $args, string $code): false|string
 {}
 
 /**

--- a/mysqli/mysqli.php
+++ b/mysqli/mysqli.php
@@ -2658,7 +2658,7 @@ function mysqli_param_count (mysqli_stmt $statement): int
  * @removed 5.4
  */
 #[Deprecated(since: '5.3')]
-function mysqli_get_metadata (mysqli_stmt $statement): bool|mysqli_result
+function mysqli_get_metadata (mysqli_stmt $statement): false|mysqli_result
 {}
 
 /**

--- a/standard/standard_0.php
+++ b/standard/standard_0.php
@@ -832,7 +832,7 @@ function iptcparse (string $iptc_block): array|false
  * Spool flag. If the spool flag is over 2 then the JPEG will be
  * returned as a string.
  * </p>
- * @return string|false If success and spool flag is lower than 2 then the JPEG will not be
+ * @return string|bool If success and spool flag is lower than 2 then the JPEG will not be
  * returned as a string, false on errors.
  */
 function iptcembed (string $iptc_data, string $filename, int $spool): string|bool

--- a/standard/standard_4.php
+++ b/standard/standard_4.php
@@ -748,7 +748,7 @@ function headers_list (): array
  * @return array|false An associative array of all the HTTP headers in the current request, or <b>FALSE</b> on failure.
  */
 #[Pure]
-function apache_request_headers (): bool|array
+function apache_request_headers (): false|array
 {}
 
 /**
@@ -758,7 +758,7 @@ function apache_request_headers (): bool|array
  * @return array|false An associative array of all the HTTP headers in the current request, or <b>FALSE</b> on failure.
  */
 #[Pure]
-function getallheaders (): bool|array
+function getallheaders (): false|array
 {}
 
 /**

--- a/standard/standard_5.php
+++ b/standard/standard_5.php
@@ -1,9 +1,9 @@
 <?php
 
 use JetBrains\PhpStorm\Deprecated;
+use JetBrains\PhpStorm\ExpectedValues;
 use JetBrains\PhpStorm\Internal\LanguageLevelTypeAware;
 use JetBrains\PhpStorm\Pure;
-use JetBrains\PhpStorm\ExpectedValues;
 
 /**
  * (PHP 5.5.0)<br/>
@@ -552,7 +552,7 @@ function fgets ($stream, ?int $length): string|false
  * @removed 8.0
  */
 #[Deprecated(since: '7.3')]
-function fgetss ($handle, ?int $length = null, $allowable_tags = null): bool|string
+function fgetss ($handle, ?int $length = null, $allowable_tags = null): false|string
 {}
 
 /**

--- a/tests/Model/BasePHPElement.php
+++ b/tests/Model/BasePHPElement.php
@@ -109,9 +109,9 @@ abstract class BasePHPElement
 
     /**
      * @param AttributeGroup[] $attrGroups
-     * @return string|null
+     * @return string[]
      */
-    protected static function findTypeFromAttribute(array $attrGroups): ?string
+    protected static function findTypesFromAttribute(array $attrGroups): array
     {
         foreach ($attrGroups as $attrGroup) {
             foreach ($attrGroup->attrs as $attr) {
@@ -120,13 +120,13 @@ abstract class BasePHPElement
                     if ($arg instanceof Array_) {
                         $value = $arg->items[0]->value;
                         if ($value instanceof String_) {
-                            return $value->value;
+                            return explode('|', preg_replace('/\w+\[]/', 'array', $value->value));
                         }
                     }
                 }
             }
         }
-        return null;
+        return [];
     }
 
     /**

--- a/tests/Model/PHPClass.php
+++ b/tests/Model/PHPClass.php
@@ -58,7 +58,7 @@ class PHPClass extends BasePHPClass
      */
     public function readObjectFromStubNode($node): static
     {
-        $this->name = $this->getFQN($node);
+        $this->name = self::getFQN($node);
         $this->isFinal = $node->isFinal();
         $this->availableVersionsRangeFromAttribute = self::findAvailableVersionsRangeFromAttribute($node->attrGroups);
         $this->collectTags($node);

--- a/tests/Model/PHPConst.php
+++ b/tests/Model/PHPConst.php
@@ -43,7 +43,7 @@ class PHPConst extends BasePHPElement
             $this->availableVersionsRangeFromAttribute = self::findAvailableVersionsRangeFromAttribute($parentNode->attrGroups);
         }
         if ($parentNode instanceof ClassConst) {
-            $this->parentName = $this->getFQN($parentNode->getAttribute('parent'));
+            $this->parentName = self::getFQN($parentNode->getAttribute('parent'));
         }
         return $this;
     }

--- a/tests/Model/PHPFunction.php
+++ b/tests/Model/PHPFunction.php
@@ -24,8 +24,10 @@ class PHPFunction extends BasePHPElement
      */
     public array $parameters = [];
 
+    /** @var string[] $returnTypesFromPhpDoc  */
     public array $returnTypesFromPhpDoc = [];
 
+    /** @var string[] $returnTypesFromSignature  */
     public array $returnTypesFromSignature = [];
 
     /**
@@ -51,11 +53,10 @@ class PHPFunction extends BasePHPElement
     {
         $functionName = self::getFQN($node);
         $this->name = $functionName;
-        $typeFromAttribute = self::findTypeFromAttribute($node->attrGroups);
+        $typesFromAttribute = self::findTypesFromAttribute($node->attrGroups);
         $this->availableVersionsRangeFromAttribute = self::findAvailableVersionsRangeFromAttribute($node->attrGroups);
-        if ($typeFromAttribute != null) {
-            array_push($this->returnTypesFromSignature, ...array_map(fn(string $type) => preg_replace('/\w+\[]/', 'array', $type),
-                explode('|', $typeFromAttribute)));
+        if (!empty($typesFromAttribute)) {
+            array_push($this->returnTypesFromSignature, ...$typesFromAttribute);
         } else {
             array_push($this->returnTypesFromSignature, ...self::convertParsedTypeToArray($node->getReturnType()));
         }

--- a/tests/Model/PHPFunction.php
+++ b/tests/Model/PHPFunction.php
@@ -6,7 +6,7 @@ namespace StubTests\Model;
 use Exception;
 use JetBrains\PhpStorm\Deprecated;
 use phpDocumentor\Reflection\DocBlock\Tags\Return_;
-use phpDocumentor\Reflection\Type;
+use phpDocumentor\Reflection\Types\Compound;
 use PhpParser\Comment\Doc;
 use PhpParser\Node\FunctionLike;
 use PhpParser\Node\Stmt\Function_;
@@ -24,9 +24,9 @@ class PHPFunction extends BasePHPElement
      */
     public array $parameters = [];
 
-    public ?Type $returnTag = null;
+    public array $returnTypesFromPhpDoc = [];
 
-    public string $returnType = '';
+    public array $returnTypesFromSignature = [];
 
     /**
      * @param ReflectionFunction $reflectionObject
@@ -39,7 +39,7 @@ class PHPFunction extends BasePHPElement
         foreach ($reflectionObject->getParameters() as $parameter) {
             $this->parameters[] = (new PHPParameter())->readObjectFromReflection($parameter);
         }
-        $this->returnType = self::convertReflectionTypeToString($reflectionObject->getReturnType());
+        array_push($this->returnTypesFromSignature, ...self::getReflectionTypeAsArray($reflectionObject->getReturnType()));
         return $this;
     }
 
@@ -49,14 +49,15 @@ class PHPFunction extends BasePHPElement
      */
     public function readObjectFromStubNode($node): static
     {
-        $functionName = $this->getFQN($node);
+        $functionName = self::getFQN($node);
         $this->name = $functionName;
         $typeFromAttribute = self::findTypeFromAttribute($node->attrGroups);
         $this->availableVersionsRangeFromAttribute = self::findAvailableVersionsRangeFromAttribute($node->attrGroups);
         if ($typeFromAttribute != null) {
-            $this->returnType = $typeFromAttribute;
+            array_push($this->returnTypesFromSignature, ...array_map(fn(string $type) => preg_replace('/\w+\[]/', 'array', $type),
+                explode('|', $typeFromAttribute)));
         } else {
-            $this->returnType = self::convertParsedTypeToString($node->getReturnType());
+            array_push($this->returnTypesFromSignature, ...self::convertParsedTypeToArray($node->getReturnType()));
         }
 
         foreach ($node->getParams() as $parameter) {
@@ -86,7 +87,14 @@ class PHPFunction extends BasePHPElement
                 $phpDoc = DocFactoryProvider::getDocFactory()->create($node->getDocComment()->getText());
                 $parsedReturnTag = $phpDoc->getTagsByName('return');
                 if (!empty($parsedReturnTag) && $parsedReturnTag[0] instanceof Return_) {
-                    $this->returnTag = $parsedReturnTag[0]->getType();
+                    $returnType = $parsedReturnTag[0]->getType();
+                    if ($returnType instanceof Compound) {
+                        foreach ($returnType as $nextType) {
+                            array_push($this->returnTypesFromPhpDoc, (string)$nextType);
+                        }
+                    } else {
+                        array_push($this->returnTypesFromPhpDoc, (string)$returnType);
+                    }
                 }
             } catch (Exception $e) {
                 $this->parseError = $e;
@@ -107,6 +115,7 @@ class PHPFunction extends BasePHPElement
                             'absent in meta' => StubProblemType::ABSENT_IN_META,
                             'has return typehint' => StubProblemType::FUNCTION_HAS_RETURN_TYPEHINT,
                             'has duplicate in stubs' => StubProblemType::HAS_DUPLICATION,
+                            'has type mismatch in signature and phpdoc' => StubProblemType::TYPE_IN_PHPDOC_DIFFERS_FROM_SIGNATURE,
                             default => -1
                         };
                     }

--- a/tests/Model/PHPInterface.php
+++ b/tests/Model/PHPInterface.php
@@ -40,7 +40,7 @@ class PHPInterface extends BasePHPClass
      */
     public function readObjectFromStubNode($node): static
     {
-        $this->name = $this->getFQN($node);
+        $this->name = self::getFQN($node);
         $this->collectTags($node);
         $this->availableVersionsRangeFromAttribute = self::findAvailableVersionsRangeFromAttribute($node->attrGroups);
         if (!empty($node->extends)) {

--- a/tests/Model/PHPMethod.php
+++ b/tests/Model/PHPMethod.php
@@ -46,11 +46,10 @@ class PHPMethod extends PHPFunction
     {
         $this->parentName = self::getFQN($node->getAttribute('parent'));
         $this->name = $node->name->name;
-        $typeFromAttribute = self::findTypeFromAttribute($node->attrGroups);
+        $typesFromAttribute = self::findTypesFromAttribute($node->attrGroups);
         $this->availableVersionsRangeFromAttribute = self::findAvailableVersionsRangeFromAttribute($node->attrGroups);
-        if ($typeFromAttribute != null) {
-            array_push($this->returnTypesFromSignature, ...array_map(fn(string $type) => preg_replace('/\w+\[]/', 'array', $type),
-                explode('|', $typeFromAttribute)));
+        if (!empty($typesFromAttribute)) {
+            array_push($this->returnTypesFromSignature, ...$typesFromAttribute);
         } else {
             array_push($this->returnTypesFromSignature, ...self::convertParsedTypeToArray($node->getReturnType()));
         }

--- a/tests/Model/PHPParameter.php
+++ b/tests/Model/PHPParameter.php
@@ -10,6 +10,7 @@ use stdClass;
 
 class PHPParameter extends BasePHPElement
 {
+    /** @var string[] $types  */
     public array $types = [];
     public bool $is_vararg = false;
     public bool $is_passed_by_ref = false;
@@ -36,10 +37,9 @@ class PHPParameter extends BasePHPElement
     {
         $this->name = $node->var->name;
 
-        $typeFromAttribute = self::findTypeFromAttribute($node->attrGroups);
-        if ($typeFromAttribute != null) {
-            array_push($this->types, ...array_map(fn(string $type) => preg_replace('/\w+\[]/', 'array', $type),
-                explode('|', $typeFromAttribute)));
+        $typesFromAttribute = self::findTypesFromAttribute($node->attrGroups);
+        if (!empty($typesFromAttribute)) {
+            array_push($this->types, ...$typesFromAttribute);
         } else {
             $this->types = self::convertParsedTypeToArray($node->type);
         }

--- a/tests/Model/PHPProperty.php
+++ b/tests/Model/PHPProperty.php
@@ -64,7 +64,7 @@ class PHPProperty extends BasePHPElement
 
         $parentNode = $node->getAttribute('parent');
         if ($parentNode !== null){
-            $this->parentName = $this->getFQN($parentNode);
+            $this->parentName = self::getFQN($parentNode);
         }
         return $this;
     }

--- a/tests/Model/StubProblemType.php
+++ b/tests/Model/StubProblemType.php
@@ -27,4 +27,5 @@ interface StubProblemType
     public const HAS_NULLABLE_TYPEHINT = 19;
     public const HAS_UNION_TYPEHINT = 20;
     public const HAS_DUPLICATION = 21;
+    public const TYPE_IN_PHPDOC_DIFFERS_FROM_SIGNATURE = 22;
 }

--- a/tests/Parsers/Utils.php
+++ b/tests/Parsers/Utils.php
@@ -35,7 +35,7 @@ class Utils
         $allSinceVersions = self::getSinceVersionsFromPhpDoc($element);
         $allSinceVersions[] = self::getSinceVersionsFromAttribute($element);
         if ($element instanceof PHPMethod) {
-            if ($element->hasInheritDocTag || $element->parentName === '___PHPSTORM_HELPERS\object') {
+            if ($element->hasInheritDocTag) {
                 return null;
             }
             $allSinceVersions[] = self::getSinceVersionsFromParentClass($element);
@@ -52,7 +52,7 @@ class Utils
         $latestVersions = self::getRemovedVersionsFromPhpDoc($element);
         $latestVersions[] = self::getLatestAvailableVersionsFromAttribute($element);
         if ($element instanceof PHPMethod) {
-            if ($element->hasInheritDocTag || $element->parentName === '___PHPSTORM_HELPERS\object') {
+            if ($element->hasInheritDocTag) {
                 return null;
             }
             $latestVersions[] = self::getLatestAvailableVersionsFromParentClass($element);

--- a/tests/StubsPhpDocTest.php
+++ b/tests/StubsPhpDocTest.php
@@ -60,13 +60,13 @@ class StubsPhpDocTest extends TestCase
     /**
      * @dataProvider \StubTests\TestData\Providers\Stubs\StubMethodsProvider::allMethodsProvider
      */
-    public function testMethodsPHPDocs(string $methodName, PHPMethod $method): void
+    public function testMethodsPHPDocs(PHPMethod $method): void
     {
-        if ($methodName === '__construct') {
-            self::assertNull($method->returnTag, '@return tag for __construct should be omitted');
+        if ($method->name === '__construct') {
+            self::assertEmpty($method->returnTypesFromPhpDoc, '@return tag for __construct should be omitted');
         }
         self::assertNull($method->parseError, $method->parseError ?: '');
-        self::checkPHPDocCorrectness($method, "method $methodName");
+        self::checkPHPDocCorrectness($method, "method $method->name");
     }
 
     private static function checkDeprecatedRemovedSinceVersionsMajor(BasePHPElement $element, string $elementName): void

--- a/tests/StubsTest.php
+++ b/tests/StubsTest.php
@@ -350,8 +350,8 @@ class StubsTest extends TestCase
     {
         $result = '';
         foreach ($function->parameters as $parameter) {
-            if (!empty($parameter->type)) {
-                $result .= $parameter->type . ' ';
+            if (!empty($parameter->types)) {
+                $result .= implode('|', $parameter->types);
             }
             if ($parameter->is_passed_by_ref) {
                 $result .= '&';

--- a/tests/TestData/mutedProblems.json
+++ b/tests/TestData/mutedProblems.json
@@ -1271,6 +1271,12 @@
           ]
         }
       ]
+    },
+    {
+      "name": "parallel\\run",
+      "problems": [
+        "has type mismatch in signature and phpdoc"
+      ]
     }
   ],
   "classes": [

--- a/xdebug/xdebug.php
+++ b/xdebug/xdebug.php
@@ -170,7 +170,7 @@ function xdebug_stop_error_collection () {}
  * By default this function will not clear the error collection buffer. If you pass true as argument to this function then the buffer will be cleared as well.
  * This function returns a string containing all collected errors formatted as an "Xdebug table".
  * @param bool $emptyList
- * @return string
+ * @return array
  */
 function xdebug_get_collected_errors(bool $emptyList = false): array {}
 


### PR DESCRIPTION
Typehints are not being stored in arrays instead of a single string. Related tests are updated to use arrays.