### PR TITLE
ZipArchive::open(): bool|int

### DIFF
--- a/zip/zip.php
+++ b/zip/zip.php
@@ -630,9 +630,9 @@ class ZipArchive implements Countable
      * <b>ZipArchive::OVERWRITE</b>
      * </p>
      *
-     * @return int|true <i>Error codes</i>
+     * @return int|bool <i>Error codes</i>
      * <p>
-     * Returns <b>TRUE</b> on success or the error code.
+     * Returns <b>TRUE</b> on success, <b>FALSE</b> or the error code on error.
      * </p>
      * <p>
      * <b>ZipArchive::ER_EXISTS</b>


### PR DESCRIPTION
The documentation is not correct here: (I will try to update it, also) "Returns true on success, or one of the following error codes" | https://www.php.net/manual/en/ziparchive.open.php

- https://github.com/vimeo/psalm/issues/6052