### PR TITLE
Fix `SimpleXMLElement::children()` return type declaration

### DIFF
--- a/SimpleXML/SimpleXML.php
+++ b/SimpleXML/SimpleXML.php
@@ -140,7 +140,7 @@ class SimpleXMLElement implements Traversable, ArrayAccess, Countable, Iterator,
      * <i>ns</i> will be regarded as a namespace
      * URL.
      * </p>
-     * @return static|null a <b>SimpleXMLElement</b> element, whether the node
+     * @return static a <b>SimpleXMLElement</b> element, whether the node
      * has children or not.
      * @since 5.0.1
      */
@@ -149,7 +149,7 @@ class SimpleXMLElement implements Traversable, ArrayAccess, Countable, Iterator,
     public function children(
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $namespaceOrPrefix = null,
         #[LanguageLevelTypeAware(['8.0' => 'bool'], default: '')] $isPrefix = false
-    ): ?static {}
+    ): static {}
 
     /**
      * Returns namespaces used in document


### PR DESCRIPTION
Hey there 👋🏼,

this is my first-time contribution in this repo, so apologies if I am missing something or am not familiar with the typical workflows for reporting issues.

I noticed the return type for `SimpleXMLElement::children()` is written as nullable in the stub, but in fact the PHP.net documentation (https://www.php.net/manual/en/simplexmlelement.children.php) says it...

> Returns a SimpleXMLElement element, whether the node has children or not.

Obviously, php.net itself shows the return type as being nullable as well. So, I wonder if that's something that should be fixed upstream first and then will make its way here magically? 