### PR TITLE
Add throws PHPDoc to `constant()`

### DIFF
--- a/standard/standard_0.php
+++ b/standard/standard_0.php
@@ -158,6 +158,7 @@ class Directory
  * </p>
  * @return mixed the value of the constant, or null if the constant is not
  * defined.
+ * @throws Error If the constant is not defined
  */
 #[Pure(true)]
 function constant(string $name): mixed {}

--- a/standard/standard_0.php
+++ b/standard/standard_0.php
@@ -156,8 +156,7 @@ class Directory
  * @param string $name <p>
  * The constant name.
  * </p>
- * @return mixed the value of the constant, or null if the constant is not
- * defined.
+ * @return mixed the value of the constant.
  * @throws Error If the constant is not defined
  */
 #[Pure(true)]


### PR DESCRIPTION
Since PHP 8 it will throw if the constant is undefined. See https://www.php.net/manual/en/function.constant.php
But this is most likely not the best way to add that info. There is no PHP-version specific throws, right?

UPDATE: found https://youtrack.jetbrains.com/issue/WI-72311 afterwards and adapted the return type description too