### PR TITLE
Fix stringable interface

### DIFF
--- a/Core/Core_c.php
+++ b/Core/Core_c.php
@@ -799,16 +799,15 @@ final class WeakMap implements ArrayAccess, Countable, IteratorAggregate
 }
 
 /**
- * Stringable interface marks classes as available for serialization
- * in a string.
+ * Stringable interface denotes a class as having a __toString() method.
  *
  * @since 8.0
  */
 interface Stringable
 {
     /**
-     * Magic method {@see https://www.php.net/manual/en/language.oop5.magic.php}
-     * called during serialization to string.
+     * Magic method {@see https://www.php.net/manual/en/language.oop5.magic.php#object.tostring}
+     * allows a class to decide how it will react when it is treated like a string.
      *
      * @return string Returns string representation of the object that
      * implements this interface (and/or "__toString" magic method).


### PR DESCRIPTION
The `interface Stringable` stub definition doesn't match the contents published on php.net:

* https://www.php.net/manual/en/class.stringable.php
* https://www.php.net/manual/en/language.oop5.magic.php#object.tostring
* https://wiki.php.net/rfc/stringable

The stub mentions the term _serializable_, which is not even mentioned in the links provided.

