### PR TITLE
preg_last_error / preg_last_error_msg are not pure

### DIFF
--- a/pcre/pcre.php
+++ b/pcre/pcre.php
@@ -497,7 +497,6 @@ function preg_grep(string $pattern, array $array, int $flags = 0): array|false {
  * <b>PREG_BAD_UTF8_ERROR</b>
  * <b>PREG_BAD_UTF8_OFFSET_ERROR</b> (since PHP 5.3.0)
  */
-#[Pure(true)]
 function preg_last_error(): int {}
 
 /**
@@ -506,7 +505,6 @@ function preg_last_error(): int {}
  * @return string one of the error messages or "No error" if there is no error.
  * @since 8.0
  */
-#[Pure(true)]
 function preg_last_error_msg(): string {}
 
 /**


### PR DESCRIPTION
`preg_last_error` and `preg_last_error_msg` are functions that definitionally read state external to them and are impure.

Their return values are completely impure and defined by the hidden state of other preg functions.