### PR TITLE
Update return type for rewinddir to void

### DIFF
--- a/standard/standard_7.php
+++ b/standard/standard_7.php
@@ -368,10 +368,9 @@ function getcwd(): string|false {}
  * not specified, the last link opened by opendir
  * is assumed.
  * </p>
- * @return null|false
  * @see https://bugs.php.net/bug.php?id=75485
  */
-function rewinddir($dir_handle): null|false {}
+function rewinddir($dir_handle): void {}
 
 /**
  * Read entry from directory handle


### PR DESCRIPTION
When I read the documentation https://www.php.net/manual/en/function.rewinddir.php right the return value is void. When I read the phpcode for rewind_dir it return value is void as well. If I read `php_userstreamop_rewinddir` correctly. I read the custom stream wrappers implementation as the original call `PHP_FUNCTION(rewinddir)` looks like just calling a macro `php_stream_rewinddir` without processing the return value. I stumbled upon this as I wrote code using phpstorm IDE hints and phpstan tells me, that there is no return value to pay respect to.

I am not sure whether my findings are correct as I am only reading PHP source code infrequently and I am not sure whether the issue might be in phpstan and the docs.