### PR TITLE
Update some iterators method return types.

### DIFF
--- a/SPL/SPL.php
+++ b/SPL/SPL.php
@@ -1422,7 +1422,7 @@ class RecursiveTreeIterator extends RecursiveIteratorIterator
      * @link https://php.net/manual/en/recursivetreeiterator.next.php
      * @return void
      */
-    public function next() {}
+    public function next(): void {}
 
     /**
      * Begin iteration

--- a/SPL/SPL.php
+++ b/SPL/SPL.php
@@ -119,7 +119,7 @@ class EmptyIterator implements Iterator
     /**
      * Return the key of the current element
      * @link https://php.net/manual/en/iterator.key.php
-     * @return string|float|int|bool|null scalar on success, or null on failure.
+     * @return mixed scalar on success, or null on failure.
      */
     #[TentativeType]
     public function key(): never {}
@@ -290,7 +290,7 @@ class RecursiveIteratorIterator implements OuterIterator
     /**
      * Access the current key
      * @link https://php.net/manual/en/recursiveiteratoriterator.key.php
-     * @return string|float|int|bool|null The current key.
+     * @return mixed The current key.
      */
     #[TentativeType]
     public function key(): mixed {}
@@ -475,7 +475,7 @@ class IteratorIterator implements OuterIterator
     /**
      * Get the key of the current element
      * @link https://php.net/manual/en/iteratoriterator.key.php
-     * @return string|float|int|bool|null The key of the current element.
+     * @return mixed The key of the current element.
      */
     #[TentativeType]
     public function key(): mixed {}
@@ -538,16 +538,16 @@ abstract class FilterIterator extends IteratorIterator
     /**
      * Get the current key
      * @link https://php.net/manual/en/filteriterator.key.php
-     * @return string|float|int|bool|null The current key.
+     * @return mixed The current key.
      */
-    public function key() {}
+    public function key(): mixed {}
 
     /**
      * Get the current element value
      * @link https://php.net/manual/en/filteriterator.current.php
      * @return mixed The current element value.
      */
-    public function current() {}
+    public function current(): mixed {}
 
     /**
      * Move the iterator forward
@@ -690,16 +690,16 @@ class LimitIterator extends IteratorIterator
     /**
      * Get current key
      * @link https://php.net/manual/en/limititerator.key.php
-     * @return string|float|int|bool|null the key for the current item.
+     * @return mixed the key for the current item.
      */
-    public function key() {}
+    public function key(): mixed {}
 
     /**
      * Get current element
      * @link https://php.net/manual/en/limititerator.current.php
      * @return mixed the current element or null if there is none.
      */
-    public function current() {}
+    public function current(): mixed {}
 
     /**
      * Move the iterator forward
@@ -802,16 +802,16 @@ class CachingIterator extends IteratorIterator implements ArrayAccess, Countable
     /**
      * Return the key for the current element
      * @link https://php.net/manual/en/cachingiterator.key.php
-     * @return string|float|int|bool|null
+     * @return mixed
      */
-    public function key() {}
+    public function key(): mixed {}
 
     /**
      * Return the current element
      * @link https://php.net/manual/en/cachingiterator.current.php
      * @return mixed
      */
-    public function current() {}
+    public function current(): mixed {}
 
     /**
      * Move the iterator forward
@@ -985,7 +985,7 @@ class NoRewindIterator extends IteratorIterator
     /**
      * Get the current key
      * @link https://php.net/manual/en/norewinditerator.key.php
-     * @return string|float|int|bool|null The current key.
+     * @return mixed The current key.
      */
     #[TentativeType]
     public function key(): mixed {}
@@ -1056,9 +1056,9 @@ class AppendIterator extends IteratorIterator
     /**
      * Gets the current key
      * @link https://php.net/manual/en/appenditerator.key.php
-     * @return string|float|int|bool|null The current key if it is valid or null otherwise.
+     * @return mixed The current key if it is valid or null otherwise.
      */
-    public function key() {}
+    public function key(): mixed {}
 
     /**
      * Gets the current value

--- a/SPL/SPL.php
+++ b/SPL/SPL.php
@@ -533,7 +533,7 @@ abstract class FilterIterator extends IteratorIterator
      * @link https://php.net/manual/en/filteriterator.valid.php
      * @return bool true if the current element is valid, otherwise false
      */
-    public function valid() {}
+    public function valid(): bool {}
 
     /**
      * Get the current key
@@ -1399,7 +1399,7 @@ class RecursiveTreeIterator extends RecursiveIteratorIterator
      * @link https://php.net/manual/en/recursivetreeiterator.valid.php
      * @return bool true if the current position is valid, otherwise false
      */
-    public function valid() {}
+    public function valid(): bool {}
 
     /**
      * Get the key of the current element

--- a/SPL/SPL.php
+++ b/SPL/SPL.php
@@ -562,7 +562,7 @@ abstract class FilterIterator extends IteratorIterator
      * @link https://php.net/manual/en/filteriterator.getinneriterator.php
      * @return Iterator The inner iterator.
      */
-    public function getInnerIterator() {}
+    public function getInnerIterator(): Iterator {}
 }
 
 /**
@@ -733,7 +733,7 @@ class LimitIterator extends IteratorIterator
      * @link https://php.net/manual/en/limititerator.getinneriterator.php
      * @return Iterator The inner iterator passed to <b>LimitIterator::__construct</b>.
      */
-    public function getInnerIterator() {}
+    public function getInnerIterator(): Iterator {}
 }
 
 /**
@@ -842,7 +842,7 @@ class CachingIterator extends IteratorIterator implements ArrayAccess, Countable
      * @link https://php.net/manual/en/cachingiterator.getinneriterator.php
      * @return Iterator an object implementing the Iterator interface.
      */
-    public function getInnerIterator() {}
+    public function getInnerIterator(): Iterator {}
 
     /**
      * Get flags used
@@ -1011,7 +1011,7 @@ class NoRewindIterator extends IteratorIterator
      * @link https://php.net/manual/en/norewinditerator.getinneriterator.php
      * @return Iterator The inner iterator, as passed to <b>NoRewindIterator::__construct</b>.
      */
-    public function getInnerIterator() {}
+    public function getInnerIterator(): Iterator {}
 }
 
 /**
@@ -1081,7 +1081,7 @@ class AppendIterator extends IteratorIterator
      * @link https://php.net/manual/en/appenditerator.getinneriterator.php
      * @return Iterator the current inner Iterator.
      */
-    public function getInnerIterator() {}
+    public function getInnerIterator(): Iterator {}
 
     /**
      * Gets an index of iterators

--- a/SPL/SPL.php
+++ b/SPL/SPL.php
@@ -1392,7 +1392,7 @@ class RecursiveTreeIterator extends RecursiveIteratorIterator
      * @link https://php.net/manual/en/recursivetreeiterator.rewind.php
      * @return void
      */
-    public function rewind() {}
+    public function rewind(): void {}
 
     /**
      * Check validity


### PR DESCRIPTION
This PR:

* Follows https://github.com/phpstan/phpstan/issues/7519
* Fix return types of `key` method of many iterators

Some examples:

* https://3v4l.org/MXHWf#v8.1.7
* https://3v4l.org/iI4Hn#v8.1.7