### PR TITLE
Fix documentation link

### DIFF
--- a/Reflection/ReflectionNamedType.php
+++ b/Reflection/ReflectionNamedType.php
@@ -21,7 +21,7 @@ class ReflectionNamedType extends ReflectionType
     /**
      * Checks if it is a built-in type
      *
-     * @link https://php.net/manual/en/reflectiontype.isbuiltin.php
+     * @link https://php.net/manual/en/reflectionnamedtype.isbuiltin.php
      * @return bool Returns {@see true} if it's a built-in type, otherwise {@see false}
      *
      * @since 7.1 overrides the parent {@see ReflectionType::isBuiltin()} method.


### PR DESCRIPTION
The old docs page doesn't exist anymore, as the method was moved to `ReflectionNamedType`.