### PR TITLE
Fix return type of SplMinHeap::insert(): void -> true

### DIFF
--- a/SPL/SPL_c1.php
+++ b/SPL/SPL_c1.php
@@ -1531,7 +1531,7 @@ class SplMinHeap extends SplHeap
      * @param TValue $value <p>
      * The value to insert.
      * </p>
-     * @return void
+     * @return true
      */
     public function insert($value) {}
 


### PR DESCRIPTION
According to php.net documentation, SplMinHeap extends SplHeap and inherits the `SplHeap::insert()` method [which always returns true](https://www.php.net/manual/en/splheap.insert.php). Return types for `SplHeap::insert()` and `SplMaxHeap::insert()` are correctly defined, however, the return type of `SplMinHeap::insert()` is `void`.

