### PR TITLE
Parameter and return of `DOMNode::lookupNamespaceURI` are both nullable

### DIFF
--- a/dom/dom_c.php
+++ b/dom/dom_c.php
@@ -297,7 +297,7 @@ class DOMNode
      * @param string|null $prefix <p>
      * The prefix of the namespace.
      * </p>
-     * @return string The namespace URI of the node.
+     * @return string|null The namespace URI of the node.
      */
     #[PhpStormStubsElementAvailable(from: '8.0')]
     #[TentativeType]
@@ -306,10 +306,10 @@ class DOMNode
     /**
      * Gets the namespace URI of the node based on the prefix
      * @link https://php.net/manual/en/domnode.lookupnamespaceuri.php
-     * @param string $prefix <p>
+     * @param string|null $prefix <p>
      * The prefix of the namespace.
      * </p>
-     * @return string The namespace URI of the node.
+     * @return string|null The namespace URI of the node.
      */
     #[PhpStormStubsElementAvailable(from: '5.3', to: '7.4')]
     public function lookupNamespaceUri($prefix) {}


### PR DESCRIPTION
Ref:
- https://github.com/php/php-src/blob/c40dcf93d0b95d9a1026476b202f5aa965fb3fdd/ext/dom/node.c#L1622-L1650
- https://github.com/php/php-src/blob/b3553159a7b15d1ddd485aba9f83485f08e2e800/ext/dom/node.c#L1515-L1543
- https://www.w3.org/TR/DOM-Level-3-Core/core.html#Node3-lookupNamespaceURI
- https://github.com/phpstan/phpstan-src/pull/2527