### PR TITLE
Fix `preg_quote` signature

### DIFF
--- a/pcre/pcre.php
+++ b/pcre/pcre.php
@@ -466,7 +466,7 @@ function preg_split(string $pattern, string $subject, int $limit = -1, int $flag
  * @return string the quoted (escaped) string.
  */
 #[Pure]
-function preg_quote(string $str, ?string $delimiter): string {}
+function preg_quote(string $str, ?string $delimiter = null): string {}
 
 /**
  * Return array entries that match the pattern


### PR DESCRIPTION
The secont parameter has default `null` value:
https://www.php.net/preg_quote