### PR TITLE
Flag functions that are marked pure that depend on external state

### DIFF
--- a/Core/Core.php
+++ b/Core/Core.php
@@ -724,7 +724,7 @@ function get_declared_classes(): array {}
  * @return string[] an array of the names of the declared interfaces in the current
  * script.
  */
-#[Pure]
+#[Pure(true)]
 function get_declared_interfaces(): array {}
 
 /**
@@ -734,7 +734,7 @@ function get_declared_interfaces(): array {}
  * @see class_uses()
  * @since 5.4
  */
-#[Pure]
+#[Pure(true)]
 function get_declared_traits(): array {}
 
 /**
@@ -747,7 +747,7 @@ function get_declared_traits(): array {}
  * the user defined ones using $arr["user"] (see example
  * below).
  */
-#[Pure]
+#[Pure(true)]
 function get_defined_functions(#[PhpStormStubsElementAvailable(from: '7.1')] bool $exclude_disabled = true): array {}
 
 /**
@@ -755,7 +755,7 @@ function get_defined_functions(#[PhpStormStubsElementAvailable(from: '7.1')] boo
  * @link https://php.net/manual/en/function.get-defined-vars.php
  * @return array A multidimensional array with all the variables.
  */
-#[Pure]
+#[Pure(true)]
 function get_defined_vars(): array {}
 
 /**
@@ -1041,7 +1041,7 @@ function gc_collect_cycles(): int {}
  * @link https://php.net/manual/en/function.gc-enabled.php
  * @return bool true if the garbage collector is enabled, false otherwise.
  */
-#[Pure]
+#[Pure(true)]
 function gc_enabled(): bool {}
 
 /**
@@ -1071,7 +1071,7 @@ function gc_disable(): void {}
  * @since 7.3
  */
 #[ArrayShape(["runs" => "int", "collected" => "int", "threshold" => "int", "roots" => "int"])]
-#[Pure]
+#[Pure(true)]
 function gc_status(): array {}
 
 /**
@@ -1096,5 +1096,5 @@ function gc_mem_caches(): int {}
  * @return resource[] Returns an array of currently active resources, indexed by resource number.
  * @since 7.0
  */
-#[Pure]
+#[Pure(true)]
 function get_resources(?string $type): array {}

--- a/standard/basic.php
+++ b/standard/basic.php
@@ -57,7 +57,7 @@ function cli_set_process_title(string $title): bool {}
  * @return string|null Return a string with the current process title or <b>NULL</b> on error.
  * @since 5.5
  */
-#[Pure]
+#[Pure(true)]
 function cli_get_process_title(): ?string {}
 
 /**

--- a/standard/standard_0.php
+++ b/standard/standard_0.php
@@ -147,7 +147,7 @@ class Directory
  * @return mixed the value of the constant, or null if the constant is not
  * defined.
  */
-#[Pure]
+#[Pure(true)]
 function constant(string $name): mixed {}
 
 /**
@@ -279,7 +279,7 @@ function time_sleep_until(float $timestamp): bool {}
  * </p>
  * @deprecated 8.1
  */
-#[Pure]
+#[Pure(true)]
 #[Deprecated(since: '8.1')]
 function strptime(string $timestamp, string $format): array|false {}
 
@@ -759,7 +759,7 @@ function sha1(string $string, bool $binary = false): string {}
  * </p>
  * @return string|false a string on success, false otherwise.
  */
-#[Pure]
+#[Pure(true)]
 function sha1_file(string $filename, bool $binary = false): string|false {}
 
 /**
@@ -790,7 +790,7 @@ function md5(string $string, bool $binary = false): string {}
  * </p>
  * @return string|false a string on success, false otherwise.
  */
-#[Pure]
+#[Pure(true)]
 function md5_file(string $filename, bool $binary = false): string|false {}
 
 /**
@@ -1224,7 +1224,7 @@ function php_sapi_name(): string|false {}
  * the sequence "s n r v m".</p>
  * @return string the description, as a string.
  */
-#[Pure]
+#[Pure(true)]
 function php_uname(string $mode = 'a'): string {}
 
 /**

--- a/standard/standard_1.php
+++ b/standard/standard_1.php
@@ -1222,5 +1222,5 @@ function setlocale(
  * element should be used.
  */
 #[ArrayShape(["decimal_point" => "string", "thousands_sep" => "string", "grouping" => "array", "int_curr_symbol" => "string", "currency_symbol" => "string", "mon_decimal_point" => "string", "mon_thousands_sep" => "string", "mon_grouping" => "string", "positive_sign" => "string", "negative_sign" => "string", "int_frac_digits" => "string", "frac_digits" => "string", "p_cs_precedes" => "bool", "p_sep_by_space" => "bool", "n_cs_precedes" => "bool", "n_sep_by_space" => "bool", "p_sign_posn" => "int", "n_sign_posn" => "int"])]
-#[Pure]
+#[Pure(true)]
 function localeconv(): array {}

--- a/standard/standard_2.php
+++ b/standard/standard_2.php
@@ -151,7 +151,7 @@ use JetBrains\PhpStorm\Pure;
  * @return string|false the element as a string, or false if item
  * is not valid.
  */
-#[Pure]
+#[Pure(true)]
 function nl_langinfo(int $item): string|false {}
 
 /**

--- a/standard/standard_3.php
+++ b/standard/standard_3.php
@@ -883,7 +883,6 @@ function getrusage(int $mode): array|false {}
  * </p>
  * @return string the unique identifier, as a string.
  */
-#[Pure]
 function uniqid(string $prefix = "", bool $more_entropy = false): string {}
 
 /**

--- a/standard/standard_3.php
+++ b/standard/standard_3.php
@@ -14,7 +14,7 @@ use JetBrains\PhpStorm\Pure;
  * page. The value returned is a Unix timestamp, suitable for
  * feeding to date. Returns false on error.
  */
-#[Pure]
+#[Pure(true)]
 function getlastmod(): int|false {}
 
 /**
@@ -759,7 +759,7 @@ function long2ip(int $ip): string|false {}
  * varname or an associative array with all environment variables if no variable name
  * is provided, or false on an error.
  */
-#[Pure]
+#[Pure(true)]
 function getenv(
     #[PhpStormStubsElementAvailable(from: '5.3', to: '7.0')] $varname,
     #[PhpStormStubsElementAvailable(from: '7.1')] ?string $name = null,
@@ -808,7 +808,7 @@ function getopt(
  * minutes).
  * @since 5.1.3
  */
-#[Pure]
+#[Pure(true)]
 function sys_getloadavg(): array|false {}
 
 /**
@@ -846,7 +846,7 @@ function microtime(#[TypeContract(true: "float", false: "string")] bool $as_floa
  * "minuteswest" - minutes west of Greenwich
  * "dsttime" - type of dst correction
  */
-#[Pure]
+#[Pure(true)]
 #[ArrayShape(["sec" => "int", "usec" => "int", "minuteswest" => "int", "dsttime" => "int"])]
 function gettimeofday(#[TypeContract(true: "float", false: "int[]")] bool $as_float = false): array|float {}
 
@@ -860,7 +860,7 @@ function gettimeofday(#[TypeContract(true: "float", false: "int[]")] bool $as_fl
  * @return array|false an associative array containing the data returned from the system
  * call. All entries are accessible by using their documented field names.
  */
-#[Pure]
+#[Pure(true)]
 function getrusage(int $mode): array|false {}
 
 /**
@@ -935,7 +935,7 @@ function convert_cyr_string(string $str, string $from, string $to): string {}
  * @link https://php.net/manual/en/function.get-current-user.php
  * @return string the username as a string.
  */
-#[Pure]
+#[Pure(true)]
 function get_current_user(): string {}
 
 /**

--- a/standard/standard_4.php
+++ b/standard/standard_4.php
@@ -14,7 +14,7 @@ use JetBrains\PhpStorm\Pure;
  * yet.
  */
 #[ArrayShape(["type" => "int", "message" => "string", "file" => "string", "line" => "int"])]
-#[Pure]
+#[Pure(true)]
 function error_get_last(): ?array {}
 
 /**
@@ -253,7 +253,7 @@ function print_r(mixed $value, bool $return = false): string|bool {}
  * </p>
  * @return int the memory amount in bytes.
  */
-#[Pure]
+#[Pure(true)]
 function memory_get_usage(bool $real_usage = false): int {}
 
 /**
@@ -266,7 +266,7 @@ function memory_get_usage(bool $real_usage = false): int {}
  * </p>
  * @return int the memory peak in bytes.
  */
-#[Pure]
+#[Pure(true)]
 function memory_get_peak_usage(bool $real_usage = false): int {}
 
 /**
@@ -368,7 +368,7 @@ function highlight_string(string $string, bool $return = false): string|bool {}
  * @return int[]|int|float|false Returns an array of integers in the form [seconds, nanoseconds], if the parameter get_as_number is false.
  * Otherwise the nanoseconds are returned as integer (64bit platforms) or float (32bit platforms).
  */
-#[Pure]
+#[Pure(true)]
 function hrtime(
     #[PhpStormStubsElementAvailable(from: '7.3', to: '7.4')] bool $as_number,
     #[PhpStormStubsElementAvailable(from: '8.0')] bool $as_number = false
@@ -389,7 +389,7 @@ function hrtime(
  * prior behavior, see bug report
  * #29606.
  */
-#[Pure]
+#[Pure(true)]
 function php_strip_whitespace(string $filename): string {}
 
 /**
@@ -402,7 +402,7 @@ function php_strip_whitespace(string $filename): string {}
  * @return string|false the value of the configuration option as a string on success, or
  * an empty string on failure or for null values.
  */
-#[Pure]
+#[Pure(true)]
 function ini_get(string $option): string|false {}
 
 /**
@@ -438,7 +438,7 @@ function ini_get(string $option): string|false {}
  * why access shows the appropriate bitmask values.
  * </p>
  */
-#[Pure]
+#[Pure(true)]
 function ini_get_all(?string $extension, bool $details = true): array|false {}
 
 /**
@@ -486,7 +486,7 @@ function ini_restore(string $option): void {}
  * @link https://php.net/manual/en/function.get-include-path.php
  * @return string|false the path, as a string.
  */
-#[Pure]
+#[Pure(true)]
 function get_include_path(): string|false {}
 
 /**
@@ -741,7 +741,7 @@ function getallheaders(): false|array {}
  * @link https://php.net/manual/en/function.connection-aborted.php
  * @return int 1 if client disconnected, 0 otherwise.
  */
-#[Pure]
+#[Pure(true)]
 function connection_aborted(): int {}
 
 /**
@@ -751,7 +751,7 @@ function connection_aborted(): int {}
  * CONNECTION_XXX constants to determine the connection
  * status.
  */
-#[Pure]
+#[Pure(true)]
 function connection_status(): int {}
 
 /**

--- a/standard/standard_6.php
+++ b/standard/standard_6.php
@@ -710,7 +710,7 @@ function flock($stream, int $operation, &$would_block): bool {}
  * name, only the last one is returned.
  * </p>
  */
-#[Pure]
+#[Pure(true)]
 function get_meta_tags(string $filename, bool $use_include_path = false): array|false {}
 
 /**
@@ -986,7 +986,7 @@ function stream_wrapper_restore(string $protocol): bool {}
  * @return array an indexed array containing the name of all stream wrappers
  * available on the running system.
  */
-#[Pure]
+#[Pure(true)]
 function stream_get_wrappers(): array {}
 
 /**
@@ -994,7 +994,7 @@ function stream_get_wrappers(): array {}
  * @link https://php.net/manual/en/function.stream-get-transports.php
  * @return array an indexed array of socket transports names.
  */
-#[Pure]
+#[Pure(true)]
 function stream_get_transports(): array {}
 
 /**
@@ -1024,7 +1024,7 @@ function stream_is_local($stream): bool {}
  * @return array|false an indexed or associative array with the headers, or false on
  * failure.
  */
-#[Pure]
+#[Pure(true)]
 function get_headers(
     string $url,
     #[LanguageLevelTypeAware(['8.0' => 'bool'], default: 'int')] $associative = false,
@@ -1203,5 +1203,5 @@ function realpath(string $path): string|false {}
  * </p>
  * @return bool true if there is a match, false otherwise.
  */
-#[Pure]
+#[Pure(true)]
 function fnmatch(string $pattern, string $filename, int $flags): bool {}

--- a/standard/standard_7.php
+++ b/standard/standard_7.php
@@ -235,7 +235,7 @@ function unpack(
  * cookies are accepted is to set one with setcookie,
  * reload, and check for the value.
  */
-#[Pure]
+#[Pure(true)]
 function get_browser(?string $user_agent, bool $return_array = false): object|array|false {}
 
 /**

--- a/standard/standard_9.php
+++ b/standard/standard_9.php
@@ -1018,7 +1018,7 @@ function version_compare(
  * @return int On success the return value will be the created key value, otherwise
  * -1 is returned.
  */
-#[Pure]
+#[Pure(true)]
 function ftok(string $filename, string $project_id): int {}
 
 /**
@@ -1038,7 +1038,7 @@ function str_rot13(string $string): string {}
  * @return array an indexed array containing the name of all stream filters
  * available.
  */
-#[Pure]
+#[Pure(true)]
 function stream_get_filters(): array {}
 
 /**


### PR DESCRIPTION
Adds the `$mayDependOnGlobalScope` to functions which depend on external state. There are a multitude of reasons for this:

* Uses the system clock
* Reads system configuration
* Influenced by PHP ini settings
* Locale dependant
* Reads from the filesystem
* Based on PHP symbols/variable scope

Initially this started out as just adding the flag to `hrtime()` but I noticed so many other cass in the same file I went through everything marked pure in the `standard/` and `Core/` directories.
