### PR TITLE
WI-66334 add duplicated signature of var_dump

### DIFF
--- a/standard/standard_4.php
+++ b/standard/standard_4.php
@@ -187,12 +187,19 @@ function unserialize(string $data, #[PhpStormStubsElementAvailable(from: '7.0')]
  * @param mixed ...$values [optional]
  * @return void
  */
-function var_dump(
-    #[PhpStormStubsElementAvailable(from: '5.3', to: '7.4')] $vars,
-    #[PhpStormStubsElementAvailable(from: '5.3', to: '7.4')] ...$vars,
-    #[PhpStormStubsElementAvailable(from: '8.0')] mixed $value,
-    #[PhpStormStubsElementAvailable(from: '8.0')] mixed ...$values
-): void {}
+#[PhpStormStubsElementAvailable(from: '8.0')]
+function var_dump(mixed $value, mixed ...$values): void {}
+
+/**
+ * Dumps information about a variable
+ * @link https://php.net/manual/en/function.var-dump.php
+ * @param mixed ...$vars <p>
+ * The variable you want to export.
+ * </p>
+ * @return void
+ */
+#[PhpStormStubsElementAvailable(from: '5.3', to: '7.4')]
+function var_dump(...$vars): void {}
 
 /**
  * Outputs or returns a parsable string representation of a variable

--- a/tests/BaseFunctionsTest.php
+++ b/tests/BaseFunctionsTest.php
@@ -85,7 +85,7 @@ class BaseFunctionsTest extends AbstractBaseStubsTestCase
     }
 
     /**
-     * @dataProvider \StubTests\TestData\Providers\Reflection\ReflectionParametersProvider::functionParametersProvider
+     * @dataProvider \StubTests\TestData\Providers\Reflection\ReflectionParametersProvider::functionOptionalParametersProvider
      * @throws RuntimeException
      */
     public function testFunctionsOptionalParameters(PHPFunction $function, PHPParameter $parameter)

--- a/tests/TestData/mutedProblems.json
+++ b/tests/TestData/mutedProblems.json
@@ -966,6 +966,27 @@
           ]
         }
       ]
+    },
+    {
+      "name": "var_dump",
+      "parameters": [
+        {
+          "name": "vars",
+          "problems": [
+            {
+              "description": "wrong optionallity",
+              "versions": [
+                5.6,
+                7.0,
+                7.1,
+                7.2,
+                7.3,
+                7.4
+              ]
+            }
+          ]
+        }
+      ]
     }
   ],
   "classes": [


### PR DESCRIPTION
Ideally should be fixed using annotation from WI-61322 but until WI-61322 is fixed let's create a dup as users complain about the wrong signature