### PR TITLE
db2_last_insert_id may return NULL

### DIFF
--- a/ibm_db2/ibm_db2.php
+++ b/ibm_db2/ibm_db2.php
@@ -1733,7 +1733,8 @@ function db2_get_option($resource, $option) {}
  * </ul>
  * @param resource $resource A valid connection resource as returned from db2_connect() or db2_pconnect().
  * The value of this parameter cannot be a statement resource or result set resource.
- * @return string Returns the auto generated ID of last insert query that successfully executed on this connection.
+ * @return string|null Returns the auto generated ID of last insert query that successfully executed on this connection
+ *                     or NULL if no ID was found.
  */
 function db2_last_insert_id($resource) {}
 


### PR DESCRIPTION
See the [source code](https://github.com/php/pecl-database-ibm_db2/blob/19850ece1954bb24f433ea2286f447a7b6c85da0/ibm_db2.c#L7457-L7462):
```c
/* Returning last insert ID (if any), or otherwise NULL */
if (last_id[0] != '\0') {
    ZEND_RETURN_STRING(last_id, 0);
} else {
    RETURN_NULL();
}
```