### PR TITLE
fixed missing return value

### DIFF
--- a/json/json.php
+++ b/json/json.php
@@ -19,7 +19,8 @@ interface JsonSerializable
      * which is a value of any type other than a resource.
      * @since 5.4
      */
-    public function jsonSerialize(): mixed;
+    #[LanguageLevelTypeAware(['8.1'=>'mixed'], default: '')]
+    public function jsonSerialize();
 }
 
 class JsonIncrementalParser

--- a/json/json.php
+++ b/json/json.php
@@ -19,7 +19,7 @@ interface JsonSerializable
      * which is a value of any type other than a resource.
      * @since 5.4
      */
-    public function jsonSerialize();
+    public function jsonSerialize(): mixed;
 }
 
 class JsonIncrementalParser


### PR DESCRIPTION
JsonSerializable::jsonSerialize is defined to have "mixed" as return type, will throw errors in php 8.1 if you not correctly define that return type
Error in php 8.1 example: `Declaration of xxx::jsonSerialize() should be compatible with xxx::jsonSerialize(): mixed`