### PR TITLE
Change php-cs-fixer to "dev-master" instead of "@stable" to parse 8.1 readonly properties

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "nikic/php-parser": "@stable",
     "phpdocumentor/reflection-docblock": "@stable",
     "phpunit/phpunit": "@stable",
-    "friendsofphp/php-cs-fixer": "@stable"
+    "friendsofphp/php-cs-fixer": "dev-master"
   },
   "autoload": {
     "files": ["PhpStormStubsMap.php"]


### PR DESCRIPTION
The changes were tested locally on PHP 8.1 beta.
This is to support PHP CS Fixer runs for https://github.com/JetBrains/phpstorm-stubs/pull/1205