### PR TITLE
Update fwrite return type to include 'false'

### DIFF
--- a/SPL/SPL_c1.php
+++ b/SPL/SPL_c1.php
@@ -779,7 +779,7 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, SeekableIt
          * the end of <i>string</i> is reached, whichever comes
          * first.
          * </p>
-         * @return int the number of bytes written, or 0 on error.
+         * @return int|bool the number of bytes written, or false on error.
          */
         public function fwrite($data, $length = null) {}
 


### PR DESCRIPTION
Since 7.4.0 SplFileObject::fwrite returns false instead of 0 on failure

[PHP Manual Reference](https://www.php.net/manual/en/splfileobject.fwrite.php)