### PR TITLE
Add template annotations for WeakReference

### DIFF
--- a/Core/Core_c.php
+++ b/Core/Core_c.php
@@ -711,7 +711,7 @@ interface Countable
  * Weak references allow the programmer to retain a reference to an
  * object which does not prevent the object from being destroyed.
  * They are useful for implementing cache like structures.
- * @template T
+ * @template T of object
  * @link https://www.php.net/manual/en/class.weakreference.php
  * @since 7.4
  */
@@ -727,7 +727,7 @@ final class WeakReference
     /**
      * Create a new weak reference.
      * @link https://www.php.net/manual/en/weakreference.create.php
-     * @template TIn
+     * @template TIn of object
      * @param TIn $object
      * @return WeakReference<TIn> the freshly instantiated object.
      * @since 7.4

--- a/Core/Core_c.php
+++ b/Core/Core_c.php
@@ -728,7 +728,7 @@ final class WeakReference
      * Create a new weak reference.
      * @link https://www.php.net/manual/en/weakreference.create.php
      * @template TIn of object
-     * @param TIn $object
+     * @param TIn $object Any object
      * @return WeakReference<TIn> the freshly instantiated object.
      * @since 7.4
      */

--- a/Core/Core_c.php
+++ b/Core/Core_c.php
@@ -728,8 +728,8 @@ final class WeakReference
      * Create a new weak reference.
      * @link https://www.php.net/manual/en/weakreference.create.php
      * @template TIn of object
-     * @param TIn $object Any object
-     * @return WeakReference<TIn> the freshly instantiated object.
+     * @param TIn $object Any object.
+     * @return WeakReference<TIn> The freshly instantiated object.
      * @since 7.4
      */
     public static function create(object $object): WeakReference {}

--- a/Core/Core_c.php
+++ b/Core/Core_c.php
@@ -711,6 +711,7 @@ interface Countable
  * Weak references allow the programmer to retain a reference to an
  * object which does not prevent the object from being destroyed.
  * They are useful for implementing cache like structures.
+ * @template T
  * @link https://www.php.net/manual/en/class.weakreference.php
  * @since 7.4
  */
@@ -726,7 +727,9 @@ final class WeakReference
     /**
      * Create a new weak reference.
      * @link https://www.php.net/manual/en/weakreference.create.php
-     * @return WeakReference the freshly instantiated object.
+     * @template TIn
+     * @param TIn $object
+     * @return WeakReference<TIn> the freshly instantiated object.
      * @since 7.4
      */
     public static function create(object $object): WeakReference {}
@@ -735,7 +738,7 @@ final class WeakReference
      * Gets a weakly referenced object. If the object has already been
      * destroyed, NULL is returned.
      * @link https://www.php.net/manual/en/weakreference.get.php
-     * @return object|null
+     * @return T|null
      * @since 7.4
      */
     public function get(): ?object {}


### PR DESCRIPTION
Now, when using `WeakReference`, PhpStorm cannot infer the type returned by the `get()` method, which is inconvenient.

This PR adds template annotations that allow PhpStorm to accurately infer types.

<img width="385" alt="Снимок экрана 2022-09-09 в 20 19 55" src="https://user-images.githubusercontent.com/51853996/189408590-b5043419-1707-4374-84d5-f401303fff71.png">

See `WeakReference` in Psalm [stubs](https://github.com/vimeo/psalm/blob/2fdcd5a5fc48ddb585cc6261e40e2460187142eb/stubs/CoreGenericClasses.phpstub)