### PR TITLE
Get rid of PECL env variable when run tests for pecl extensions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
           PHP_VERSION: ${{matrix.php}}
 
       - name: Dump Reflection To File
-        run: docker-compose -f docker-compose.yml run -e PHP_VERSION=${{matrix.php}} php_under_test /usr/local/bin/php /opt/project/phpstorm-stubs/tests/Tools/dump-reflection-to-file.php
+        run: docker-compose -f docker-compose.yml run -e PHP_VERSION=${{matrix.php}} php_under_test /usr/local/bin/php /opt/project/phpstorm-stubs/tests/Tools/dump-reflection-to-file.php ReflectionData.json
         env:
           PHP_VERSION: ${{matrix.php}}
 

--- a/.github/workflows/testPeclExtensions.yml
+++ b/.github/workflows/testPeclExtensions.yml
@@ -19,22 +19,17 @@ jobs:
 
       - name: Composer Install
         run: docker-compose -f docker-compose.yml run test_runner composer install -d /opt/project/phpstorm-stubs --ignore-platform-reqs
-        env:
-          PHP_VERSION: '8.0'
-
-      - name: Dump Reflection Without Pecl To File
-        run: docker-compose -f docker-compose.yml run -e PHP_VERSION='8.0' -e NO_PECL=true php_under_test /usr/local/bin/php /opt/project/phpstorm-stubs/tests/Tools/dump-reflection-to-file.php
-        env:
-          PHP_VERSION: '8.0'
-          NO_PECL: true
 
       - name: Dump Reflection With Pecl To File
-        run: docker-compose -f docker-compose.yml run -e PHP_VERSION='8.0' pecl_extensions /usr/local/bin/php /opt/project/phpstorm-stubs/tests/Tools/dump-reflection-to-file.php
-        env:
-          PHP_VERSION: '8.0'
+        run: docker-compose -f docker-compose.yml run pecl_extensions /usr/local/bin/php /opt/project/phpstorm-stubs/tests/Tools/dump-reflection-to-file.php ReflectionDataPecl.json
+
+      - name: Dump Reflection Without Pecl To File
+        run: docker-compose -f docker-compose.yml run php_under_test /usr/local/bin/php /opt/project/phpstorm-stubs/tests/Tools/dump-reflection-to-file.php ReflectionData.json
+
+      - name: Build Reflection Data With Pecl Only
+        run: docker-compose -f docker-compose.yml run php_under_test /usr/local/bin/php /opt/project/phpstorm-stubs/tests/Tools/dump-pecl-to-file.php
 
       - name: Run Tests
-        run: docker-compose -f docker-compose.yml run -e PECL=true -e PHP_VERSION='8.0' test_runner /opt/project/phpstorm-stubs/vendor/bin/phpunit /opt/project/phpstorm-stubs/tests/
+        run: docker-compose -f docker-compose.yml run -e PHP_VERSION='8.0' test_runner /opt/project/phpstorm-stubs/vendor/bin/phpunit /opt/project/phpstorm-stubs/tests/
         env:
           PHP_VERSION: '8.0'
-          PECL: true

--- a/tests/Model/BasePHPElement.php
+++ b/tests/Model/BasePHPElement.php
@@ -22,7 +22,6 @@ use Reflector;
 use RuntimeException;
 use stdClass;
 use StubTests\Parsers\ParserUtils;
-use StubTests\TestData\Providers\ReflectionStubsSingleton;
 use function array_key_exists;
 use function count;
 use function in_array;
@@ -215,16 +214,5 @@ abstract class BasePHPElement
     public static function entitySuitsCurrentPhpVersion(BasePHPElement $element): bool
     {
         return in_array((float)getenv('PHP_VERSION'), ParserUtils::getAvailableInVersions($element), true);
-    }
-
-    /**
-     * @param PHPInterface|PHPClass $class
-     * @return bool
-     * @throws RuntimeException
-     */
-    public static function classExistInCoreReflection($class): bool
-    {
-        return ReflectionStubsSingleton::getReflectionStubsNoPecl()->getClass($class->name) !== null ||
-            ReflectionStubsSingleton::getReflectionStubsNoPecl()->getInterface($class->name) !== null;
     }
 }

--- a/tests/StubsMetaInternalTagTest.php
+++ b/tests/StubsMetaInternalTagTest.php
@@ -5,7 +5,6 @@ namespace StubTests;
 
 use PHPUnit\Framework\Exception;
 use RuntimeException;
-use StubTests\Model\PHPFunction;
 use StubTests\Model\PHPMethod;
 use StubTests\Model\StubProblemType;
 use StubTests\Parsers\Visitors\MetaOverrideFunctionsParser;
@@ -39,9 +38,8 @@ class StubsMetaInternalTagTest extends BaseStubsTest
                     ReflectionStubsSingleton::getReflectionStubs()->getFunctions(),
                     fn ($refFunction) => $refFunction->name === $function->name
                 );
-                /** @var PHPFunction $reflectionFunction */
                 $reflectionFunction = array_pop($reflectionFunctions);
-                if (!$reflectionFunction->hasMutedProblem(StubProblemType::ABSENT_IN_META)) {
+                if ($reflectionFunction !== null && !$reflectionFunction->hasMutedProblem(StubProblemType::ABSENT_IN_META)) {
                     self::checkInternalMetaInOverride($function->name);
                 }
             }

--- a/tests/TestData/Providers/Reflection/ReflectionClassesTestDataProviders.php
+++ b/tests/TestData/Providers/Reflection/ReflectionClassesTestDataProviders.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace StubTests\TestData\Providers\Reflection;
 
 use Generator;
-use StubTests\Model\BasePHPElement;
 use StubTests\Model\PHPClass;
 use StubTests\Model\StubProblemType;
 use StubTests\TestData\Providers\EntitiesFilter;
@@ -17,9 +16,6 @@ class ReflectionClassesTestDataProviders
         $allClassesAndInterfaces = ReflectionStubsSingleton::getReflectionStubs()->getClasses() +
             ReflectionStubsSingleton::getReflectionStubs()->getInterfaces();
         foreach (EntitiesFilter::getFiltered($allClassesAndInterfaces) as $class) {
-            if (!empty(getenv('PECL')) && BasePHPElement::classExistInCoreReflection($class)) {
-                continue;
-            }
             //exclude classes from PHPReflectionParser
             if (strncmp($class->name, 'PHP', 3) !== 0) {
                 yield "class $class->name" => [$class];
@@ -34,9 +30,6 @@ class ReflectionClassesTestDataProviders
             fn (PHPClass $class) => empty($class->interfaces),
             StubProblemType::WRONG_INTERFACE
         ) as $class) {
-            if (!empty(getenv('PECL')) && BasePHPElement::classExistInCoreReflection($class)) {
-                continue;
-            }
             //exclude classes from PHPReflectionParser
             if (strncmp($class->name, 'PHP', 3) !== 0) {
                 yield "class $class->name" => [$class];
@@ -54,9 +47,6 @@ class ReflectionClassesTestDataProviders
             StubProblemType::WRONG_PARENT
         );
         foreach ($filtered as $class) {
-            if (!empty(getenv('PECL')) && BasePHPElement::classExistInCoreReflection($class)) {
-                continue;
-            }
             yield "class $class->name" => [$class];
         }
     }

--- a/tests/TestData/Providers/Reflection/ReflectionConstantsProvider.php
+++ b/tests/TestData/Providers/Reflection/ReflectionConstantsProvider.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace StubTests\TestData\Providers\Reflection;
 
 use Generator;
-use StubTests\Model\BasePHPElement;
 use StubTests\Model\PHPClass;
 use StubTests\Model\PHPConst;
 use StubTests\Model\PHPInterface;
@@ -17,9 +16,6 @@ class ReflectionConstantsProvider
     public static function constantProvider(): ?Generator
     {
         foreach (EntitiesFilter::getFiltered(ReflectionStubsSingleton::getReflectionStubs()->getConstants()) as $constant) {
-            if (!empty(getenv('PECL')) && !empty(ReflectionStubsSingleton::getReflectionStubsNoPecl()->getConstant($constant->name))) {
-                continue;
-            }
             yield "constant $constant->name" => [$constant];
         }
     }
@@ -27,9 +23,6 @@ class ReflectionConstantsProvider
     public static function constantValuesProvider(): ?Generator
     {
         foreach (self::getFilteredConstants() as $constant) {
-            if (!empty(getenv('PECL')) && !empty(ReflectionStubsSingleton::getReflectionStubsNoPecl()->getConstant($constant->name))) {
-                continue;
-            }
             yield "constant $constant->name" => [$constant];
         }
     }
@@ -39,9 +32,6 @@ class ReflectionConstantsProvider
         $classesAndInterfaces = ReflectionStubsSingleton::getReflectionStubs()->getClasses() +
             ReflectionStubsSingleton::getReflectionStubs()->getInterfaces();
         foreach (EntitiesFilter::getFiltered($classesAndInterfaces) as $class) {
-            if (!empty(getenv('PECL')) && BasePHPElement::classExistInCoreReflection($class)) {
-                continue;
-            }
             foreach (EntitiesFilter::getFiltered($class->constants) as $constant) {
                 yield "constant $class->name::$constant->name" => [$class, $constant];
             }
@@ -53,9 +43,6 @@ class ReflectionConstantsProvider
         $classesAndInterfaces = ReflectionStubsSingleton::getReflectionStubs()->getClasses() +
             ReflectionStubsSingleton::getReflectionStubs()->getInterfaces();
         foreach (EntitiesFilter::getFiltered($classesAndInterfaces) as $class) {
-            if (!empty(getenv('PECL')) && BasePHPElement::classExistInCoreReflection($class)) {
-                continue;
-            }
             foreach (self::getFilteredConstants($class) as $constant) {
                 yield "constant $class->name::$constant->name" => [$class, $constant];
             }

--- a/tests/TestData/Providers/Reflection/ReflectionFunctionsProvider.php
+++ b/tests/TestData/Providers/Reflection/ReflectionFunctionsProvider.php
@@ -13,9 +13,6 @@ class ReflectionFunctionsProvider
     public static function allFunctionsProvider(): ?Generator
     {
         foreach (EntitiesFilter::getFiltered(ReflectionStubsSingleton::getReflectionStubs()->getFunctions()) as $function) {
-            if (!empty(getenv('PECL')) && !empty(ReflectionStubsSingleton::getReflectionStubsNoPecl()->getFunction($function->name))) {
-                continue;
-            }
             yield "function $function->name" => [$function];
         }
     }
@@ -27,9 +24,6 @@ class ReflectionFunctionsProvider
             null,
             StubProblemType::FUNCTION_IS_DEPRECATED
         ) as $function) {
-            if (!empty(getenv('PECL')) && !empty(ReflectionStubsSingleton::getReflectionStubsNoPecl()->getFunction($function->name))) {
-                continue;
-            }
             yield "function $function->name" => [$function];
         }
     }
@@ -42,9 +36,6 @@ class ReflectionFunctionsProvider
             StubProblemType::FUNCTION_PARAMETER_MISMATCH,
             StubProblemType::HAS_DUPLICATION
         ) as $function) {
-            if (!empty(getenv('PECL')) && !empty(ReflectionStubsSingleton::getReflectionStubsNoPecl()->getFunction($function->name))) {
-                continue;
-            }
             yield "function $function->name" => [$function];
         }
     }

--- a/tests/TestData/Providers/Reflection/ReflectionMethodsProvider.php
+++ b/tests/TestData/Providers/Reflection/ReflectionMethodsProvider.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace StubTests\TestData\Providers\Reflection;
 
 use Generator;
-use StubTests\Model\BasePHPElement;
 use StubTests\Model\StubProblemType;
 use StubTests\TestData\Providers\EntitiesFilter;
 use StubTests\TestData\Providers\ReflectionStubsSingleton;
@@ -49,9 +48,6 @@ class ReflectionMethodsProvider
         $classesAndInterfaces = ReflectionStubsSingleton::getReflectionStubs()->getClasses() +
             ReflectionStubsSingleton::getReflectionStubs()->getInterfaces();
         foreach (EntitiesFilter::getFiltered($classesAndInterfaces) as $class) {
-            if (!empty(getenv('PECL')) && BasePHPElement::classExistInCoreReflection($class)) {
-                continue;
-            }
             foreach (EntitiesFilter::getFiltered($class->methods, null, ...$problemTypes) as $method) {
                 yield "Method $class->name::$method->name" => [$class, $method];
             }

--- a/tests/TestData/Providers/Reflection/ReflectionParametersProvider.php
+++ b/tests/TestData/Providers/Reflection/ReflectionParametersProvider.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace StubTests\TestData\Providers\Reflection;
 
 use Generator;
-use StubTests\Model\BasePHPElement;
 use StubTests\Model\PHPParameter;
 use StubTests\Model\StubProblemType;
 use StubTests\TestData\Providers\EntitiesFilter;
@@ -15,9 +14,6 @@ class ReflectionParametersProvider
     public static function functionParametersProvider(): ?Generator
     {
         foreach (EntitiesFilter::getFilteredFunctions() as $function) {
-            if (!empty(getenv('PECL')) && !empty(ReflectionStubsSingleton::getReflectionStubsNoPecl()->getFunction($function->name))) {
-                continue;
-            }
             $PHPParameters = EntitiesFilter::getFilteredParameters(
                 $function,
                 null
@@ -31,9 +27,6 @@ class ReflectionParametersProvider
     public static function functionParametersWithTypeProvider(): ?Generator
     {
         foreach (EntitiesFilter::getFilteredFunctions() as $function) {
-            if (!empty(getenv('PECL')) && !empty(ReflectionStubsSingleton::getReflectionStubsNoPecl()->getFunction($function->name))) {
-                continue;
-            }
             foreach (EntitiesFilter::getFilteredParameters(
                 $function,
                 null,
@@ -47,9 +40,6 @@ class ReflectionParametersProvider
     public static function functionOptionalParametersProvider(): ?Generator
     {
         foreach (EntitiesFilter::getFilteredFunctions() as $function) {
-            if (!empty(getenv('PECL')) && !empty(ReflectionStubsSingleton::getReflectionStubsNoPecl()->getFunction($function->name))) {
-                continue;
-            }
             foreach (EntitiesFilter::getFilteredParameters(
                 $function,
                 fn (PHPParameter $parameter) => !$parameter->isOptional,
@@ -64,9 +54,6 @@ class ReflectionParametersProvider
     public static function functionOptionalParametersWithDefaultValueProvider(): ?Generator
     {
         foreach (EntitiesFilter::getFilteredFunctions() as $function) {
-            if (!empty(getenv('PECL')) && !empty(ReflectionStubsSingleton::getReflectionStubsNoPecl()->getFunction($function->name))) {
-                continue;
-            }
             foreach (EntitiesFilter::getFilteredParameters(
                 $function,
                 fn (PHPParameter $parameter) => !$parameter->isOptional || empty($parameter->defaultValue),
@@ -82,9 +69,6 @@ class ReflectionParametersProvider
         $classesAndInterfaces = ReflectionStubsSingleton::getReflectionStubs()->getClasses() +
             ReflectionStubsSingleton::getReflectionStubs()->getInterfaces();
         foreach (EntitiesFilter::getFiltered($classesAndInterfaces) as $class) {
-            if (!empty(getenv('PECL')) && BasePHPElement::classExistInCoreReflection($class)) {
-                continue;
-            }
             //exclude classes from PHPReflectionParser
             if (strncmp($class->name, 'PHP', 3) !== 0) {
                 foreach (EntitiesFilter::getFilteredFunctions($class) as $method) {
@@ -101,9 +85,6 @@ class ReflectionParametersProvider
         $classesAndInterfaces = ReflectionStubsSingleton::getReflectionStubs()->getClasses() +
             ReflectionStubsSingleton::getReflectionStubs()->getInterfaces();
         foreach (EntitiesFilter::getFiltered($classesAndInterfaces) as $class) {
-            if (!empty(getenv('PECL')) && BasePHPElement::classExistInCoreReflection($class)) {
-                continue;
-            }
             //exclude classes from PHPReflectionParser
             if (strncmp($class->name, 'PHP', 3) !== 0) {
                 foreach (EntitiesFilter::getFilteredFunctions($class) as $method) {
@@ -124,9 +105,6 @@ class ReflectionParametersProvider
         $classesAndInterfaces = ReflectionStubsSingleton::getReflectionStubs()->getClasses() +
             ReflectionStubsSingleton::getReflectionStubs()->getInterfaces();
         foreach (EntitiesFilter::getFiltered($classesAndInterfaces) as $class) {
-            if (!empty(getenv('PECL')) && BasePHPElement::classExistInCoreReflection($class)) {
-                continue;
-            }
             //exclude classes from PHPReflectionParser
             if (strncmp($class->name, 'PHP', 3) !== 0) {
                 foreach (EntitiesFilter::getFilteredFunctions($class) as $method) {

--- a/tests/TestData/Providers/Reflection/ReflectionPropertiesProvider.php
+++ b/tests/TestData/Providers/Reflection/ReflectionPropertiesProvider.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace StubTests\TestData\Providers\Reflection;
 
 use Generator;
-use StubTests\Model\BasePHPElement;
 use StubTests\Model\PHPProperty;
 use StubTests\Model\StubProblemType;
 use StubTests\TestData\Providers\EntitiesFilter;
@@ -41,9 +40,6 @@ class ReflectionPropertiesProvider
     {
         $classesAndInterfaces = ReflectionStubsSingleton::getReflectionStubs()->getClasses();
         foreach (EntitiesFilter::getFiltered($classesAndInterfaces) as $class) {
-            if (!empty(getenv('PECL')) && BasePHPElement::classExistInCoreReflection($class)) {
-                continue;
-            }
             foreach (EntitiesFilter::getFiltered(
                 $class->properties,
                 fn (PHPProperty $property) => $property->access === 'private',

--- a/tests/TestData/Providers/ReflectionStubsSingleton.php
+++ b/tests/TestData/Providers/ReflectionStubsSingleton.php
@@ -11,12 +11,7 @@ class ReflectionStubsSingleton
     /**
      * @var StubsContainer|null
      */
-    private static $reflectionStubs = null;
-
-    /**
-     * @var StubsContainer|null
-     */
-    private static $reflectionStubsNoPecl = null;
+    private static $reflectionStubs;
 
     public static function getReflectionStubs(): StubsContainer
     {
@@ -24,15 +19,5 @@ class ReflectionStubsSingleton
             self::$reflectionStubs = PHPReflectionParser::getStubs();
         }
         return self::$reflectionStubs;
-    }
-
-    public static function getReflectionStubsNoPecl(): StubsContainer
-    {
-        if (self::$reflectionStubsNoPecl === null) {
-            if (file_exists(__DIR__ . '/../../../ReflectionDataNoPecl.json')) {
-                self::$reflectionStubsNoPecl = unserialize(file_get_contents(__DIR__ . '/../../../ReflectionDataNoPecl.json'));
-            }
-        }
-        return self::$reflectionStubsNoPecl;
     }
 }

--- a/tests/TestData/Providers/Stubs/StubsParametersProvider.php
+++ b/tests/TestData/Providers/Stubs/StubsParametersProvider.php
@@ -5,7 +5,6 @@ namespace StubTests\TestData\Providers\Stubs;
 
 use Generator;
 use RuntimeException;
-use StubTests\Model\BasePHPElement;
 use StubTests\Model\StubProblemType;
 use StubTests\Parsers\ParserUtils;
 use StubTests\TestData\Providers\EntitiesFilter;
@@ -75,9 +74,6 @@ class StubsParametersProvider
         $coreClassesAndInterfaces = PhpStormStubsSingleton::getPhpStormStubs()->getCoreClasses() +
             PhpStormStubsSingleton::getPhpStormStubs()->getCoreInterfaces();
         foreach (EntitiesFilter::getFiltered($coreClassesAndInterfaces) as $class) {
-            if (!empty(getenv('PECL')) && BasePHPElement::classExistInCoreReflection($class)) {
-                continue;
-            }
             foreach (EntitiesFilter::getFilteredFunctions($class, false) as $method) {
                 foreach (EntitiesFilter::getFilteredParameters($method, null, ...$problemTypes) as $parameter) {
                     if (!empty($parameter->availableVersionsRangeFromAttribute)) {

--- a/tests/Tools/dump-pecl-to-file.php
+++ b/tests/Tools/dump-pecl-to-file.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+use StubTests\Model\StubsContainer;
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+/** @var StubsContainer $coreStubs */
+$coreStubs = unserialize(file_get_contents(__DIR__ . '/../../ReflectionData.json'), ['allowed_classes' => true]);
+/** @var StubsContainer $peclAndCoreStubs */
+$peclAndCoreStubs = unserialize(file_get_contents(__DIR__ . '/../../ReflectionDataPecl.json'), ['allowed_classes' => true]);
+$onlyPeclStubs = new StubsContainer();
+foreach ($peclAndCoreStubs->getConstants() as $peclConstant) {
+    if (empty(array_filter($coreStubs->getConstants(), fn ($constant) => $constant->name === $peclConstant->name))) {
+        $onlyPeclStubs->addConstant($peclConstant);
+    }
+}
+foreach ($peclAndCoreStubs->getClasses() as $peclClass) {
+    if (empty(array_filter($coreStubs->getClasses(), fn ($class) => $class->name === $peclClass->name))) {
+        $onlyPeclStubs->addClass($peclClass);
+    }
+}
+foreach ($peclAndCoreStubs->getFunctions() as $peclFunction) {
+    if (empty(array_filter($coreStubs->getFunctions(), fn ($function) => $function->name === $peclFunction->name))) {
+        $onlyPeclStubs->addFunction($peclFunction);
+    }
+}
+foreach ($peclAndCoreStubs->getInterfaces() as $peclInterface) {
+    if (empty(array_filter($coreStubs->getInterfaces(), fn ($interface) => $interface->name === $peclInterface->name))) {
+        $onlyPeclStubs->addInterface($peclInterface);
+    }
+}
+file_put_contents(__DIR__ . '/../../ReflectionData.json', serialize($onlyPeclStubs));

--- a/tests/Tools/dump-reflection-to-file.php
+++ b/tests/Tools/dump-reflection-to-file.php
@@ -7,8 +7,5 @@ require_once __DIR__ . '/../../vendor/autoload.php';
 
 use StubTests\TestData\Providers\ReflectionStubsSingleton;
 
-if (empty(getenv('NO_PECL'))) {
-    file_put_contents(__DIR__ . '/../../ReflectionData.json', serialize(ReflectionStubsSingleton::getReflectionStubs()));
-} else {
-    file_put_contents(__DIR__ . '/../../ReflectionDataNoPecl.json', serialize(ReflectionStubsSingleton::getReflectionStubs()));
-}
+$reflectionFileName = $argv[1];
+file_put_contents(__DIR__ . "/../../$reflectionFileName", serialize(ReflectionStubsSingleton::getReflectionStubs()));


### PR DESCRIPTION
Previously, to run tests against pecl extensions, pecl related entities were fetched during tests. Now we prepare pecl reflection data in advance.