### PR TITLE
Reflector::export has been removed in 7.4

### DIFF
--- a/Reflection/Reflector.php
+++ b/Reflection/Reflector.php
@@ -1,7 +1,5 @@
 <?php
 
-use JetBrains\PhpStorm\Deprecated;
-
 /**
  * <b>Reflector</b> is an interface implemented by all
  * exportable Reflection classes.
@@ -15,9 +13,8 @@ interface Reflector extends Stringable
      *
      * @link https://php.net/manual/en/reflector.export.php
      * @return string|null
-     * @removed 8.0
+     * @removed 7.4
      */
-    #[Deprecated(since: '7.4')]
     public static function export();
 
     /**


### PR DESCRIPTION
See: https://3v4l.org/gBvAo