### PR TITLE
Fixed meta for setlocale when more than one locale is provided

### DIFF
--- a/meta/locales/.phpstorm.meta.php
+++ b/meta/locales/.phpstorm.meta.php
@@ -208,4 +208,5 @@ namespace PHPSTORM_META {
     );
 
     expectedArguments(\setlocale(), 1, argumentsSet('locales'));
+    expectedArguments(\setlocale(), 2, argumentsSet('locales'));
 }


### PR DESCRIPTION
**Steps to reproduce:**
Write:
```php
setlocale(LC_ALL, 'de_DE', '<caret>');
```
**Expected**
Completion at third argument (second locale)

**Actual**
No completion because of this stub definition:
```php
function setlocale(
    #[ExpectedValues([LC_ALL,  LC_COLLATE,  LC_CTYPE,  LC_MONETARY,  LC_NUMERIC,  LC_TIME,  LC_MESSAGES])] int $category,
    #[PhpStormStubsElementAvailable(from: '8.0')] $locales,
    #[PhpStormStubsElementAvailable(from: '5.3', to: '7.4')] $rest,
    ...$rest
): string|false {}
```