### PR TITLE
Include @throws tag for __soapCall

### DIFF
--- a/soap/soap.php
+++ b/soap/soap.php
@@ -322,7 +322,12 @@ class SoapClient
      * </p>
      * <p>
      * On error, if the SoapClient object was constructed with the exceptions
-     * option set to <b>FALSE</b>, a SoapFault object will be returned.
+     * option set to <b>FALSE</b>, a SoapFault object will be returned. If this
+     * option is not set, or is set to <b>TRUE</b>, then a SoapFault object will
+     * be thrown as an exception.
+     * @throws SoapFault A SoapFault exception will be thrown if an error occurs
+     * and the SoapClient was constructed with the exceptions option not set, or
+     * set to <b>TRUE</b>.
      * @since 5.0.1
      */
     #[TentativeType]


### PR DESCRIPTION
The `__soapCall` function can throw a `SoapFault` Exception.

From the [documentation](https://www.php.net/manual/en/soapclient.soapcall.php):

> On error, a call to a SOAP function can cause PHP to throw exceptions or return a [SoapFault](https://www.php.net/manual/en/class.soapfault.php) object if exceptions are disabled.

An example of catching a thrown `SoapFault` can be found in the examples of the `is_soap_fault` [documentation](https://www.php.net/manual/en/function.is-soap-fault).