### PR TITLE
Fix parameter definition for Grpc\ChannelCredentials::createSsl

### DIFF
--- a/grpc/grpc.php
+++ b/grpc/grpc.php
@@ -506,17 +506,17 @@ namespace Grpc;
         /**
          * Create SSL credentials.
          *
-         * @param string $pem_root_certs  PEM encoding of the server root certificates
-         * @param string $pem_private_key PEM encoding of the client's private key
-         * @param string $pem_cert_chain  PEM encoding of the client's certificate chain
+         * @param string|null $pem_root_certs  PEM encoding of the server root certificates
+         * @param string|null $pem_private_key PEM encoding of the client's private key
+         * @param string|null $pem_cert_chain  PEM encoding of the client's certificate chain
          *
          * @return ChannelCredentials The new SSL credentials object
          * @throws \InvalidArgumentException
          */
         public static function createSsl(
-            $pem_root_certs = '',
-            $pem_private_key = '',
-            $pem_cert_chain = ''
+            string $pem_root_certs = null,
+            string $pem_private_key = null,
+            string $pem_cert_chain = null
         ) {}
 
         /**


### PR DESCRIPTION
This PR contains two fixes.

1.  https://github.com/grpc/grpc/blob/master/src/php/ext/grpc/channel_credentials.c#L157
```c
  char *pem_root_certs = NULL;
  grpc_ssl_pem_key_cert_pair pem_key_cert_pair;

  php_grpc_int root_certs_length = 0;
  php_grpc_int private_key_length = 0;
  php_grpc_int cert_chain_length = 0;

  pem_key_cert_pair.private_key = pem_key_cert_pair.cert_chain = NULL;
```
In PhpDoc the default value is the empty string, but in the actual C code the default value is null


2. https://github.com/grpc/grpc/blob/master/src/php/ext/grpc/channel_credentials.c#L161
```
 /* "|s!s!s!" == 3 optional nullable strings */
  if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|s!s!s!",
```
`|s!s!s!` In `zend_parse_parameters` used in the method indicates that "all are optional and nullable", and the source code seems to work that way 🐔

---
PhpDoc fix is currently under review

grpc/grpc#27283
