### PR TITLE
DateTimeZone::__construct throws Exception

### DIFF
--- a/date/date_c.php
+++ b/date/date_c.php
@@ -762,6 +762,7 @@ class DateTimeZone
     /**
      * @param string $timezone
      * @link https://php.net/manual/en/datetimezone.construct.php
+     * @throws Exception Emits Exception in case of an error.
      */
     public function __construct(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $timezone) {}
 


### PR DESCRIPTION
As documented in https://www.php.net/manual/en/datetimezone.construct.php