### PR TITLE
Add missing type hint to XSL transformToXml

### DIFF
--- a/xsl/xsl.php
+++ b/xsl/xsl.php
@@ -47,7 +47,7 @@ class XSLTProcessor  {
 	 * @param DOMDocument|SimpleXMLElement $doc <p>
 	 * The transformed document.
 	 * </p>
-	 * @return string|false The result of the transformation as a string or <b>FALSE</b> on error.
+	 * @return string|false|null The result of the transformation as a string or <b>FALSE</b> on error.
 	 */
 	public function transformToXml ($doc) {}
 


### PR DESCRIPTION
`transformToXml` can return null. (See [documentation](https://www.php.net/manual/en/xsltprocessor.transformtoxml.php))

This example should return null.

```php
$stylesheet = new \DOMDocument();
$stylesheet->loadXML('<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"></xsl:stylesheet>');
$processor = new \XSLTProcessor();
$document = new \DOMDocument();
$document->loadXML('<root></root>');
$processor->importStylesheet($stylesheet);
$result = $processor->transformToXml($document);
```

I have fixed the type hint in this PR.