### PR TITLE
store types from attribute to separate array

### DIFF
--- a/tests/Model/BasePHPElement.php
+++ b/tests/Model/BasePHPElement.php
@@ -116,13 +116,13 @@ abstract class BasePHPElement
         foreach ($attrGroups as $attrGroup) {
             foreach ($attrGroup->attrs as $attr) {
                 if ($attr->name->toString() === LanguageLevelTypeAware::class) {
-                    $arg = $attr->args[0]->value;
-                    if ($arg instanceof Array_) {
-                        $value = $arg->items[0]->value;
-                        if ($value instanceof String_) {
-                            return explode('|', preg_replace('/\w+\[]/', 'array', $value->value));
-                        }
+                    $types = [];
+                    $versionTypesMap = $attr->args[0]->value->items;
+                    foreach ($versionTypesMap as $item) {
+                        $types[$item->key->value] = explode('|', preg_replace('/\w+\[]/', 'array', $item->value->value));
                     }
+                    $types[$attr->args[1]->name->name] = explode('|', preg_replace('/\w+\[]/', 'array', $attr->args[1]->value->value));
+                    return $types;
                 }
             }
         }

--- a/tests/Model/PHPFunction.php
+++ b/tests/Model/PHPFunction.php
@@ -28,6 +28,9 @@ class PHPFunction extends BasePHPElement
     /** @var string[] $returnTypesFromPhpDoc  */
     public array $returnTypesFromPhpDoc = [];
 
+    /** @var string[] $returnTypesFromAttribute  */
+    public array $returnTypesFromAttribute = [];
+
     /** @var string[] $returnTypesFromSignature  */
     public array $returnTypesFromSignature = [];
 
@@ -56,12 +59,8 @@ class PHPFunction extends BasePHPElement
         $this->name = $functionName;
         $typesFromAttribute = self::findTypesFromAttribute($node->attrGroups);
         $this->availableVersionsRangeFromAttribute = self::findAvailableVersionsRangeFromAttribute($node->attrGroups);
-        if (!empty($typesFromAttribute)) {
-            array_push($this->returnTypesFromSignature, ...$typesFromAttribute);
-        } else {
-            array_push($this->returnTypesFromSignature, ...self::convertParsedTypeToArray($node->getReturnType()));
-        }
-
+        $this->returnTypesFromAttribute = $typesFromAttribute;
+        array_push($this->returnTypesFromSignature, ...self::convertParsedTypeToArray($node->getReturnType()));
         foreach ($node->getParams() as $parameter) {
             $this->parameters[] = (new PHPParameter())->readObjectFromStubNode($parameter);
         }

--- a/tests/Model/PHPMethod.php
+++ b/tests/Model/PHPMethod.php
@@ -49,11 +49,8 @@ class PHPMethod extends PHPFunction
         $this->name = $node->name->name;
         $typesFromAttribute = self::findTypesFromAttribute($node->attrGroups);
         $this->availableVersionsRangeFromAttribute = self::findAvailableVersionsRangeFromAttribute($node->attrGroups);
-        if (!empty($typesFromAttribute)) {
-            array_push($this->returnTypesFromSignature, ...$typesFromAttribute);
-        } else {
-            array_push($this->returnTypesFromSignature, ...self::convertParsedTypeToArray($node->getReturnType()));
-        }
+        $this->returnTypesFromAttribute = $typesFromAttribute;
+        array_push($this->returnTypesFromSignature, ...self::convertParsedTypeToArray($node->getReturnType()));
         $this->collectTags($node);
         $this->checkDeprecationTag($node);
         $this->checkReturnTag($node);
@@ -69,7 +66,7 @@ class PHPMethod extends PHPFunction
             $relatedParamTags = array_filter($this->paramTags, fn(Param $tag) => $tag->getVariableName() === $parameter->name);
             /** @var Param $relatedParamTag */
             $relatedParamTag = array_pop($relatedParamTags);
-            if (!empty($relatedParamTag)){
+            if (!empty($relatedParamTag)) {
                 $parameter->isOptional = $parameter->isOptional || str_contains((string)$relatedParamTag->getDescription(), '[optional]');
             }
         }

--- a/tests/StubsTest.php
+++ b/tests/StubsTest.php
@@ -460,13 +460,13 @@ class StubsTest extends TestCase
         /** @var PHPParameter $arrayParameter */
         $arrayParameter = array_pop($arrayParameters);
         self::assertCount(2, $implodeParameters);
-        self::assertEquals(['array', 'string'], $separatorParameter->types);
+        self::assertEquals(['array', 'string'], $separatorParameter->typesFromSignature);
         if (property_exists($separatorParameter->defaultValue, 'value')) {
             self::assertEquals('', $separatorParameter->defaultValue->value);
         } else {
             self::fail("Couldn't read default value");
         }
-        self::assertEquals(['?array'], $arrayParameter->types);
+        self::assertEquals(['?array'], $arrayParameter->typesFromSignature);
         self::assertEquals(['string'], $implodeFunction->returnTypesFromSignature);
         self::assertEquals(['string'], $implodeFunction->returnTypesFromPhpDoc);
     }


### PR DESCRIPTION
Store types from LanguageLevelTypeAware attribute to separate array and update tests accordingly. Compare typehints from reflection with signature and if it doesn't match try to find the same typehints in attribute