### PR TITLE
mark rand_* functions as $mayDependOnGlobalScope

### DIFF
--- a/standard/standard_2.php
+++ b/standard/standard_2.php
@@ -927,6 +927,7 @@ function proc_nice(int $priority): bool {}
  * @return int A pseudo random value between min
  * (or 0) and max (or getrandmax, inclusive).
  */
+#[Pure(true)]
 function rand(int $min = 0, int $max): int {}
 
 /**
@@ -965,6 +966,7 @@ function getrandmax(): int {}
  * @return int A random integer value between min (or 0)
  * and max (or mt_getrandmax, inclusive)
  */
+#[Pure(true)]
 function mt_rand(int $min = 0, int $max): int {}
 
 /**

--- a/standard/standard_9.php
+++ b/standard/standard_9.php
@@ -222,6 +222,7 @@ function array_change_key_case(array $array, int $case): array {}
  * of keys for the random entries. This is done so that you can pick
  * random keys as well as values out of the array.
  */
+#[Pure(true)]
 function array_rand(array $array, int $num = 1): array|string|int {}
 
 /**


### PR DESCRIPTION
Functions are actually Pure in terms of PhpStorm (don't have side effects) but result of function calls is different. For such cases Pure attribute has parameter $mayDependOnGlobalScope that indicates whether the function result may be dependent on anything except passed variables