### PR TITLE
Add Readonly attribute

### DIFF
--- a/meta/attributes/Readonly.php
+++ b/meta/attributes/Readonly.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace JetBrains\PhpStorm;
+
+use Attribute;
+
+/**
+ * This marks a property as readonly.
+ *
+ * That means that this property can only be writting from the declaring class constructor it self.
+ *
+ * @since 8.0
+ */
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class Readonly
+{
+}


### PR DESCRIPTION
This will add a `Readonly` attribute to the stubs.

I have created a small package to support a `readonly` functionality using static analysis (currently phpstan)
https://github.com/icanhazstring/phpstan-readonly-property

I introduced my own `Readonly` attribute inside the package. But it would be nice to have it in a more global package, so that other static analysis tools can use it without the need to require my library which requires phpstan.

Edit:
I created a PHPStorm Issue you can find it here: https://youtrack.jetbrains.com/issue/WI-61559