### PR TITLE
DOMElement::$attributes is not nullable

### DIFF
--- a/dom/dom_c.php
+++ b/dom/dom_c.php
@@ -1641,6 +1641,14 @@ class DOMElement extends DOMNode implements DOMParentNode, DOMChildNode
     public $nextSibling;
 
     /**
+     * @var DOMNamedNodeMap
+     * A <classname>DOMNamedNodeMap</classname> containing the attributes of this node (if it is a <classname>DOMElement</classname>) or NULL otherwise.
+     * @link https://php.net/manual/en/class.domnode.php#domnode.props.attributes
+     */
+    #[LanguageLevelTypeAware(['8.1' => 'DOMNamedNodeMap'], default: '')]
+    public $attributes;
+
+    /**
      * @var bool
      * Not implemented yet, always return NULL
      * @link https://php.net/manual/en/class.domelement.php#domelement.props.schematypeinfo


### PR DESCRIPTION
I got an inconsistency here between PHPStan and Psalm, and at first I though Psalm was wrong: https://github.com/vimeo/psalm/issues/9242

But, after reading the doc description, they are right and this PR fixes it on this side.