### PR TITLE
phpdoc blocks fixes

### DIFF
--- a/Ev/Ev.php
+++ b/Ev/Ev.php
@@ -811,6 +811,8 @@ final class EvPeriodic extends EvWatcher
      * Simply stops and restarts the periodic watcher again.
      *
      * Simply stops and restarts the periodic watcher again. This is only useful when attributes are changed.
+     *
+     * @return void
      */
     public function again() {}
 
@@ -852,6 +854,7 @@ final class EvPeriodic extends EvWatcher
      * Configures the watcher
      * @param float $offset The same meaning as for {@see EvPeriodic::__construct}
      * @param float $interval The same meaning as for {@see EvPeriodic::__construct}
+     * @param null|callable $reschedule_cb The same meaning as for {@see EvPeriodic::__construct}
      * @return void
      */
     public function set($offset, $interval, $reschedule_cb = null) {}
@@ -1409,6 +1412,7 @@ final class EvLoop
      *
      * @param float $offset
      * @param float $interval
+     * @param callable $reschedule_cb
      * @param callable $callback
      * @param mixed $data
      * @param int $priority

--- a/curl/curl_d.php
+++ b/curl/curl_d.php
@@ -511,7 +511,7 @@ define('CURL_SSLVERSION_TLSv1_2', 6);
  * If it hasn't been modified, a "304 Not Modified" header will be returned assuming <b>CURLOPT_HEADER</b> is <b>TRUE</b>.
  * Use <b>CURL_TIMECOND_IFUNMODSINCE</b> for the reverse effect.
  * <b>CURL_TIMECOND_IFMODSINCE</b> is the default.
- * * @link https://www.php.net/manual/en/function.curl-setopt.php
+ * @link https://www.php.net/manual/en/function.curl-setopt.php
  */
 define('CURLOPT_TIMECONDITION', 33);
 /**

--- a/gnupg/gnupg.php
+++ b/gnupg/gnupg.php
@@ -50,7 +50,7 @@ class gnupg
      * Verifies a signed text
      * @link https://php.net/manual/en/function.gnupg-verify.php
      *
-     * * @param string $signed_text
+     * @param string $signed_text
      * @param string $signature
      * @param string &$plaintext
      *

--- a/intl/IntlChar.php
+++ b/intl/IntlChar.php
@@ -858,7 +858,7 @@ class IntlChar
      * @link https://php.net/manual/en/intlchar.enumcharnames.php
      * @param int|string $start The first code point in the enumeration range.
      * @param int|string $end One more than the last code point in the enumeration range (the first one after the range).
-     * @param callable $callback<p>
+     * @param callable $callback <p>
      * The function that is to be called for each character name.  The following three arguments will be passed into it:
      * </p><ul>
      * <li>integer <em>$codepoint</em> - The numeric code point value</li>

--- a/libvirt-php/libvirt-php.php
+++ b/libvirt-php/libvirt-php.php
@@ -415,7 +415,7 @@ function libvirt_connect_get_soundhw_models($conn, ?string $arch, int $flags = 0
 /**
  * Function is used to get the system information from connection if available
  * @param resource $conn resource for connection
- * @return string|false: XML description of system information from the connection or FALSE for error
+ * @return string|false XML description of system information from the connection or FALSE for error
  * @since 0.4.1(-2)
  */
 function libvirt_connect_get_sysinfo($conn): string|false {}
@@ -947,7 +947,7 @@ function libvirt_domain_new($conn, string $name, string|null|false $arch, int $m
 
 /**
  * Function is used to get the VNC server location for the newly created domain (newly started installation)
- * @return string|null: a VNC server for a newly created domain resource (if any)
+ * @return string|null a VNC server for a newly created domain resource (if any)
  * @since 0.4.5
  */
 function libvirt_domain_new_get_vnc(): string|null {}

--- a/mongo/mongo.php
+++ b/mongo/mongo.php
@@ -813,7 +813,7 @@ class MongoDB
      * @link https://php.net/manual/en/mongodb.setwriteconcern.php
      * Set the write concern for this database
      * @param mixed $w <p>The write concern. This may be an integer denoting the number of servers required to acknowledge the write, or a string mode (e.g. "majority").</p>
-     * @param int $wtimeout[optional] <p>The maximum number of milliseconds to wait for the server to satisfy the write concern.</p>
+     * @param int $wtimeout [optional] <p>The maximum number of milliseconds to wait for the server to satisfy the write concern.</p>
      * @return bool Returns <b>TRUE</b> on success, or <b>FALSE</b> otherwise.
      */
     public function setWriteConcern($w, $wtimeout) {}

--- a/oci8/oci8.php
+++ b/oci8/oci8.php
@@ -1954,9 +1954,9 @@ function ocilogoff($connection_resource) {}
  * @link https://php.net/manual/en/function.ocilogon.php
  * @param string $username
  * @param string $password
- * @param string $connection_string[optional]
- * @param string $character_set[optional]
- * @param int $session_mode[optional]
+ * @param string $connection_string [optional]
+ * @param string $character_set [optional]
+ * @param int $session_mode [optional]
  * @return resource|false Returns a connection identifier or FALSE on error.
  */
 function ocilogon($username, $password, $connection_string, $character_set, $session_mode) {}

--- a/pdflib/PDFlib.php
+++ b/pdflib/PDFlib.php
@@ -838,16 +838,12 @@ class PDFlib
      */
     public function get_errnum() {}
     /**
-     * @param void $
-     *
      * @return int
      *
      * @link https://secure.php.net/manual/en/function.pdf-get-majorversion.php(dep)
      */
     public function get_majorversion() {}
     /**
-     * @param void $
-     *
      * @return int
      *
      * @link https://secure.php.net/manual/en/function.pdf-get-minorversion.php(dep)
@@ -1638,7 +1634,7 @@ class PDFlib
 
 /**
  * Activates a previously created structure element or other content item.
- * @param resource $pdfdoc
+ * @param resource $pdf The pDF doc
  * @param int $id
  *
  * @return bool
@@ -2385,7 +2381,7 @@ function PDF_end_layer($pdf) {}
 function PDF_end_page_ext($pdf, $optlist) {}
 
 /**
- * @param resource $pdf
+ * @param resource $p The PDF doc
  *
  * @return bool
  *
@@ -2394,7 +2390,7 @@ function PDF_end_page_ext($pdf, $optlist) {}
 function PDF_end_page($p) {}
 
 /**
- * @param resource $pdf
+ * @param resource $p The PDF doc
  *
  * @return bool
  *
@@ -2403,7 +2399,7 @@ function PDF_end_page($p) {}
 function PDF_end_pattern($p) {}
 
 /**
- * @param resource $pdf
+ * @param resource $p The PDF doc
  *
  * @return bool
  *
@@ -2412,7 +2408,7 @@ function PDF_end_pattern($p) {}
 function PDF_end_template($p) {}
 
 /**
- * @param resource $pdf
+ * @param resource $p The PDF doc
  *
  * @return bool
  *
@@ -2584,16 +2580,12 @@ function PDF_get_errmsg($pdf) {}
  */
 function PDF_get_errnum($pdf) {}
 /**
- * @param void $
- *
  * @return int
  *
  * @link https://secure.php.net/manual/en/function.pdf-get-majorversion.php(dep)
  */
 function PDF_get_majorversion() {}
 /**
- * @param void $
- *
  * @return int
  *
  * @link https://secure.php.net/manual/en/function.pdf-get-minorversion.php(dep)
@@ -2980,7 +2972,7 @@ function PDF_process_pdi($pdf, $doc, $page, $optlist) {}
 function PDF_rect($pdf, $x, $y, $width, $height) {}
 
 /**
- * @param resource $pdf
+ * @param resource $p The PDF doc
  *
  * @return bool
  *
@@ -3009,7 +3001,7 @@ function PDF_resume_page($pdf, $optlist) {}
 function PDF_rotate($pdf, $phi) {}
 
 /**
- * @param resource $pdf
+ * @param resource $p The PDF doc
  *
  * @return bool
  *
@@ -3407,7 +3399,7 @@ function PDF_skew($pdf, $alpha, $beta) {}
 function PDF_stringwidth($pdf, $text, $font, $fontsize) {}
 
 /**
- * @param resource $pdf
+ * @param resource $p The PDF doc
  *
  * @return bool
  *

--- a/rdkafka/RdKafka/ProducerTopic.php
+++ b/rdkafka/RdKafka/ProducerTopic.php
@@ -11,6 +11,7 @@ class ProducerTopic extends Topic
      * @param int         $msgflags
      * @param string|null $payload
      * @param string|null $key
+     * @param string|null $msg_opaque
      *
      * @return void
      */
@@ -23,6 +24,7 @@ class ProducerTopic extends Topic
      * @param string|null $key
      * @param array|null  $headers
      * @param int         $timestamp_ms
+     * @param string|null $msg_opaque
      *
      * @return void
      */

--- a/redis/Redis.php
+++ b/redis/Redis.php
@@ -458,7 +458,7 @@ class Redis
      *
      * @see     setex()
      * @param   string       $key
-     * @param   int          $ttl, in milliseconds.
+     * @param   int          $ttl in milliseconds.
      * @param   string|mixed $value
      *
      * @return bool TRUE if the command is successful
@@ -681,7 +681,7 @@ class Redis
      * @param array        $patterns   an array of glob-style patterns to subscribe
      * @param string|array $callback   Either a string or an array with an object and method.
      *                     The callback will get four arguments ($redis, $pattern, $channel, $message)
-     * @param mixed        Any non-null return value in the callback will be returned to the caller
+     * @return mixed       Any non-null return value in the callback will be returned to the caller
      *
      * @link    https://redis.io/commands/psubscribe
      * @example

--- a/wincache/wincache.php
+++ b/wincache/wincache.php
@@ -404,7 +404,7 @@ function wincache_ucache_meminfo() {}
  * is case sensitive. key can also take array of name =&gt; value pairs where
  * names will be used as keys. This can be used to add multiple values in the
  * cache in one operation, thus avoiding race condition.</p>
- * @param mixed $value<p>
+ * @param mixed $value <p>
  * Value of a variable to store. Value supports all data types except resources,
  * such as file handles. This parameter is ignored if first argument is an array.
  * A general guidance is to pass NULL as value while using array as key.</p>

--- a/yaf/yaf.php
+++ b/yaf/yaf.php
@@ -624,6 +624,7 @@ class Yaf_Loader
      * @link https://secure.php.net/manual/en/yaf-loader.registerlocalnamespace.php
      *
      * @param string|string[] $namespace a string or a array of class name prefix. all class prefix with these prefix will be loaded in local library path.
+     * @param string $path
      *
      * @return bool
      */
@@ -1543,28 +1544,31 @@ abstract class Yaf_Request_Abstract
      * @link https://secure.php.net/manual/en/yaf-request-abstract.setmodulename.php
      *
      * @param string $module
+     * @param bool $format_name
      *
      * @return Yaf_Request_Abstract|bool
      */
-    public function setModuleName($module, $format_name = null) {}
+    public function setModuleName($module, $format_name = true) {}
 
     /**
      * @link https://secure.php.net/manual/en/yaf-request-abstract.setcontrollername.php
      *
      * @param string $controller
+     * @param bool $format_name
      *
      * @return Yaf_Request_Abstract|bool
      */
-    public function setControllerName($controller, $format_name = null) {}
+    public function setControllerName($controller, $format_name = true) {}
 
     /**
      * @link https://secure.php.net/manual/en/yaf-request-abstract.setactionname.php
      *
      * @param string $action
+     * @param bool $format_name
      *
      * @return Yaf_Request_Abstract|bool
      */
-    public function setActionName($action, $format_name = null) {}
+    public function setActionName($action, $format_name = true) {}
 
     /**
      * @link https://secure.php.net/manual/en/yaf-request-abstract.getmethod.php
@@ -2246,6 +2250,7 @@ class Yaf_Request_Simple extends Yaf_Request_Abstract
      * @link https://secure.php.net/manual/en/yaf-request-simple.construct.php
      *
      * @param string $method
+     * @param string $module
      * @param string $controller
      * @param string $action
      * @param array $params


### PR DESCRIPTION
I used the tool I maintain ([Doctum](https://github.com/code-lts/doctum#readme)) to find the errors.
Here is the online version of the generated API docs: https://doctum.long-term.support/api-docs/phpstorm-stubs/

<details><summary>Full error list (38) before fixes (most errors are not fixed)</summary>
<p>

```
ERROR: The "reschedule_cb" parameter of the method "set" is missing a @param tag on "EvPeriodic::set" in Ev/Ev.php:857
ERROR: The "loop" parameter of the method "__construct" is missing a @param tag on "EvFork::__construct" in Ev/Ev.php:1212
ERROR: The "loop" parameter of the method "createStopped" is missing a @param tag on "EvFork::createStopped" in Ev/Ev.php:1223
ERROR: The "reschedule_cb" parameter of the method "periodic" is missing a @param tag on "EvLoop::periodic" in Ev/Ev.php:1416
ERROR: The "signed_text" parameter of the method "verify" is missing a @param tag on "gnupg::verify" in gnupg/gnupg.php:60
ERROR: The "callback" parameter of the method "enumCharNames" is missing a @param tag on "IntlChar::enumCharNames" in intl/IntlChar.php:879
ERROR: The hint on "libvirt_connect_get_sysinfo" at @return is invalid: "string|false: XML description of system information from the connection or FALSE for error" on "\libvirt_connect_get_sysinfo" in libvirt-php/libvirt-php.php:421
ERROR: The hint on "libvirt_domain_new_get_vnc" at @return is invalid: "string|null: a VNC server for a newly created domain resource (if any)" on "\libvirt_domain_new_get_vnc" in libvirt-php/libvirt-php.php:953
ERROR: The "wtimeout" parameter of the method "setWriteConcern" is missing a @param tag on "MongoDB::setWriteConcern" in mongo/mongo.php:819
ERROR: The "character_set" parameter of the method "ocilogon" is missing a @param tag on "\ocilogon" in oci8/oci8.php:1962
ERROR: The "connection_string" parameter of the method "ocilogon" is missing a @param tag on "\ocilogon" in oci8/oci8.php:1962
ERROR: The "session_mode" parameter of the method "ocilogon" is missing a @param tag on "\ocilogon" in oci8/oci8.php:1962
ERROR: The method "get_majorversion" has "1" @param tags but only "0" where expected. on "PDFlib::get_majorversion" in pdflib/PDFlib.php:847
ERROR: The method "get_minorversion" has "1" @param tags but only "0" where expected. on "PDFlib::get_minorversion" in pdflib/PDFlib.php:855
ERROR: The "pdf" parameter of the method "PDF_activate_item" is missing a @param tag on "\PDF_activate_item" in pdflib/PDFlib.php:1648
ERROR: The "p" parameter of the method "PDF_end_page" is missing a @param tag on "\PDF_end_page" in pdflib/PDFlib.php:2394
ERROR: The "p" parameter of the method "PDF_end_pattern" is missing a @param tag on "\PDF_end_pattern" in pdflib/PDFlib.php:2403
ERROR: The "p" parameter of the method "PDF_end_template" is missing a @param tag on "\PDF_end_template" in pdflib/PDFlib.php:2412
ERROR: The "p" parameter of the method "PDF_endpath" is missing a @param tag on "\PDF_endpath" in pdflib/PDFlib.php:2421
ERROR: The method "PDF_get_majorversion" has "1" @param tags but only "0" where expected. on "\PDF_get_majorversion" in pdflib/PDFlib.php:2593
ERROR: The method "PDF_get_minorversion" has "1" @param tags but only "0" where expected. on "\PDF_get_minorversion" in pdflib/PDFlib.php:2601
ERROR: The "p" parameter of the method "PDF_restore" is missing a @param tag on "\PDF_restore" in pdflib/PDFlib.php:2989
ERROR: The "p" parameter of the method "PDF_save" is missing a @param tag on "\PDF_save" in pdflib/PDFlib.php:3018
ERROR: The "p" parameter of the method "PDF_stroke" is missing a @param tag on "\PDF_stroke" in pdflib/PDFlib.php:3416
ERROR: The "msg_opaque" parameter of the method "produce" is missing a @param tag on "RdKafka\ProducerTopic::produce" in rdkafka/RdKafka/ProducerTopic.php:17
ERROR: The "msg_opaque" parameter of the method "producev" is missing a @param tag on "RdKafka\ProducerTopic::producev" in rdkafka/RdKafka/ProducerTopic.php:29
ERROR: The "ttl" parameter of the method "psetex" is missing a @param tag on "Redis::psetex" in redis/Redis.php:469
ERROR: The method "psubscribe" has "3" @param tags but only "2" where expected. on "Redis::psubscribe" in redis/Redis.php:696
ERROR: The "value" parameter of the method "wincache_ucache_set" is missing a @param tag on "\wincache_ucache_set" in wincache/wincache.php:429
ERROR: The "path" parameter of the method "registerLocalNamespace" is missing a @param tag on "Yaf_Loader::registerLocalNamespace" in yaf/yaf.php:630
ERROR: The method "execute" has "1" @param tags but only "0" where expected. on "Yaf_Action_Abstract::execute" in yaf/yaf.php:1256
ERROR: The "format_name" parameter of the method "setModuleName" is missing a @param tag on "Yaf_Request_Abstract::setModuleName" in yaf/yaf.php:1549
ERROR: The "format_name" parameter of the method "setControllerName" is missing a @param tag on "Yaf_Request_Abstract::setControllerName" in yaf/yaf.php:1558
ERROR: The "format_name" parameter of the method "setActionName" is missing a @param tag on "Yaf_Request_Abstract::setActionName" in yaf/yaf.php:1567
ERROR: The "module" parameter of the method "__construct" is missing a @param tag on "Yaf_Request_Simple::__construct" in yaf/yaf.php:2255
ERROR: The method "execute" has "1" @param tags but only "0" where expected. on "Yaf\Action_Abstract::execute" in yaf/yaf_namespace.php:1215
ERROR: The "protocol" parameter of the method "__construct" is missing a @param tag on "Yar_Server::__construct" in yar/yar.php:50
ERROR: The "async" parameter of the method "__construct" is missing a @param tag on "Yar_Client::__construct" in yar/yar.php:88
```

</p>
</details>