### PR TITLE
Fixed ReflectionType::__toString()

### DIFF
--- a/Reflection/ReflectionType.php
+++ b/Reflection/ReflectionType.php
@@ -42,9 +42,9 @@ abstract class ReflectionType implements Stringable
      * @link https://php.net/manual/en/reflectiontype.tostring.php
      * @return string Returns the type of the parameter.
      * @since 7.0
-     * @see ReflectionType::getName()
+     * @see ReflectionNamedType::getName()
      */
-    #[Deprecated(replacement: "%class$->getName()", since: "7.1")]
+    #[Deprecated(since: "7.1")]
     public function __toString()
     {
     }


### PR DESCRIPTION
There's no `getName()` method in the `ReflectionType` abstract class, this is really misleading. It is only available in one of the subclasses, in the `ReflectionNamedType`. `ReflectionUnionType`, on the contrary, does not have this method.

Also there's no clear replacement. In case of `ReflectionUnionType` developer has to iterate over `$union->getTypes()` recursively.

See https://www.php.net/manual/ru/class.reflectiontype.php