### PR TITLE
[phpstorm-stubs] fix openssl_random_pseudo_bytes return type

### DIFF
--- a/openssl/openssl.php
+++ b/openssl/openssl.php
@@ -1174,7 +1174,7 @@ function openssl_pkey_derive(
  * </p>
  * @return string|false the generated string of bytes on success, or false on failure.
  */
-#[LanguageLevelTypeAware(["8.0" => "string"], default: "string|false")]
+#[LanguageLevelTypeAware(["7.4" => "string"], default: "string|false")]
 function openssl_random_pseudo_bytes(int $length, &$strong_result) {}
 
 /**


### PR DESCRIPTION
According to https://www.php.net/manual/en/function.openssl-random-pseudo-bytes.php this function returns `string` only since PHP 7.4 already. I could also find a changelog entry on
https://www.php.net/ChangeLog-7.php#PHP_7_4
> openssl_random_pseudo_bytes() now throws in error conditions.

I wanted to double-check via php-src, but couldn't find the right place in the 7.4 tag and wasn't a 100% sure. maybe you want to still double-check this somehow if possible