### PR TITLE
add missing type name in var tag for pq

### DIFF
--- a/pq/pq.php
+++ b/pq/pq.php
@@ -241,7 +241,7 @@ class Connection  {
 	 *
 	 * @public
 	 * @readonly
-	 * @var
+	 * @var resource
 	 */
 	public $socket;
 	/**
@@ -1030,7 +1030,7 @@ class LOB  {
 	 *
 	 * @public
 	 * @readonly
-	 * @var
+	 * @var resource
 	 */
 	public $stream;
 	/**


### PR DESCRIPTION
Stub for pq was missing `resource` types in two `@var` tags
@see https://github.com/m6w6/ext-pq/issues/39