### PR TITLE
WI-70049 - Documented Memcached checkKey method

### DIFF
--- a/memcached/memcached.php
+++ b/memcached/memcached.php
@@ -1494,6 +1494,14 @@ class Memcached
     public function isPristine() {}
 
     /**
+     * (PECL memcached &gt;= 3.2.0)<br/>
+     * Check if the given key is valid.
+     * @param string $key
+     * @return bool
+     */
+    public function checkKey($key) {}
+
+    /**
      * Flush and send buffered commands
      * @link https://github.com/php-memcached-dev/php-memcached/blob/v3.1.5/php_memcached.c
      * @return bool


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/WI-70049/Document-Memcached-checkKey-method

Memcached exposes a method `checkKey`: https://github.com/php-memcached-dev/php-memcached/blob/master/php_memcached.c#L3454

The php-memcached stub file also mentions this method: https://github.com/php-memcached-dev/php-memcached/blob/master/php_memcached.stub.php

Can be used like this:
```
$mem = new Memcached();
$checkKey = $mem->checkKey("valid");
var_dump($checkKey);
```

this will output `true`.

But for example a key with a space in it will not pass the validation and return `false`.