### PR TITLE
Update values of `Memcached::HAVE_**` constants

### DIFF
--- a/memcached/memcached.php
+++ b/memcached/memcached.php
@@ -50,14 +50,14 @@ class Memcached
      * <p>Type: boolean.</p>
      * @link https://php.net/manual/en/memcached.constants.php
      */
-    public const HAVE_IGBINARY = 0;
+    public const HAVE_IGBINARY = false;
 
     /**
      * <p>Indicates whether JSON serializer support is available.</p>
      * <p>Type: boolean.</p>
      * @link https://php.net/manual/en/memcached.constants.php
      */
-    public const HAVE_JSON = 0;
+    public const HAVE_JSON = false;
 
     /**
      * <p>Indicates whether msgpack serializer support is available.</p>
@@ -66,20 +66,20 @@ class Memcached
      * @since 3.0.0
      * @link https://php.net/manual/en/memcached.constants.php
      */
-    public const HAVE_MSGPACK = 0;
+    public const HAVE_MSGPACK = false;
 
     /**
      * <p>Indicate whether set_encoding_key is available</p>
      * <p>Type: boolean.</p>
      * @link https://github.com/php-memcached-dev/php-memcached/blob/v3.1.5/memcached-api.php, https://github.com/php-memcached-dev/php-memcached/blob/v3.1.5/php_memcached.c#L4387
      */
-    public const HAVE_ENCODING = 0;
+    public const HAVE_ENCODING = false;
 
     /**
      * Feature support
      */
-    public const HAVE_SESSION = 1;
-    public const HAVE_SASL = 0;
+    public const HAVE_SESSION = true;
+    public const HAVE_SASL = false;
 
     /**
      * <p>Specifies the hashing algorithm used for the item keys. The valid


### PR DESCRIPTION
Related to https://github.com/phpstan/phpstan/issues/6263

According to [PHP documentation](https://www.php.net/manual/en/memcached.constants.php), the `Memcached::HAVE_**` constants are booleans. The stub here is correct as to the PHPDoc only, correctly typing them as booleans. However, the values themselves are integers of `1` and `0`. I think this was set as such because in the C source code, the values used are `1` and `0` but the registering function is `REGISTER_MEMC_CLASS_CONST_BOOL`.
https://github.com/php-memcached-dev/php-memcached/blob/d7daff649406efbd43af3253212b1cb946ff3f85/php_memcached.c#L4362-L4366

However, checking with `var_dump`, these constants are actually booleans.
https://github.com/paulbalandan/phpstan-bug6263/runs/5032025575?check_suite_focus=true