### PR TITLE
Fix incorrect documentation notation a to an

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/mbstring/mbstring.php
+++ b/mbstring/mbstring.php
@@ -880,7 +880,7 @@ function mb_decode_numericentity(string $string, array $map, ?string $encoding =
  * newline ("\n").
  * </p>
  * @param string|null $additional_params [optional] <p>
- * additional_parameter is a MTA command line
+ * additional_parameter is an MTA command line
  * parameter. It is useful when setting the correct Return-Path
  * header when using sendmail.
  * </p>


### PR DESCRIPTION
I found and corrected the incorrect notation while checking the documentation.