### PR TITLE
[phpstorm-stubs] WI-60009 add template to ReflectionClass

### DIFF
--- a/Reflection/ReflectionClass.php
+++ b/Reflection/ReflectionClass.php
@@ -8,6 +8,7 @@ use JetBrains\PhpStorm\Internal\TentativeType;
 use JetBrains\PhpStorm\Pure;
 
 /**
+ * @template T
  * The <b>ReflectionClass</b> class reports information about a class.
  *
  * @link https://php.net/manual/en/class.reflectionclass.php
@@ -46,7 +47,7 @@ class ReflectionClass implements Reflector
      * Constructs a ReflectionClass
      *
      * @link https://php.net/manual/en/reflectionclass.construct.php
-     * @param string|object $objectOrClass Either a string containing the name of
+     * @param string|object|T $objectOrClass Either a string containing the name of
      * the class to reflect, or an object.
      * @throws ReflectionException if the class does not exist.
      */
@@ -457,7 +458,7 @@ class ReflectionClass implements Reflector
      * Creates a new class instance without invoking the constructor.
      *
      * @link https://php.net/manual/en/reflectionclass.newinstancewithoutconstructor.php
-     * @return object a new instance of the class.
+     * @return object|T a new instance of the class.
      * @throws ReflectionException if the class is an internal class that
      * cannot be instantiated without invoking the constructor. In PHP 5.6.0
      * onwards, this exception is limited only to internal classes that are final.


### PR DESCRIPTION
Add template to ReflectionClass to infer type in expression like 
```
$class = new ReflectionClass(MyClass::class);
$instance = $class->newInstanceWithoutConstructor();
```
<img width="586" alt="Screenshot 2022-04-30 at 14 30 39" src="https://user-images.githubusercontent.com/37301285/166105637-087f338b-3152-4ab4-a9c0-c533f5d3082a.png">

