### PR TITLE
fixed wrong arg name for session_set_save_handler

### DIFF
--- a/session/session.php
+++ b/session/session.php
@@ -252,7 +252,7 @@ function session_set_save_handler(callable $open, callable $close, callable $rea
  * (PHP 5.4)<br/>
  * Sets user-level session storage functions
  * @link https://php.net/manual/en/function.session-set-save-handler.php
- * @param SessionHandlerInterface $session_handler An instance of a class implementing SessionHandlerInterface, such as SessionHandler,
+ * @param SessionHandlerInterface $sessionhandler An instance of a class implementing SessionHandlerInterface, such as SessionHandler,
  * to register as the session handler. Since PHP 5.4 only.
  * @param bool $register_shutdown [optional] Register session_write_close() as a register_shutdown_function() function.
  * @return bool true on success or false on failure.

--- a/session/session.php
+++ b/session/session.php
@@ -257,7 +257,7 @@ function session_set_save_handler(callable $open, callable $close, callable $rea
  * @param bool $register_shutdown [optional] Register session_write_close() as a register_shutdown_function() function.
  * @return bool true on success or false on failure.
  */
-function session_set_save_handler(SessionHandlerInterface $session_handler, $register_shutdown = true): bool {}
+function session_set_save_handler(SessionHandlerInterface $sessionhandler, $register_shutdown = true): bool {}
 
 /**
  * Get and/or set the current cache limiter


### PR DESCRIPTION
I got an error when using named arguments. (PHPStan and Psalm were working correctly)

ref: https://www.php.net/manual/en/function.session-set-save-handler.php

> session_set_save_handler(object $sessionhandler, bool $register_shutdown = true): bool