### PR TITLE
fix Phar::offsetGet return type

### DIFF
--- a/Phar/Phar.php
+++ b/Phar/Phar.php
@@ -507,7 +507,7 @@ class Phar extends RecursiveDirectoryIterator implements RecursiveIterator, Seek
      * iterate over a file's contents or to retrieve information about the current file.
      */
     #[TentativeType]
-    public function offsetGet($localName): SplFileInfo {}
+    public function offsetGet($localName): PharFileInfo {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 1.0.0)<br/>


### PR DESCRIPTION
https://www.php.net/manual/en/phar.offsetget.php

Signature in docs suggests that it's SplFileInfo but all the other documentation indicates it should be PharFileInfo