### PR TITLE
Add pure attribute to filesystem functions

### DIFF
--- a/standard/standard_1.php
+++ b/standard/standard_1.php
@@ -258,7 +258,7 @@ function dirname(string $path, int $levels = 1): string {}
  * If options is used, this function will return a
  * string if not all elements are requested.
  */
-#[Pure]
+#[Pure(true)]
 function pathinfo(string $path, int $flags = PATHINFO_ALL): array|string {}
 
 /**

--- a/standard/standard_2.php
+++ b/standard/standard_2.php
@@ -590,6 +590,7 @@ function http_build_query(object|array $data, string $numeric_prefix = "", ?stri
  * </p>
  * @return string|false the contents of the symbolic link path or false on error.
  */
+#[Pure(true)]
 function readlink(string $path): string|false {}
 
 /**
@@ -602,7 +603,7 @@ function readlink(string $path): string|false {}
  * of the Unix C stat structure returned by the lstat
  * system call. Returns 0 or false in case of error.
  */
-#[Pure]
+#[Pure(true)]
 function linkinfo(string $path): int|false {}
 
 /**

--- a/standard/standard_4.php
+++ b/standard/standard_4.php
@@ -790,6 +790,7 @@ function ignore_user_abort(?bool $enable): int {}
  * @return array|false The settings are returned as an associative array on success,
  * and false on failure.
  */
+#[Pure(true)]
 function parse_ini_file(string $filename, bool $process_sections = false, int $scanner_mode = INI_SCANNER_NORMAL): array|false {}
 
 /**
@@ -823,7 +824,7 @@ function parse_ini_string(string $ini_string, bool $process_sections = false, in
  * </p>
  * @return bool true on success or false on failure.
  */
-#[Pure]
+#[Pure(true)]
 function is_uploaded_file(string $filename): bool {}
 
 /**

--- a/standard/standard_5.php
+++ b/standard/standard_5.php
@@ -454,6 +454,7 @@ function fclose($stream): bool {}
  * @return bool true if the file pointer is at EOF or an error occurs
  * (including socket timeout); otherwise returns false.
  */
+#[Pure(true)]
 function feof($stream): bool {}
 
 /**
@@ -748,6 +749,7 @@ function ftruncate($stream, int $size): bool {}
  * @return array|false an array with the statistics of the file; the format of the array
  * is described in detail on the stat manual page.
  */
+#[Pure(true)]
 function fstat($stream): array|false {}
 
 /**
@@ -793,6 +795,7 @@ function fseek($stream, int $offset, int $whence = SEEK_SET): int {}
  * <p>
  * If an error occurs, returns false.
  */
+#[Pure(true)]
 function ftell($stream): int|false {}
 
 /**
@@ -982,6 +985,7 @@ function tmpfile() {}
  * present.
  * </p>
  */
+#[Pure(true)]
 function file(string $filename, int $flags, $context): array|false {}
 
 /**
@@ -1008,6 +1012,7 @@ function file(string $filename, int $flags, $context): array|false {}
  * </p>
  * @return string|false The function returns the read data or false on failure.
  */
+#[Pure(true)]
 function file_get_contents(string $filename, bool $use_include_path = false, $context, int $offset = 0, ?int $length): string|false {}
 
 /**

--- a/standard/standard_6.php
+++ b/standard/standard_6.php
@@ -1198,4 +1198,5 @@ function realpath(string $path): string|false {}
  * </p>
  * @return bool true if there is a match, false otherwise.
  */
+#[Pure]
 function fnmatch(string $pattern, string $filename, int $flags): bool {}

--- a/standard/standard_7.php
+++ b/standard/standard_7.php
@@ -433,7 +433,7 @@ function scandir(string $directory, int $sorting_order, $context): array|false {
  * On some systems it is impossible to distinguish between empty match and an
  * error.</p>
  */
-#[Pure]
+#[Pure(true)]
 function glob(string $pattern, int $flags): array|false {}
 
 /**
@@ -445,7 +445,7 @@ function glob(string $pattern, int $flags): array|false {}
  * @return int|false the time the file was last accessed, or false on failure.
  * The time is returned as a Unix timestamp.
  */
-#[Pure]
+#[Pure(true)]
 function fileatime(string $filename): int|false {}
 
 /**
@@ -457,7 +457,7 @@ function fileatime(string $filename): int|false {}
  * @return int|false the time the file was last changed, or false on failure.
  * The time is returned as a Unix timestamp.
  */
-#[Pure]
+#[Pure(true)]
 function filectime(string $filename): int|false {}
 
 /**
@@ -471,7 +471,7 @@ function filectime(string $filename): int|false {}
  * posix_getgrgid to resolve it to a group name.
  * Upon failure, false is returned.
  */
-#[Pure]
+#[Pure(true)]
 function filegroup(string $filename): int|false {}
 
 /**
@@ -482,7 +482,7 @@ function filegroup(string $filename): int|false {}
  * </p>
  * @return int|false the inode number of the file, or false on failure.
  */
-#[Pure]
+#[Pure(true)]
 function fileinode(string $filename): int|false {}
 
 /**
@@ -495,7 +495,7 @@ function fileinode(string $filename): int|false {}
  * The time is returned as a Unix timestamp, which is
  * suitable for the date function.
  */
-#[Pure]
+#[Pure(true)]
 function filemtime(string $filename): int|false {}
 
 /**
@@ -508,7 +508,7 @@ function filemtime(string $filename): int|false {}
  * The user ID is returned in numerical format, use
  * posix_getpwuid to resolve it to a username.
  */
-#[Pure]
+#[Pure(true)]
 function fileowner(string $filename): int|false {}
 
 /**
@@ -519,7 +519,7 @@ function fileowner(string $filename): int|false {}
  * </p>
  * @return int|false the permissions on the file, or false on failure.
  */
-#[Pure]
+#[Pure(true)]
 function fileperms(string $filename): int|false {}
 
 /**
@@ -531,7 +531,7 @@ function fileperms(string $filename): int|false {}
  * @return int|false the size of the file in bytes, or false (and generates an error
  * of level E_WARNING) in case of an error.
  */
-#[Pure]
+#[Pure(true)]
 function filesize(string $filename): int|false {}
 
 /**
@@ -548,7 +548,7 @@ function filesize(string $filename): int|false {}
  * produce an E_NOTICE message if the stat call fails
  * or if the file type is unknown.
  */
-#[Pure]
+#[Pure(true)]
 function filetype(string $filename): string|false {}
 
 /**
@@ -614,7 +614,7 @@ function is_writeable(string $filename): bool {}
  * @return bool true if the file or directory specified by
  * filename exists and is readable, false otherwise.
  */
-#[Pure]
+#[Pure(true)]
 function is_readable(string $filename): bool {}
 
 /**
@@ -626,7 +626,7 @@ function is_readable(string $filename): bool {}
  * @return bool true if the filename exists and is executable, or false on
  * error.
  */
-#[Pure]
+#[Pure(true)]
 function is_executable(string $filename): bool {}
 
 /**
@@ -665,7 +665,7 @@ function is_dir(string $filename): bool {}
  * @return bool true if the filename exists and is a symbolic link, false
  * otherwise.
  */
-#[Pure]
+#[Pure(true)]
 function is_link(string $filename): bool {}
 
 /**
@@ -757,7 +757,7 @@ function is_link(string $filename): bool {}
  * <p>
  * In case of error, stat returns false.
  */
-#[Pure]
+#[Pure(true)]
 function stat(string $filename): array|false {}
 
 /**
@@ -774,7 +774,7 @@ function stat(string $filename): array|false {}
  * link, the status of the symbolic link is returned, not the status of the
  * file pointed to by the symbolic link.
  */
-#[Pure]
+#[Pure(true)]
 function lstat(string $filename): array|false {}
 
 /**
@@ -908,6 +908,7 @@ function clearstatcache(bool $clear_realpath_cache = false, string $filename): v
  * @return float|false the total number of bytes as a float
  * or false on failure.
  */
+#[Pure(true)]
 function disk_total_space(string $directory): float|false {}
 
 /**

--- a/standard/standard_9.php
+++ b/standard/standard_9.php
@@ -1252,7 +1252,7 @@ function sys_get_temp_dir(): string {}
  * the cache.
  * @since 5.3.2
  */
-#[Pure]
+#[Pure(true)]
 function realpath_cache_get(): array {}
 
 /**
@@ -1261,7 +1261,7 @@ function realpath_cache_get(): array {}
  * @return int Returns how much memory realpath cache is using.
  * @since 5.3.2
  */
-#[Pure]
+#[Pure(true)]
 function realpath_cache_size(): int {}
 
 /**


### PR DESCRIPTION
Adds the 'Pure' attribute to filesystem functions where it was missing. Also sets the `$mayDependOnGlobalScope` flag where appropriate.