### PR TITLE
Added (!$functions) handling

### DIFF
--- a/tests/Model/StubsContainer.php
+++ b/tests/Model/StubsContainer.php
@@ -126,6 +126,11 @@ class StubsContainer
         if (!empty($functions)) {
             return array_pop($functions);
         }
+        // Added this while tracking down "Attempt to read property "parameters" on null" error.
+        // Happens when BasePHPElement::entitySuitsCurrentPhpVersion returns false when running tests on PHP beta: getenv('PHP_VERSION')
+        if (!$functions) {
+            throw new RuntimeException("Could not get function " . $name . " from reflection, possibly unsupported PHP_VERSION in getenv");
+        }
         return null;
     }
 

--- a/tests/Model/StubsContainer.php
+++ b/tests/Model/StubsContainer.php
@@ -97,7 +97,7 @@ class StubsContainer
      * @param string $name
      * @param string|null $sourceFilePath
      * @param bool $shouldSuitCurrentPhpVersion
-     * @return PHPFunction|null
+     * @return PHPFunction
      * @throws RuntimeException
      */
     public function getFunction($name, $sourceFilePath = null, $shouldSuitCurrentPhpVersion = true)
@@ -125,13 +125,9 @@ class StubsContainer
         }
         if (!empty($functions)) {
             return array_pop($functions);
+        } else {
+            throw new RuntimeException("Could not get function {$name} from reflection, possibly unsupported PHP_VERSION in getenv");
         }
-        // Added this while tracking down "Attempt to read property "parameters" on null" error.
-        // Happens when BasePHPElement::entitySuitsCurrentPhpVersion returns false when running tests on PHP beta: getenv('PHP_VERSION')
-        if (!$functions) {
-            throw new RuntimeException("Could not get function " . $name . " from reflection, possibly unsupported PHP_VERSION in getenv");
-        }
-        return null;
     }
 
     public function addFunction(PHPFunction $function)


### PR DESCRIPTION
Added this while tracking down "Attempt to read property "parameters" on null" error.
Happens when \StubTests\Model\BasePHPElement::entitySuitsCurrentPhpVersion returns false when running tests on PHP beta. It is not expected that getenv('PHP_VERSION') would return e.g. PHP8.2_beta:
![image](https://user-images.githubusercontent.com/33625946/180824037-474b4638-137b-45f6-b534-96cefadbc19d.png)
