### PR TITLE
Fix bcdiv/bcmod() $scale default value

### DIFF
--- a/bcmath/bcmath.php
+++ b/bcmath/bcmath.php
@@ -106,7 +106,7 @@ function bcdiv(string $num1, string $num2, ?int $scale = 0): ?string {}
  */
 #[Pure]
 #[PhpStormStubsElementAvailable('8.0')]
-function bcdiv(string $num1, string $num2, ?int $scale = 0): string {}
+function bcdiv(string $num1, string $num2, ?int $scale = null): string {}
 
 /**
  * Get modulus of an arbitrary precision number
@@ -150,7 +150,7 @@ function bcmod(string $num1, string $num2, ?int $scale = 0): ?string {}
  */
 #[Pure]
 #[PhpStormStubsElementAvailable('8.0')]
-function bcmod(string $num1, string $num2, ?int $scale = 0): string {}
+function bcmod(string $num1, string $num2, ?int $scale = null): string {}
 
 /**
  * Raise an arbitrary precision number to another


### PR DESCRIPTION
Fixes default value for `$scale` on PHP 8:

- [bcdiv](https://www.php.net/manual/en/function.bcdiv.php):
    ```php
    bcdiv(string $num1, string $num2, ?int $scale = null): string
    ```
- [bcmod](https://www.php.net/manual/en/function.bcmod.php):
    ```php
    bcmod(string $num1, string $num2, ?int $scale = null): string
    ```