### PR TITLE
MongoDB Serializable interface is not deprecated

### DIFF
--- a/mongodb/mongodb.php
+++ b/mongodb/mongodb.php
@@ -2768,7 +2768,6 @@ namespace MongoDB\BSON {
          * Classes that implement this interface may return data to be serialized as a BSON array or document in lieu of the object's public properties
          * @link https://php.net/manual/en/class.mongodb-bson-serializable.php
          */
-        #[Deprecated(since: '8.1')]
         interface Serializable extends Type
         {
             /**


### PR DESCRIPTION
I don't believe this interface is deprecated. 

I think it was marked by mistake. Maybe confused with one in the core (different namespace), which is deprecated in PHP 8.1