### PR TITLE
fpm_get_status may return false if the fpm scoreboard is locked or unavailable.

### DIFF
--- a/fpm/fpm.php
+++ b/fpm/fpm.php
@@ -2,9 +2,9 @@
 /**
  * Returns FPM status info array
  * @since 7.3
- * @return array
+ * @return array|false
  */
-function fpm_get_status(): array {}
+function fpm_get_status(): array|false {}
 
 /**
  * This function flushes all response data to the client and finishes the request.


### PR DESCRIPTION
php.net does not indicate that this method may return false, but it can do in rare circumstances:

https://github.com/php/php-src/blob/master/sapi/fpm/fpm/fpm_main.c#L1490

the false return happens if the scoreboard is unavailable or already in use:

https://github.com/php/php-src/blob/master/sapi/fpm/fpm/fpm_status.c#L57-L60

