### PR TITLE
Fix `DOMNode` & `DOMElement` property types

### DIFF
--- a/dom/dom_c.php
+++ b/dom/dom_c.php
@@ -22,7 +22,7 @@ class DOMNode
     public $nodeName;
 
     /**
-     * @var string
+     * @var string|null
      * The value of this node, depending on its type
      * @link https://php.net/manual/en/class.domnode.php#domnode.props.nodevalue
      */
@@ -119,7 +119,7 @@ class DOMNode
     public $prefix;
 
     /**
-     * @var string
+     * @var string|null
      * Returns the local part of the qualified name of this node.
      * @link https://php.net/manual/en/class.domnode.php#domnode.props.localname
      */
@@ -1597,35 +1597,35 @@ class DOMAttr extends DOMNode
 class DOMElement extends DOMNode implements DOMParentNode, DOMChildNode
 {
     /**
-     * @var DOMElement|null
+     * @var DOMNode|null
      * The parent of this node. If there is no such node, this returns NULL.
      * @link https://php.net/manual/en/class.domnode.php#domnode.props.parentnode
      */
     public $parentNode;
 
     /**
-     * @var DOMElement|null
+     * @var DOMNode|null
      * The first child of this node. If there is no such node, this returns NULL.
      * @link https://php.net/manual/en/class.domnode.php#domnode.props.firstchild
      */
     public $firstChild;
 
     /**
-     * @var DOMElement|null
+     * @var DOMNode|null
      * The last child of this node. If there is no such node, this returns NULL.
      * @link https://php.net/manual/en/class.domnode.php#domnode.props.lastchild
      */
     public $lastChild;
 
     /**
-     * @var DOMElement|null
+     * @var DOMNode|null
      * The node immediately preceding this node. If there is no such node, this returns NULL.
      * @link https://php.net/manual/en/class.domnode.php#domnode.props.previoussibling
      */
     public $previousSibling;
 
     /**
-     * @var DOMElement|null
+     * @var DOMNode|null
      * The node immediately following this node. If there is no such node, this returns NULL.
      * @link https://php.net/manual/en/class.domnode.php#domnode.props.nextsibling
      */


### PR DESCRIPTION
Due to false positive errors from PHPStan I found out that the stubs from this repo have incorrect types for `DOMNode` & `DOMElement` properties. All of these are actually correctly noted in the docs: [DOMNode](https://www.php.net/manual/en/class.domnode.php), [DOMElement](https://www.php.net/manual/en/class.domelement.php) and I have also verified all of these in runtime:

* `DomNode::$nodeValue` - example: https://3v4l.org/qa86V
* `DomNode::$localName` - example: https://3v4l.org/5613l
* `DomElement::$parentNode` - example: https://3v4l.org/Dv8CN
* `DomElement::$firstChild` - example: https://3v4l.org/FcLun
* `DomElement::$lastChild` - example: https://3v4l.org/TifIr
* `DomElement::$previousSibling` - example: https://3v4l.org/t3rAL
* `DomElement::$nextSibling` - example: https://3v4l.org/H77QM

I am not sure why the properties on `DomElement` which are inherited from `DomNode` are "redeclared", maybe they should not? Also generally does it make any sense since properties should be invariant?