### PR TITLE
Fix FFI\CType::TYPE_LONG_DOUBLE constant typo.

### DIFF
--- a/FFI/.phpstorm.meta.php
+++ b/FFI/.phpstorm.meta.php
@@ -50,7 +50,7 @@ namespace PHPSTORM_META {
         \FFI\CType::TYPE_VOID,
         \FFI\CType::TYPE_FLOAT,
         \FFI\CType::TYPE_DOUBLE,
-        \FFI\CType::TYPE_LONG_DOUBLE,
+        \FFI\CType::TYPE_LONGDOUBLE,
         \FFI\CType::TYPE_UINT8,
         \FFI\CType::TYPE_SINT8,
         \FFI\CType::TYPE_UINT16,

--- a/FFI/FFI.php
+++ b/FFI/FFI.php
@@ -360,7 +360,7 @@ namespace FFI {
          *
          * @since 8.1
          */
-        public const TYPE_LONG_DOUBLE = 3;
+        public const TYPE_LONGDOUBLE = 3;
 
         /**
          * @since 8.1
@@ -547,7 +547,7 @@ namespace FFI {
          *  - {@see CType::TYPE_VOID}
          *  - {@see CType::TYPE_FLOAT}
          *  - {@see CType::TYPE_DOUBLE}
-         *  - {@see CType::TYPE_LONG_DOUBLE}
+         *  - {@see CType::TYPE_LONGDOUBLE}
          *  - {@see CType::TYPE_UINT8}
          *  - {@see CType::TYPE_SINT8}
          *  - {@see CType::TYPE_UINT16}


### PR DESCRIPTION
Correction of the name of the CType's constant:

**Before:**
```
FFI\CType::TYPE_LONG_DOUBLE
```

**After:**
```
FFI\CType::TYPE_LONGDOUBLE
```

The problem was found here: https://github.com/symfony/symfony/pull/46773#discussion_r907116975