### PR TITLE
Revert "Closure::__invoke() does not have any parameters in PHP"

### DIFF
--- a/Core/Core_c.php
+++ b/Core/Core_c.php
@@ -634,10 +634,11 @@ final class Closure
     /**
      * This is for consistency with other classes that implement calling magic,
      * as this method is not used for calling the function.
+     * @param mixed ...$_ [optional]
      * @return mixed
      * @link https://secure.php.net/manual/en/class.closure.php
      */
-    public function __invoke() {}
+    public function __invoke(...$_) {}
 
     /**
      * Duplicates the closure with a new bound object and class scope

--- a/tests/TestData/mutedProblems.json
+++ b/tests/TestData/mutedProblems.json
@@ -2936,6 +2936,22 @@
       ]
     },
     {
+      "name": "Closure",
+      "methods": [
+        {
+          "name": "__invoke",
+          "problems": [
+            {
+              "description": "parameter mismatch",
+              "versions": [
+                "ALL"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
       "name": "SyncEvent",
       "methods": [
         {


### PR DESCRIPTION
This reverts commit ec24a9ac53b5b4cc258dd457aab42781e7763df1.
Closure object can be called with parameters despite reflection doesn't return any parameter
```
<?php
function testClosure(Closure $cb, $param) { var_dump($cb($param));}
testClosure($cb = fn($param) => $param,1);
```