### PR TITLE
Template ReflectionAttribute

### DIFF
--- a/Reflection/ReflectionAttribute.php
+++ b/Reflection/ReflectionAttribute.php
@@ -4,6 +4,8 @@ use JetBrains\PhpStorm\Pure;
 
 /**
  * @since 8.0
+ *
+ * @template T of object
  */
 final class ReflectionAttribute implements Reflector
 {
@@ -62,7 +64,7 @@ final class ReflectionAttribute implements Reflector
     /**
      * Creates a new instance of the attribute with passed arguments
      *
-     * @return object
+     * @return T
      * @since 8.0
      */
     public function newInstance() {}

--- a/Reflection/ReflectionClass.php
+++ b/Reflection/ReflectionClass.php
@@ -592,11 +592,13 @@ class ReflectionClass implements Reflector
     public function getShortName() {}
 
     /**
-     * Returns an array of function attributes.
+     * @template T
      *
-     * @param string|null $name Name of an attribute class
+     * Returns an array of class attributes.
+     *
+     * @param class-string<T>|null $name Name of an attribute class
      * @param int $flags Сriteria by which the attribute is searched.
-     * @return ReflectionAttribute[]
+     * @return ReflectionAttribute<T>[]
      * @since 8.0
      */
     #[Pure]

--- a/Reflection/ReflectionClassConstant.php
+++ b/Reflection/ReflectionClassConstant.php
@@ -175,11 +175,13 @@ class ReflectionClassConstant implements Reflector
     public function __toString() {}
 
     /**
+     * @template T
+     *
      * Returns an array of constant attributes.
      *
-     * @param string|null $name Name of an attribute class
+     * @param class-string<T>|null $name Name of an attribute class
      * @param int $flags Сriteria by which the attribute is searched.
-     * @return ReflectionAttribute[]
+     * @return ReflectionAttribute<T>[]
      * @since 8.0
      */
     #[Pure]

--- a/Reflection/ReflectionFunctionAbstract.php
+++ b/Reflection/ReflectionFunctionAbstract.php
@@ -271,11 +271,13 @@ abstract class ReflectionFunctionAbstract implements Reflector
     public function hasReturnType() {}
 
     /**
+     * @template T
+     *
      * Returns an array of function attributes.
      *
-     * @param string|null $name Name of an attribute class
+     * @param class-string<T>|null $name Name of an attribute class
      * @param int $flags Сriteria by which the attribute is searched.
-     * @return ReflectionAttribute[]
+     * @return ReflectionAttribute<T>[]
      * @since 8.0
      */
     #[Pure]

--- a/Reflection/ReflectionParameter.php
+++ b/Reflection/ReflectionParameter.php
@@ -256,11 +256,13 @@ class ReflectionParameter implements Reflector
     public function isPromoted() {}
 
     /**
+     * @template T
+     *
      * Returns an array of parameter attributes.
      *
-     * @param string|null $name Name of an attribute class
+     * @param class-string<T>|null $name Name of an attribute class
      * @param int $flags Сriteria by which the attribute is searched.
-     * @return ReflectionAttribute[]
+     * @return ReflectionAttribute<T>[]
      * @since 8.0
      */
     #[Pure]

--- a/Reflection/ReflectionProperty.php
+++ b/Reflection/ReflectionProperty.php
@@ -306,9 +306,13 @@ class ReflectionProperty implements Reflector
     public function getDefaultValue() {}
 
     /**
-     * @param null|string $name
-     * @param int $flags
-     * @return ReflectionAttribute[]
+     * @template T
+     *
+     * Returns an array of property attributes.
+     *
+     * @param class-string<T>|null $name Name of an attribute class
+     * @param int $flags Сriteria by which the attribute is searched.
+     * @return ReflectionAttribute<T>[]
      * @since 8.0
      */
     #[Pure]


### PR DESCRIPTION
Hopefully this PR is the correct direction for attribute class types to be inferred by PhpStorm.

```php
$attributes = $reflectionObject->getAttributes(MyAttribute::class);
foreach ($attributes as $attribute) {
    // With @template annotations, hopefully PhpStorm can infer the type of $object as `MyAttribute`.
    $object = $attribute->newInstance();
}
```