### PR TITLE
Added PhpStormStubsMap::DIR constant to simplify integration

### DIFF
--- a/PhpStormStubsMap.php
+++ b/PhpStormStubsMap.php
@@ -9,6 +9,8 @@ namespace JetBrains\PHPStormStub;
  */
 final class PhpStormStubsMap
 {
+const DIR = __DIR__;
+
 const CLASSES = array (
   'AMQPBasicProperties' => 'amqp/amqp.php',
   'AMQPChannel' => 'amqp/amqp.php',

--- a/tests/Tools/generate-stub-map
+++ b/tests/Tools/generate-stub-map
@@ -271,6 +271,8 @@ namespace JetBrains\PHPStormStub;
  */
 final class PhpStormStubsMap
 {
+const DIR = __DIR__;
+
 const CLASSES = {$exportedClasses};
 
 const FUNCTIONS = {$exportedFunctions};


### PR DESCRIPTION
Currently directory can be obtained with expression

```php
$stubsDir = dirname((new \ReflectionClass(PhpStormStubsMap::class))->getFileName());
```

After this PR it could be simplified to

```php
$stubsDir = PhpStormStubsMap::DIR;
```