### PR TITLE
fix(standard/assert): second parameter can be `Throwable` since 7.0

### DIFF
--- a/standard/standard_9.php
+++ b/standard/standard_9.php
@@ -887,7 +887,7 @@ function key_exists($key, array $array): bool {}
  */
 function assert(
     mixed $assertion,
-    #[LanguageLevelTypeAware(['8.0' => 'Throwable|string|null'], default: 'string')] $description = null
+    #[LanguageLevelTypeAware(['7.0' => 'Throwable|string|null'], default: 'string')] $description = null
 ): bool {}
 
 /**


### PR DESCRIPTION
... according [manual for `assert()`](https://www.php.net/manual/en/function.assert.php#refsect1-function.assert-parameters) 