### PR TITLE
Fix intdiv throws annotation

### DIFF
--- a/standard/standard_3.php
+++ b/standard/standard_3.php
@@ -341,12 +341,10 @@ function is_nan(float $num): bool {}
  * @link https://php.net/manual/en/function.intdiv.php
  * @param int $num1 <p>Number to be divided.</p>
  * @param int $num2 <p>Number which divides the <b><i>dividend</i></b></p>
- * @return int <p>
- * If divisor is 0, a {@link DivisionByZeroError} exception is thrown.
- * If the <b><i>dividend</i></b> is <b>PHP_INT_MIN</b> and the <b><i>divisor</i></b> is -1,
- * then an {@link ArithmeticError} exception is thrown.
- * </p>
+ * @return int
  * @since 7.0
+ * @throws DivisionByZeroError <p>if divisor is 0</p>
+ * @throws ArithmeticError <p>if the <b><i>dividend</i></b> is <b>PHP_INT_MIN</b> and the <b><i>divisor</i></b> is -1</p>
  */
 #[Pure]
 function intdiv(int $num1, int $num2): int {}


### PR DESCRIPTION
For tools which read the phpdoc, `@throws` tag should be use.