### PR TITLE
Fix some type hinting errors in the RedisCluster stub

### DIFF
--- a/redis/RedisCluster.php
+++ b/redis/RedisCluster.php
@@ -2916,7 +2916,7 @@ class RedisCluster
      *            a RedisCluster::PIPELINE block is simply transmitted faster to the server, but without any guarantee
      *            of atomicity. discard cancels a transaction.
      *
-     * @return Redis returns the Redis instance and enters multi-mode.
+     * @return RedisCluster returns the Redis instance and enters multi-mode.
      * Once in multi-mode, all subsequent method calls return the same object until exec() is called.
      * @link    https://redis.io/commands/multi
      * @example

--- a/redis/RedisCluster.php
+++ b/redis/RedisCluster.php
@@ -97,6 +97,7 @@ class RedisCluster
      * // redis.clusters.seeds = "mycluster[]=localhost:7000&test[]=localhost:7001"
      * // redis.clusters.timeout = "mycluster=5"
      * // redis.clusters.read_timeout = "mycluster=10"
+     * // redis.clusters.auth = "mycluster=password" OR ['user' => 'foo', 'pass' => 'bar] as example
      *
      * //Then, this cluster can be loaded by doing the following
      *
@@ -107,7 +108,7 @@ class RedisCluster
     public function __construct($name, $seeds, $timeout = null, $readTimeout = null, $persistent = false, $auth = null) {}
 
     /**
-     * Disconnects from the Redis instance, except when pconnect is used.
+     * Disconnects from the RedisCluster instance, except when pconnect is used.
      */
     public function close() {}
 
@@ -2916,7 +2917,7 @@ class RedisCluster
      *            a RedisCluster::PIPELINE block is simply transmitted faster to the server, but without any guarantee
      *            of atomicity. discard cancels a transaction.
      *
-     * @return RedisCluster returns the Redis instance and enters multi-mode.
+     * @return RedisCluster returns the RedisCluster instance and enters multi-mode.
      * Once in multi-mode, all subsequent method calls return the same object until exec() is called.
      * @link    https://redis.io/commands/multi
      * @example
@@ -3268,7 +3269,7 @@ class RedisCluster
      *
      * @param string|array $nodeParams key or [host,port]
      *
-     * @return  string STRING: +PONG on success. Throws a RedisException object on connectivity error, as described
+     * @return  string STRING: +PONG on success. Throws a RedisClusterException object on connectivity error, as described
      *                 above.
      * @link    https://redis.io/commands/ping
      */


### PR DESCRIPTION
- The multi() method should return a RedisCluster instance, not a Redis one
- Fixed a similar issue for a thrown exception class name
- added the `redis.clusters.auth` line

Those changes are from https://github.com/zgb7mtr/phpredis_cluster_phpdoc/blob/master/src/RedisCluster.php , which is the base file that was used for this stub.