### PR TITLE
generate-stub-map: add PhpStormStubsMap::getFileName()

### DIFF
--- a/tests/Tools/generate-stub-map
+++ b/tests/Tools/generate-stub-map
@@ -275,6 +275,23 @@ const CLASSES = {$exportedClasses};
 const FUNCTIONS = {$exportedFunctions};
 
 const CONSTANTS = {$exportedConstants};
+
+/**
+ * @param string $name
+ * @return string|null
+ */
+public static function getFileName($name)
+{
+    $file = null;
+    if (isset(self::CLASSES[$name]) {
+        $file = self::CLASSES[$name];
+    } elseif (isset(self::FUNCTIONS[$name])) {
+        $file = self::FUNCTIONS[$name];
+    } elseif (isset(self::CONSTANTS[$name])) {
+        $file = self::CONSTANTS[$name];
+    }
+    return $file !== null ? \realpath($file) : null;
+}
 }
 PHP;
 

--- a/tests/Tools/generate-stub-map
+++ b/tests/Tools/generate-stub-map
@@ -277,20 +277,20 @@ const FUNCTIONS = {$exportedFunctions};
 const CONSTANTS = {$exportedConstants};
 
 /**
- * @param string $name
+ * @param string \$name
  * @return string|null
  */
-public static function getFileName($name)
+public static function getFileName(\$name)
 {
-    $file = null;
-    if (isset(self::CLASSES[$name]) {
-        $file = self::CLASSES[$name];
-    } elseif (isset(self::FUNCTIONS[$name])) {
-        $file = self::FUNCTIONS[$name];
-    } elseif (isset(self::CONSTANTS[$name])) {
-        $file = self::CONSTANTS[$name];
+    \$file = null;
+    if (isset(self::CLASSES[\$name]) {
+        \$file = self::CLASSES[\$name];
+    } elseif (isset(self::FUNCTIONS[\$name])) {
+        \$file = self::FUNCTIONS[\$name];
+    } elseif (isset(self::CONSTANTS[\$name])) {
+        \$file = self::CONSTANTS[\$name];
     }
-    return $file !== null ? \realpath($file) : null;
+    return \$file !== null ? realpath(\$file) : null;
 }
 }
 PHP;

--- a/tests/Tools/generate-stub-map
+++ b/tests/Tools/generate-stub-map
@@ -258,6 +258,25 @@ use const PHP_EOL;
     $exportedFunctions = var_export($mapWithRelativeFilePaths['functions'], true);
     $exportedConstants = var_export($mapWithRelativeFilePaths['constants'], true);
 
+    $getFileNameMethod = <<<'PHP'
+    /**
+     * @param string $name
+     * @return string|null
+     */
+    public static function getFileName($name)
+    {
+        $file = null;
+        if (isset(self::CLASSES[$name]) {
+            $file = self::CLASSES[$name];
+        } elseif (isset(self::FUNCTIONS[$name])) {
+            $file = self::FUNCTIONS[$name];
+        } elseif (isset(self::CONSTANTS[$name])) {
+            $file = self::CONSTANTS[$name];
+        }
+        return $file !== null ? \realpath($file) : null;
+    }
+PHP;
+
     $output = <<<"PHP"
 <?php
 
@@ -276,22 +295,7 @@ const FUNCTIONS = {$exportedFunctions};
 
 const CONSTANTS = {$exportedConstants};
 
-/**
- * @param string \$name
- * @return string|null
- */
-public static function getFileName(\$name)
-{
-    \$file = null;
-    if (isset(self::CLASSES[\$name]) {
-        \$file = self::CLASSES[\$name];
-    } elseif (isset(self::FUNCTIONS[\$name])) {
-        \$file = self::FUNCTIONS[\$name];
-    } elseif (isset(self::CONSTANTS[\$name])) {
-        \$file = self::CONSTANTS[\$name];
-    }
-    return \$file !== null ? realpath(\$file) : null;
-}
+{$getFileNameMethod}
 }
 PHP;
 


### PR DESCRIPTION
This method is needed to get absolute path to stub without any tricks like as `Reflection*::getFileName()`.