### PR TITLE
Generate dump correctly, gitignore it, display docker build output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,9 +11,11 @@ rest-client.private.env.json
 .idea/workspace.xml
 .idea/shelf
 
-#Composer
+# Composer
 vendor
 composer.lock
 
 .php_cs.cache
 .phpunit.result.cache
+
+ReflectionData.json

--- a/runTests.sh
+++ b/runTests.sh
@@ -8,9 +8,9 @@ do
   SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
   cd "$SCRIPT_DIR" || exit
   echo "Building docker container for PHP_$i..."
-  docker-compose -f docker-compose.yml build >/dev/null
+  docker-compose -f docker-compose.yml build
   echo "Dumping reflection data to file $SCRIPT_DIR/ReflectionData.json for PHP_$i..."
-  docker-compose -f docker-compose.yml run -e PHP_VERSION="$i" php_under_test /usr/local/bin/php /opt/project/phpstorm-stubs/tests/Tools/dump-reflection-to-file.php
+  docker-compose -f docker-compose.yml run -e PHP_VERSION="$i" php_under_test /usr/local/bin/php /opt/project/phpstorm-stubs/tests/Tools/dump-reflection-to-file.php ReflectionData.json
   echo "Running tests agains PHP_$i..."
   docker-compose -f docker-compose.yml run -e PHP_VERSION="$i" test_runner /opt/project/phpstorm-stubs/vendor/bin/phpunit --configuration /opt/project/phpstorm-stubs/phpunit.xml --testsuite PHP_"$i"
   echo "Removing file $SCRIPT_DIR/ReflectionData.json with reflection data for PHP_$i..."


### PR DESCRIPTION
There are 3 main changes:
- the run tests script was calling the dumper incorrectly, causing a php error and missing json dump
- the dumped file should have been gitignored
- since it takes some time to build the docker images, I opted for showing the output

I don't have a strong opinion on these changes, but I thought they would be useful.