### PR TITLE
mailparse_msg_get_part() can return false

### DIFF
--- a/mailparse/mailparse.php
+++ b/mailparse/mailparse.php
@@ -111,7 +111,7 @@ function mailparse_msg_get_part_data($mimemail) {}
  * A valid MIME resource.
  * </p>
  * @param string $mimesection
- * @return resource
+ * @return resource|false
  */
 function mailparse_msg_get_part($mimemail, $mimesection) {}
 


### PR DESCRIPTION
According to the source, it returns false when called incorrectly, or when the requested part was not found.