### PR TITLE
Remove Pure attribute on realpath

### DIFF
--- a/standard/standard_6.php
+++ b/standard/standard_6.php
@@ -1137,7 +1137,7 @@ function socket_get_status($stream): array {}
  * the file does not exist.
  * </p>
  */
-#[Pure]
+#[Pure(true)]
 function realpath(string $path): string|false {}
 
 /**


### PR DESCRIPTION
This function depends on side-effects, as can be demonstrated with this minimal test case:

```php
var_dump(realpath('foo')); // bool(false)
mkdir('foo');
var_dump(realpath('foo')); // string(8) "/tmp/dir"
```

https://youtrack.jetbrains.com/issue/WI-59567