### PR TITLE
Remove iterable pseudotype

### DIFF
--- a/Core/Core_c.php
+++ b/Core/Core_c.php
@@ -14,11 +14,6 @@ use JetBrains\PhpStorm\Pure;
 class stdClass {}
 
 /**
- * @link https://wiki.php.net/rfc/iterable
- */
-interface iterable {}
-
-/**
  * Interface to detect if a class is traversable using foreach.
  * Abstract base interface that cannot be implemented alone.
  * Instead it must be implemented by either {@see IteratorAggregate} or {@see Iterator}.
@@ -26,10 +21,8 @@ interface iterable {}
  * @link https://php.net/manual/en/class.traversable.php
  * @template TKey
  * @template-covariant TValue
- *
- * @template-implements iterable<TKey, TValue>
  */
-interface Traversable extends iterable {}
+interface Traversable {}
 
 /**
  * Interface to create an external Iterator.

--- a/PhpStormStubsMap.php
+++ b/PhpStormStubsMap.php
@@ -1222,7 +1222,6 @@ const CLASSES = array (
   'http\\QueryString' => 'http/http3.php',
   'http\\Url' => 'http/http3.php',
   'imageObj' => 'mapscript/mapscript.php',
-  'iterable' => 'Core/Core_c.php',
   'java' => 'zend/zend.php',
   'labelObj' => 'mapscript/mapscript.php',
   'labelcacheMemberObj' => 'mapscript/mapscript.php',


### PR DESCRIPTION
This isn't a real interface. Because of this stub PhpStorm currently doesn't complain about such code:

<img width="365" alt="Screenshot 2023-02-14 at 22 46 09" src="https://user-images.githubusercontent.com/104888/218870445-7800de89-7a6a-4587-ae12-290709f88115.png">

But PHP ends with fatal error: https://3v4l.org/UYkWD

The RFC https://wiki.php.net/rfc/iterable states:

> This RFC proposes a new iterable pseudo-type. This type is analogous to callable, accepting multiple types instead of one single type. 

jetbrains/phpstorm-stubs do not contain "interface callable" either...