### PR TITLE
Avoid using multi-line annotations for PHP 7 compatibility

### DIFF
--- a/Core/Core.php
+++ b/Core/Core.php
@@ -1064,12 +1064,7 @@ function gc_disable(): void {}
  * </ul>
  * @since 7.3
  */
-#[ArrayShape([
-    "runs" => "int",
-    "collected" => "int",
-    "threshold" => "int",
-    "roots" => "int"
-])]
+#[ArrayShape(["runs" => "int", "collected" => "int", "threshold" => "int", "roots" => "int"])]
 #[Pure]
 function gc_status(): array {}
 

--- a/PDO/PDO.php
+++ b/PDO/PDO.php
@@ -1163,11 +1163,7 @@ class PDO
      * <b>PDOStatement::errorInfo</b> to return the error
      * information for an operation performed on a particular statement handle.
      */
-    #[ArrayShape([
-        0 => "string",
-        1 => "int",
-        2 => "string",
-    ])]
+    #[ArrayShape([0 => "string", 1 => "int", 2 => "string"])]
     public function errorInfo() {}
 
     /**
@@ -1517,11 +1513,7 @@ class PDOStatement implements IteratorAggregate
      * <td>Driver specific error message.</td>
      * </tr>
      */
-    #[ArrayShape([
-        0 => "string",
-        1 => "int",
-        2 => "string",
-    ])]
+    #[ArrayShape([0 => "string", 1 => "int", 2 => "string"])]
     public function errorInfo() {}
 
     /**

--- a/Phar/Phar.php
+++ b/Phar/Phar.php
@@ -350,10 +350,7 @@ class Phar extends RecursiveDirectoryIterator implements RecursiveIterator, Seek
      * phar.require_hash INI variable
      * is set to true.
      */
-    #[ArrayShape([
-        "hash" => "string",
-        "hash_type" => "string",
-    ])]
+    #[ArrayShape(["hash" => "string", "hash_type" => "string"])]
     public function getSignature() {}
 
     /**

--- a/curl/curl.php
+++ b/curl/curl.php
@@ -139,17 +139,7 @@ function curl_copy_handle(#[LanguageLevelTypeAware(["8.0" => "CurlHandle"], defa
  * <td>An array of protocols names supported by cURL</td>
  * </tr>
  */
-#[ArrayShape([
-    "version_number" => "string",
-    "version" => "string",
-    "ssl_version_number" => "int",
-    "ssl_version" => "string",
-    "libz_version" => "string",
-    "host" => "string",
-    "age" => "int",
-    "features" => "int",
-    "protocols" => "array",
-])]
+#[ArrayShape(["version_number" => "string", "version" => "string", "ssl_version_number" => "int", "ssl_version" => "string", "libz_version" => "string", "host" => "string", "age" => "int", "features" => "int", "protocols" => "array"])]
 #[Pure]
 function curl_version($age = null): array|false {}
 

--- a/date/date.php
+++ b/date/date.php
@@ -983,12 +983,7 @@ function date_parse_from_format(string $format, string $datetime): array {}
  * @link https://php.net/manual/en/function.date-get-last-errors.php
  * @return array|false <p>Returns array containing info about warnings and errors.</p>
  */
-#[ArrayShape([
-    "warning_count" => "int",
-    "warnings" => "string[]",
-    "error_count" => "int",
-    "errors" => "string[]",
-])]
+#[ArrayShape(["warning_count" => "int", "warnings" => "string[]", "error_count" => "int", "errors" => "string[]"])]
 #[Pure(true)]
 function date_get_last_errors(): array|false {}
 

--- a/date/date_c.php
+++ b/date/date_c.php
@@ -204,12 +204,7 @@ class DateTimeImmutable implements DateTimeInterface
      * @link https://secure.php.net/manual/en/datetimeimmutable.getlasterrors.php
      * @return array|false Returns array containing info about warnings and errors.
      */
-    #[ArrayShape([
-        "warning_count" => "int",
-        "warnings" => "string[]",
-        "error_count" => "int",
-        "errors" => "string[]",
-    ])]
+    #[ArrayShape(["warning_count" => "int", "warnings" => "string[]", "error_count" => "int", "errors" => "string[]"])]
     public static function getLastErrors() {}
 
     /**
@@ -612,12 +607,7 @@ class DateTime implements DateTimeInterface
      * @return array|false
      * @link https://php.net/manual/en/datetime.getlasterrors.php
      */
-    #[ArrayShape([
-        "warning_count" => "int",
-        "warnings" => "string[]",
-        "error_count" => "int",
-        "errors" => "string[]",
-    ])]
+    #[ArrayShape(["warning_count" => "int", "warnings" => "string[]", "error_count" => "int", "errors" => "string[]"])]
     public static function getLastErrors() {}
 
     /**

--- a/imagick/imagick.php
+++ b/imagick/imagick.php
@@ -1524,10 +1524,7 @@ class Imagick implements Iterator, Countable
      * @return float[] an array containing minima and maxima values of the channel(s).
      * @throws ImagickException on error.
      */
-    #[ArrayShape([
-        "minima" => "float",
-        "maxima" => "float"
-    ])]
+    #[ArrayShape(["minima" => "float", "maxima" => "float"])]
     #[Pure]
     public function getImageChannelRange($channel) {}
 
@@ -1723,10 +1720,7 @@ class Imagick implements Iterator, Countable
      * members.
      * @throws ImagickException on error.
      */
-    #[ArrayShape([
-        "kurtosis" => "float",
-        "skewness" => "float"
-    ])]
+    #[ArrayShape(["kurtosis" => "float", "skewness" => "float"])]
     #[Pure]
     public function getImageChannelKurtosis($channel = Imagick::CHANNEL_DEFAULT) {}
 
@@ -2272,10 +2266,7 @@ class Imagick implements Iterator, Countable
      * @return int[] an array with the width/height of the image.
      * @throws ImagickException on error.
      */
-    #[ArrayShape([
-        "width" => "int",
-        "height" => "int"
-    ])]
+    #[ArrayShape(["width" => "int", "height" => "int"])]
     #[Pure]
     public function getImageGeometry() {}
 
@@ -3551,10 +3542,7 @@ class Imagick implements Iterator, Countable
      * @return float[] Array consisting of "x" and "y" coordinates of point.
      * @throws ImagickException on error.
      */
-    #[ArrayShape([
-        "x" => "float",
-        "y" => "float"
-    ])]
+    #[ArrayShape(["x" => "float", "y" => "float"])]
     #[Pure]
     public function getImageBluePrimary() {}
 
@@ -3616,10 +3604,7 @@ class Imagick implements Iterator, Countable
      * @return int[]
      * @throws ImagickException on error.
      */
-    #[ArrayShape([
-        "minima" => "int",
-        "maxima" => "int"
-    ])]
+    #[ArrayShape(["minima" => "int", "maxima" => "int"])]
     #[Deprecated]
     #[Pure]
     public function getImageChannelExtrema($channel) {}
@@ -3637,10 +3622,7 @@ class Imagick implements Iterator, Countable
      * @return float[]
      * @throws ImagickException on error.
      */
-    #[ArrayShape([
-        "mean" => "float",
-        "standardDeviation" => "float"
-    ])]
+    #[ArrayShape(["mean" => "float", "standardDeviation" => "float"])]
     #[Pure]
     public function getImageChannelMean($channel) {}
 
@@ -3731,10 +3713,7 @@ class Imagick implements Iterator, Countable
      * @return int[] an associative array with the keys "min" and "max".
      * @throws ImagickException on error.
      */
-    #[ArrayShape([
-        "min" => "int",
-        "max" => "int"
-    ])]
+    #[ArrayShape(["min" => "int", "max" => "int"])]
     #[Deprecated]
     #[Pure]
     public function getImageExtrema() {}
@@ -3767,10 +3746,7 @@ class Imagick implements Iterator, Countable
      * @throws ImagickException on failure
      * @throws ImagickException on error.
      */
-    #[ArrayShape([
-        "x" => "float",
-        "y" => "float"
-    ])]
+    #[ArrayShape(["x" => "float", "y" => "float"])]
     #[Pure]
     public function getImageGreenPrimary() {}
 
@@ -3834,12 +3810,7 @@ class Imagick implements Iterator, Countable
      * keys "width", "height", "x", and "y".
      * @throws ImagickException on error.
      */
-    #[ArrayShape([
-        "width" => "int",
-        "height" => "int",
-        "x" => "int",
-        "y" => "int"
-    ])]
+    #[ArrayShape(["width" => "int", "height" => "int", "x" => "int", "y" => "int"])]
     #[Pure]
     public function getImagePage() {}
 
@@ -3881,10 +3852,7 @@ class Imagick implements Iterator, Countable
      * Throw an <b>ImagickException</b> on error.
      * @throws ImagickException on error
      */
-    #[ArrayShape([
-        "x" => "float",
-        "y" => "float"
-    ])]
+    #[ArrayShape(["x" => "float", "y" => "float"])]
     #[Pure]
     public function getImageRedPrimary() {}
 
@@ -3905,10 +3873,7 @@ class Imagick implements Iterator, Countable
      * @return float[] the resolution as an array.
      * @throws ImagickException on error.
      */
-    #[ArrayShape([
-        "x" => "float",
-        "y" => "float"
-    ])]
+    #[ArrayShape(["x" => "float", "y" => "float"])]
     #[Pure]
     public function getImageResolution() {}
 
@@ -3991,10 +3956,7 @@ class Imagick implements Iterator, Countable
      * "x" and "y".
      * @throws ImagickException on error.
      */
-    #[ArrayShape([
-        "x" => "float",
-        "y" => "float"
-    ])]
+    #[ArrayShape(["x" => "float", "y" => "float"])]
     #[Pure]
     public function getImageWhitePoint() {}
 
@@ -4693,12 +4655,7 @@ class Imagick implements Iterator, Countable
      * @throws ImagickException on error
      */
     //width:int, height:int, x:int, y:int
-    #[ArrayShape([
-        "width" => "int",
-        "height" => "int",
-        "x" => "int",
-        "y" => "int"
-    ])]
+    #[ArrayShape(["width" => "int", "height" => "int", "x" => "int", "y" => "int"])]
     #[Pure]
     public function getPage() {}
 
@@ -4709,10 +4666,7 @@ class Imagick implements Iterator, Countable
      * @return array the Imagick quantum depth as a string.
      */
     // quantumDepthLong:int, quantumDepthString:string
-    #[ArrayShape([
-        "quantumDepthLong" => "int",
-        "quantumDepthString" => "string",
-    ])]
+    #[ArrayShape(["quantumDepthLong" => "int", "quantumDepthString" => "string"])]
     public static function getQuantumDepth() {}
 
     /**
@@ -4721,10 +4675,7 @@ class Imagick implements Iterator, Countable
      * @link https://php.net/manual/en/imagick.getquantumrange.php
      * @return array the Imagick quantum range as a string.
      */
-    #[ArrayShape([
-        "quantumDepthLong" => "int",
-        "quantumDepthString" => "string",
-    ])]
+    #[ArrayShape(["quantumDepthLong" => "int", "quantumDepthString" => "string"])]
     public static function getQuantumRange() {}
 
     /**
@@ -4775,10 +4726,7 @@ class Imagick implements Iterator, Countable
      * keys "columns" and "rows".
      * @throws ImagickException on error.
      */
-    #[ArrayShape([
-        "columns" => "int",
-        "rows" => "int"
-    ])]
+    #[ArrayShape(["columns" => "int", "rows" => "int"])]
     #[Pure]
     public function getSize() {}
 
@@ -4788,10 +4736,7 @@ class Imagick implements Iterator, Countable
      * @link https://php.net/manual/en/imagick.getversion.php
      * @return array the ImageMagick API version as a string and as a number.
      */
-    #[ArrayShape([
-        "versionNumber" => "int",
-        "versionString" => "string",
-    ])]
+    #[ArrayShape(["versionNumber" => "int", "versionString" => "string"])]
     public static function getVersion() {}
 
     /**
@@ -7070,11 +7015,7 @@ class ImagickPixel
      * "saturation", and "luminosity". Throws ImagickPixelException on failure.
      * @throws ImagickPixelException on failure
      */
-    #[ArrayShape([
-        "hue" => "float",
-        "saturation" => "float",
-        "luminosity" => "float"
-    ])]
+    #[ArrayShape(["hue" => "float", "saturation" => "float", "luminosity" => "float"])]
     #[Pure]
     public function getHSL() {}
 
@@ -7242,12 +7183,7 @@ class ImagickPixel
      * ImagickPixelException on error.
      * @throws ImagickPixelException on error.
      */
-    #[ArrayShape([
-        "r" => "int|float",
-        "g" => "int|float",
-        "b" => "int|float",
-        "a" => "int|float"
-    ])]
+    #[ArrayShape(["r" => "int|float", "g" => "int|float", "b" => "int|float", "a" => "int|float"])]
     #[Pure]
     public function getColor($normalized = 0) {}
 

--- a/session/session.php
+++ b/session/session.php
@@ -397,14 +397,7 @@ function session_set_cookie_params(array|int $lifetime_or_options, ?string $path
  * "httponly" - The
  * cookie can only be accessed through the HTTP protocol.
  */
-#[ArrayShape([
-    "lifetime" => "int",
-    "path" => "string",
-    "domain" => "string",
-    "secure" => "bool",
-    "httponly" => "bool",
-    "samesite" => "string"
-])]
+#[ArrayShape(["lifetime" => "int", "path" => "string", "domain" => "string", "secure" => "bool", "httponly" => "bool", "samesite" => "string"])]
 function session_get_cookie_params(): array {}
 
 /**

--- a/standard/standard_2.php
+++ b/standard/standard_2.php
@@ -479,16 +479,7 @@ function fscanf($stream, string $format, #[TypeContract(exists: "int|false|null"
  * If the component parameter is specified a
  * string is returned instead of an array.
  */
-#[ArrayShape([
-    "scheme" => "string",
-    "host" => "string",
-    "port" => "int",
-    "user" => "string",
-    "pass" => "string",
-    "query" => "string",
-    "path" => "string",
-    "fragment" => "string",
-])]
+#[ArrayShape(["scheme" => "string", "host" => "string", "port" => "int", "user" => "string", "pass" => "string", "query" => "string", "path" => "string", "fragment" => "string"])]
 #[Pure]
 function parse_url(string $url, int $component = -1) {}
 
@@ -911,16 +902,7 @@ function proc_terminate($process, int $signal = 15): bool {}
  * </td>
  * </tr>
  */
-#[ArrayShape([
-    "command" => "string",
-    "pid" => "int",
-    "running" => "bool",
-    "signaled" => "bool",
-    "stopped" => "bool",
-    "exitcode" => "int",
-    "termsig" => "int",
-    "stopsig" => "int",
-])]
+#[ArrayShape(["command" => "string", "pid" => "int", "running" => "bool", "signaled" => "bool", "stopped" => "bool", "exitcode" => "int", "termsig" => "int", "stopsig" => "int"])]
 #[LanguageLevelTypeAware(["8.0" => "array"], default: "array|false")]
 function proc_get_status($process) {}
 

--- a/standard/standard_3.php
+++ b/standard/standard_3.php
@@ -838,12 +838,7 @@ function microtime(#[TypeContract(true: "float", false: "string")] bool $as_floa
  * "dsttime" - type of dst correction
  */
 #[Pure]
-#[ArrayShape([
-    "sec" => "int",
-    "usec" => "int",
-    "minuteswest" => "int",
-    "dsttime" => "int"
-])]
+#[ArrayShape(["sec" => "int", "usec" => "int", "minuteswest" => "int", "dsttime" => "int"])]
 function gettimeofday(#[TypeContract(true: "float", false: "int[]")] bool $as_float = false): array|float {}
 
 /**

--- a/standard/standard_4.php
+++ b/standard/standard_4.php
@@ -11,12 +11,7 @@ use JetBrains\PhpStorm\Pure;
  * "message", "file" and "line". Returns null if there hasn't been an error
  * yet.
  */
-#[ArrayShape([
-    "type" => "int",
-    "message" => "string",
-    "file" => "string",
-    "line" => "int",
-])]
+#[ArrayShape(["type" => "int", "message" => "string", "file" => "string", "line" => "int"])]
 #[Pure]
 function error_get_last(): ?array {}
 

--- a/standard/standard_6.php
+++ b/standard/standard_6.php
@@ -868,20 +868,7 @@ function socket_set_blocking($stream, bool $enable): bool {}
  * stream.
  * </p>
  */
-#[ArrayShape([
-    "timed_out" => "bool",
-    "blocked" => "bool",
-    "eof" => "bool",
-    "unread_bytes" => "int",
-    "stream_type" => "string",
-    "wrapper_type" => "string",
-    "wrapper_data" => "mixed",
-    "mode" => "string",
-    "seekable" => "bool",
-    "uri" => "string",
-    "crypto" => "array",
-    "mediatype" => "string",
-])]
+#[ArrayShape(["timed_out" => "bool", "blocked" => "bool", "eof" => "bool", "unread_bytes" => "int", "stream_type" => "string", "wrapper_type" => "string", "wrapper_data" => "mixed", "mode" => "string", "seekable" => "bool", "uri" => "string", "crypto" => "array", "mediatype" => "string"])]
 function stream_get_meta_data($stream): array {}
 
 /**


### PR DESCRIPTION
While the package requires PHP 8 for development,
https://github.com/JetBrains/phpstorm-stubs/blob/a09a014a1984d2ac875c6b1220b7f17ca7d0a873/composer.json#L16-L17
It doesn't require PHP 8 when the package is used as a library.

Although, some code in the package is currently not compatible with PHP 7:
https://github.com/JetBrains/phpstorm-stubs/blob/a09a014a1984d2ac875c6b1220b7f17ca7d0a873/PDO/PDO.php#L1166-L1170

An attempt to use this code with PHP 7 causes a parse error:
```
php -l PDO/PDO.php

Parse error: syntax error, unexpected '0' (T_LNUMBER), expecting function (T_FUNCTION) or const (T_CONST) in PDO/PDO.php on line 1167
```
