### PR TITLE
hrtime(): $as_number is optional

### DIFF
--- a/standard/standard_4.php
+++ b/standard/standard_4.php
@@ -384,7 +384,7 @@ function highlight_string(string $string, bool $return = false): string|bool {}
  */
 #[Pure(true)]
 function hrtime(
-    #[PhpStormStubsElementAvailable(from: '7.3', to: '7.4')] bool $as_number,
+    #[PhpStormStubsElementAvailable(from: '7.3', to: '7.4')] bool $as_number = false,
     #[PhpStormStubsElementAvailable(from: '8.0')] bool $as_number = false
 ): array|int|float|false {}
 

--- a/standard/standard_4.php
+++ b/standard/standard_4.php
@@ -383,10 +383,7 @@ function highlight_string(string $string, bool $return = false): string|bool {}
  * Otherwise the nanoseconds are returned as integer (64bit platforms) or float (32bit platforms).
  */
 #[Pure(true)]
-function hrtime(
-    #[PhpStormStubsElementAvailable(from: '7.3', to: '7.4')] bool $as_number = false,
-    #[PhpStormStubsElementAvailable(from: '8.0')] bool $as_number = false
-): array|int|float|false {}
+function hrtime(bool $as_number = false): array|int|float|false {}
 
 /**
  * Return source with stripped comments and whitespace


### PR DESCRIPTION
$as_number was always optional, see https://3v4l.org/uK5ro and https://www.php.net/manual/en/function.hrtime.php