### PR TITLE
WI-59165 Invalid stub for get_headers function: The associative parameter has been changed from int to bool in PHP 8.0

### DIFF
--- a/standard/standard_6.php
+++ b/standard/standard_6.php
@@ -1024,7 +1024,7 @@ function stream_is_local($stream): bool {}
  * failure.
  */
 #[Pure]
-function get_headers(string $url, bool $associative = false, $context): array|false {}
+function get_headers(string $url, #[LanguageLevelTypeAware(['8.0' => 'bool'], default: 'int')] $associative = false, $context = null): array|false {}
 
 /**
  * Set timeout period on a stream


### PR DESCRIPTION
The actual issue reported in WI-59165 was already fixed.
However the type of the $associative parameter has only changed since PHP 8.0 to bool from int.
I have added the #[LanguageLevelTypeAware] attribute accordingly.

I have not touched the default value and PhpDoc, which would still be wrong for PHP 7.4. But there doesn't seem to be a way to also fix those.