### PR TITLE
Delete removed annotations from DateTime constants

### DIFF
--- a/date/date_c.php
+++ b/date/date_c.php
@@ -377,69 +377,18 @@ class DateTimeImmutable implements DateTimeInterface
  */
 class DateTime implements DateTimeInterface
 {
-    /**
-     * @removed 7.2
-     */
     public const ATOM = 'Y-m-d\TH:i:sP';
-
-    /**
-     * @removed 7.2
-     */
     public const COOKIE = 'l, d-M-Y H:i:s T';
-
-    /**
-     * @removed 7.2
-     */
     public const ISO8601 = 'Y-m-d\TH:i:sO';
-
-    /**
-     * @removed 7.2
-     */
     public const RFC822 = 'D, d M y H:i:s O';
-
-    /**
-     * @removed 7.2
-     */
     public const RFC850 = 'l, d-M-y H:i:s T';
-
-    /**
-     * @removed 7.2
-     */
     public const RFC1036 = 'D, d M y H:i:s O';
-
-    /**
-     * @removed 7.2
-     */
     public const RFC1123 = 'D, d M Y H:i:s O';
-
-    /**
-     * @removed 7.2
-     */
     public const RFC2822 = 'D, d M Y H:i:s O';
-
-    /**
-     * @removed 7.2
-     */
     public const RFC3339 = 'Y-m-d\TH:i:sP';
-
-    /**
-     * @removed 7.2
-     */
     public const RFC3339_EXTENDED = 'Y-m-d\TH:i:s.vP';
-
-    /**
-     * @removed 7.2
-     */
     public const RFC7231 = 'D, d M Y H:i:s \G\M\T';
-
-    /**
-     * @removed 7.2
-     */
     public const RSS = 'D, d M Y H:i:s O';
-
-    /**
-     * @removed 7.2
-     */
     public const W3C = 'Y-m-d\TH:i:sP';
 
     /**


### PR DESCRIPTION
PhpStorm marks code using these constants as broken as they have been removed. But they can still be used as they are inherited from the DateTimeInterface.
In theory we could remove the constants from DateTime completely. But the interface constants have `since 7.2` which would also be wrong for DateTime constants.
So I think this is the best solution.

Ref. #951