### PR TITLE
Additional signature for newrelic_notice_error for passing an Exception

### DIFF
--- a/newrelic/newrelic.php
+++ b/newrelic/newrelic.php
@@ -275,23 +275,24 @@ function newrelic_name_transaction(string $name): bool {}
  * case:
  * - newrelic_notice_error(string $message)
  * - newrelic_notice_error(Throwable|Exception $e)
+ * - newrelic_notice_error(string $errstr, Throwable|Exception $e)
  * - newrelic_notice_error(int $errno, string $errstr, string $errfile, int $errline, string $errcontext)
  *
  * @link  https://docs.newrelic.com/docs/agents/php-agent/php-agent-api/newrelic_notice_error/
  * @since 2.6
  *
- * @param string|Throwable|Exception|int $messageOrExceptionOrCode Either an error message, an exception object, or
+ * @param string|Throwable|Exception|int  $messageOrExceptionOrCode Either an error message, an exception object, or
  *                                                                 an
  *                                                                 integer error code
- * @param string|null                    $errstr                   [optional] Required if first argument is an
+ * @param string|Throwable|Exception|null $errstrOrException       [optional] Required if first argument is an
  *                                                                 integer, Provide an error message that will be
  *                                                                 meaningful to you when it displays in error
- *                                                                 traces.
- * @param string|null                    $errfile                  [optional] The name of the file that the error
+ *                                                                 traces or an exception object.
+ * @param string|null                     $errfile                  [optional] The name of the file that the error
  *                                                                 occurred in.
- * @param int|null                       $errline                  [optional] The line number where the error
+ * @param int|null                        $errline                  [optional] The line number where the error
  *                                                                 occurred.
- * @param string|null                    $errcontext               [optional] An array that points to the symbol
+ * @param string|null                     $errcontext               [optional] An array that points to the symbol
  *                                                                 table
  *                                                                 that was active when the error occurred.
  *
@@ -299,7 +300,7 @@ function newrelic_name_transaction(string $name): bool {}
  */
 function newrelic_notice_error(
     string|Throwable|Exception|int $messageOrExceptionOrCode,
-    string $errstr = null,
+    string|Throwable|Exception $errstrOrException = null,
     string $errfile = null,
     int $errline = null,
     string $errcontext = null


### PR DESCRIPTION
Documents for newrelic give a fourth signature option for
newrelice_notice_error() which is not listed in the stub.

newrelic_notice_error(string $errstr, Throwable|Exception $e)

See https://docs.newrelic.com/docs/apm/agents/php-agent/php-agent-api/newrelic_notice_error/