### PR TITLE
Allow DNF types in ReflectionUnionType::getTypes()

### DIFF
--- a/Reflection/ReflectionUnionType.php
+++ b/Reflection/ReflectionUnionType.php
@@ -1,5 +1,6 @@
 <?php
 
+use JetBrains\PhpStorm\Internal\LanguageLevelTypeAware;
 use JetBrains\PhpStorm\Pure;
 
 /**
@@ -8,10 +9,16 @@ use JetBrains\PhpStorm\Pure;
 class ReflectionUnionType extends ReflectionType
 {
     /**
-     * Get list of named types of union type
+     * Get list of types of union type
      *
-     * @return ReflectionNamedType[]
+     * @return ReflectionNamedType[]|ReflectionIntersectionType[]
      */
     #[Pure]
+    #[LanguageLevelTypeAware(
+        [
+            '8.2' => 'ReflectionNamedType[]|ReflectionIntersectionType[]'
+        ],
+        default: 'ReflectionNamedType[]'
+    )]
     public function getTypes(): array {}
 }


### PR DESCRIPTION
Since [DNF types](https://wiki.php.net/rfc/dnf_types) have been introduced in PHP 8.2, types returned by `ReflectionUnionType::getTypes()` include `ReflectionIntersectionType` in addition to `ReflectionNamedType`:

https://3v4l.org/ZFKZ6#v8.2.1

I'm not entirely sure of the syntax in this patch, suggestions welcome.