### PR TITLE
Update Redis config() method

### DIFF
--- a/redis/Redis.php
+++ b/redis/Redis.php
@@ -4333,7 +4333,7 @@ class Redis
      * $redis->config("SET", "dir", "/var/run/redis/dumps/");
      * </pre>
      */
-    public function config($operation, $key, $value) {}
+    public function config($operation, $key, $value = '') {}
 
     /**
      * Evaluate a LUA script serverside


### PR DESCRIPTION
Fix for `Required parameter '$value' missing` when you calling `config()` method with GET option. E.g. `$redis->config('GET', 'databases')`