### PR TITLE
Use a modern return type for ReflectionFunctionAbstract::getReturnType()

### DIFF
--- a/Reflection/ReflectionFunctionAbstract.php
+++ b/Reflection/ReflectionFunctionAbstract.php
@@ -1,6 +1,7 @@
 <?php
 
 use JetBrains\PhpStorm\Immutable;
+use JetBrains\PhpStorm\Internal\LanguageLevelTypeAware;
 use JetBrains\PhpStorm\Pure;
 
 /**
@@ -247,11 +248,12 @@ abstract class ReflectionFunctionAbstract implements Reflector
      * Gets the specified return type of a function
      *
      * @link https://php.net/manual/en/reflectionfunctionabstract.getreturntype.php
-     * @return ReflectionNamedType|null Returns a {@see ReflectionNamedType} object if a
+     * @return ReflectionType|ReflectionNamedType|null Returns a {@see ReflectionType} object if a
      * return type is specified, {@see null} otherwise.
-     * @since 7.1
+     * @since 7.0
      */
     #[Pure]
+    #[LanguageLevelTypeAware(['7.1' => 'ReflectionNamedType|null'], default: 'ReflectionType|null')]
 	public function getReturnType()
     {
     }

--- a/Reflection/ReflectionFunctionAbstract.php
+++ b/Reflection/ReflectionFunctionAbstract.php
@@ -247,9 +247,9 @@ abstract class ReflectionFunctionAbstract implements Reflector
      * Gets the specified return type of a function
      *
      * @link https://php.net/manual/en/reflectionfunctionabstract.getreturntype.php
-     * @return ReflectionType|null Returns a {@see ReflectionType} object if a
+     * @return ReflectionNamedType|null Returns a {@see ReflectionNamedType} object if a
      * return type is specified, {@see null} otherwise.
-     * @since 7.0
+     * @since 7.1
      */
     #[Pure]
 	public function getReturnType()

--- a/Reflection/ReflectionFunctionAbstract.php
+++ b/Reflection/ReflectionFunctionAbstract.php
@@ -248,12 +248,12 @@ abstract class ReflectionFunctionAbstract implements Reflector
      * Gets the specified return type of a function
      *
      * @link https://php.net/manual/en/reflectionfunctionabstract.getreturntype.php
-     * @return ReflectionType|ReflectionNamedType|null Returns a {@see ReflectionType} object if a
+     * @return ReflectionType|null Returns a {@see ReflectionType} object if a
      * return type is specified, {@see null} otherwise.
      * @since 7.0
      */
     #[Pure]
-    #[LanguageLevelTypeAware(['7.1' => 'ReflectionNamedType|null'], default: 'ReflectionType|null')]
+    #[LanguageLevelTypeAware(['7.1' => 'ReflectionNamedType|null', '8.0' => 'ReflectionNamedType|ReflectionUnionType|null'], default: 'ReflectionType|null')]
 	public function getReturnType()
     {
     }

--- a/Reflection/ReflectionParameter.php
+++ b/Reflection/ReflectionParameter.php
@@ -144,11 +144,12 @@ class ReflectionParameter implements Reflector
      * Gets a parameter's type
      *
      * @link https://php.net/manual/en/reflectionparameter.gettype.php
-     * @return ReflectionType|null Returns a {@see ReflectionType} object if a
+     * @return ReflectionType|ReflectionNamedType|null Returns a {@see ReflectionType} object if a
      * parameter type is specified, {@see null} otherwise.
      * @since 7.0
      */
     #[Pure]
+    #[LanguageLevelTypeAware(['7.1' => 'ReflectionNamedType|null'], default: 'ReflectionType|null')]
 	public function getType()
     {
     }

--- a/Reflection/ReflectionParameter.php
+++ b/Reflection/ReflectionParameter.php
@@ -144,12 +144,12 @@ class ReflectionParameter implements Reflector
      * Gets a parameter's type
      *
      * @link https://php.net/manual/en/reflectionparameter.gettype.php
-     * @return ReflectionType|ReflectionNamedType|null Returns a {@see ReflectionType} object if a
+     * @return ReflectionType|null Returns a {@see ReflectionType} object if a
      * parameter type is specified, {@see null} otherwise.
      * @since 7.0
      */
     #[Pure]
-    #[LanguageLevelTypeAware(['7.1' => 'ReflectionNamedType|null'], default: 'ReflectionType|null')]
+    #[LanguageLevelTypeAware(['7.1' => 'ReflectionNamedType|null', '8.0' => 'ReflectionNamedType|ReflectionUnionType|null'], default: 'ReflectionType|null')]
 	public function getType()
     {
     }

--- a/Reflection/ReflectionParameter.php
+++ b/Reflection/ReflectionParameter.php
@@ -2,6 +2,7 @@
 
 use JetBrains\PhpStorm\Deprecated;
 use JetBrains\PhpStorm\Immutable;
+use JetBrains\PhpStorm\Internal\LanguageLevelTypeAware;
 use JetBrains\PhpStorm\Pure;
 
 /**

--- a/Reflection/ReflectionProperty.php
+++ b/Reflection/ReflectionProperty.php
@@ -236,7 +236,7 @@ class ReflectionProperty implements Reflector
      * Gets property type
      *
      * @link https://php.net/manual/en/reflectionproperty.gettype.php
-     * @return ReflectionType|null Returns a {@see ReflectionType} if the
+     * @return ReflectionNamedType|null Returns a {@see ReflectionNamedType} if the
      * property has a type, and {@see null} otherwise.
      * @since 7.4
      */

--- a/Reflection/ReflectionProperty.php
+++ b/Reflection/ReflectionProperty.php
@@ -236,11 +236,12 @@ class ReflectionProperty implements Reflector
      * Gets property type
      *
      * @link https://php.net/manual/en/reflectionproperty.gettype.php
-     * @return ReflectionNamedType|null Returns a {@see ReflectionNamedType} if the
+     * @return ReflectionNamedType|ReflectionUnionType|null Returns a {@see ReflectionType} if the
      * property has a type, and {@see null} otherwise.
      * @since 7.4
      */
     #[Pure]
+    #[LanguageLevelTypeAware(['8.0' => 'ReflectionNamedType|ReflectionUnionType|null'], default: 'ReflectionNamedType|null')]
 	public function getType()
     {
     }

--- a/Reflection/ReflectionProperty.php
+++ b/Reflection/ReflectionProperty.php
@@ -2,6 +2,7 @@
 
 use JetBrains\PhpStorm\Deprecated;
 use JetBrains\PhpStorm\Immutable;
+use JetBrains\PhpStorm\Internal\LanguageLevelTypeAware;
 use JetBrains\PhpStorm\Pure;
 
 /**


### PR DESCRIPTION
ReflectionFunctionAbstract::getReturnType() added to PHP7.0

As for PHP7.0, it returns ReflectionType
As for PHP7.1+, it returns ReflectionNamedType


Technically, existing stub is valid, because class ReflectionNamedType extends ReflectionType, but when you use `ReflectionFunctionAbstract::getReturnType()->getName()` it’s wrong on PHP7.0 and leads to Fatal error: `Uncaught Error: Call to undefined method ReflectionType::getName()`.

As alternative, we can use `@return ReflectionType|ReflectionNamedType|null`



@see https://3v4l.org/Q8aDT


related PR on psalm repo: https://github.com/vimeo/psalm/pull/5204