### PR TITLE
ssh2_connect :: default port 22

### DIFF
--- a/ssh2/ssh2.php
+++ b/ssh2/ssh2.php
@@ -175,7 +175,7 @@
  * </p>
  * @return resource|false a resource on success, or false on error.
  */
-function ssh2_connect($host, $port = null, ?array $methods = null, ?array $callbacks = null) {}
+function ssh2_connect($host, $port = 22, ?array $methods = null, ?array $callbacks = null) {}
 
 /**
  * (PECL ssh2 &gt;= 1.0)<br/>


### PR DESCRIPTION
Hi :raised_hand:

PHP Documentation: https://www.php.net/manual/ru/function.ssh2-connect.php

On the official php page, this function has a default value of "22" for the "port" parameter 