### PR TITLE
Update extract's ExpectedValues

### DIFF
--- a/standard/standard_8.php
+++ b/standard/standard_8.php
@@ -857,6 +857,7 @@ function extract(
                EXTR_PREFIX_SAME,
                EXTR_PREFIX_ALL,
                EXTR_PREFIX_INVALID,
+               EXTR_IF_EXISTS,
                EXTR_PREFIX_IF_EXISTS,
                EXTR_REFS
            ])] int $flags = EXTR_OVERWRITE,


### PR DESCRIPTION
Add missing ExpectedValue "EXTR_IF_EXISTS" to `extract`'s `$flags`
See issue tracker WI-67763
https://youtrack.jetbrains.com/issue/WI-67763/Add-EXTRIFEXISTS-as-to-ExpectedValues-for-extracts-flags-parameter