### PR TITLE
[phpstorm-stubs] remove Pure attribute on rand functions that can change global state

### DIFF
--- a/gmp/gmp.php
+++ b/gmp/gmp.php
@@ -391,7 +391,6 @@ function gmp_prob_prime(GMP|string|int $num, int $repetitions = 10): int {}
  * or a numeric string provided that it is possible to convert the latter to a number.</p>
  * @return GMP A random GMP number.
  */
-#[Pure(true)]
 function gmp_random_bits(int $bits): GMP {}
 
 /**
@@ -401,7 +400,6 @@ function gmp_random_bits(int $bits): GMP {}
  * @param GMP|string|int $max <p>A GMP number representing the upper bound for the random number</p>
  * @return GMP A random GMP number.
  */
-#[Pure(true)]
 function gmp_random_range(GMP|string|int $min, GMP|string|int $max): GMP {}
 
 /**

--- a/standard/standard_1.php
+++ b/standard/standard_1.php
@@ -358,7 +358,6 @@ function strrchr(string $haystack, string $needle): string|false {}
  * </p>
  * @return string the shuffled string.
  */
-#[Pure]
 function str_shuffle(string $string): string {}
 
 /**

--- a/standard/standard_2.php
+++ b/standard/standard_2.php
@@ -932,7 +932,6 @@ function proc_nice(int $priority): bool {}
  * @return int A pseudo random value between min
  * (or 0) and max (or getrandmax, inclusive).
  */
-#[Pure(true)]
 function rand(int $min = 0, int $max): int {}
 
 /**
@@ -971,7 +970,6 @@ function getrandmax(): int {}
  * @return int A random integer value between min (or 0)
  * and max (or mt_getrandmax, inclusive)
  */
-#[Pure(true)]
 function mt_rand(int $min = 0, int $max): int {}
 
 /**

--- a/standard/standard_9.php
+++ b/standard/standard_9.php
@@ -223,7 +223,6 @@ function array_change_key_case(array $array, int $case): array {}
  * of keys for the random entries. This is done so that you can pick
  * random keys as well as values out of the array.
  */
-#[Pure(true)]
 function array_rand(array $array, int $num = 1): array|string|int {}
 
 /**


### PR DESCRIPTION
mt_rand both reads and modifies global RNG state internally.  random_int()/random_bytes() would modify OS-level state. gmp_random_* modify random state in GMP. array_rand, shuffle, str_shuffle are the same. They all effectively call mt_rand() internally and change state