### PR TITLE
Vote to add `PhpStormStubsMap::getFilename()`

### DIFF
--- a/PhpStormStubsMap.php
+++ b/PhpStormStubsMap.php
@@ -14124,4 +14124,13 @@ const CONSTANTS = array (
   'yaf_err_type_error' => 'yaf/yaf.php',
   'yaf_version' => 'yaf/yaf.php',
 );
+  /**
+   * @param string $className
+   * @psalm-param class-string $className
+   * @return string|null
+   */
+  public function getFilename($className)
+  {
+    return isset(self::CLASSES[$className]) ? \realpath(self::CLASSES[$className]) : null;
+  }
 }


### PR DESCRIPTION
This method is needed to get absolute path to stub without any tricks like as `ReflectionClass::getFileName()`.

> This is a generated file, do not modify it directly!

I don't found class generator in this package and issues disabled.