### PR TITLE
mark connection_status() and connection_aborted() impure

### DIFF
--- a/standard/standard_4.php
+++ b/standard/standard_4.php
@@ -760,7 +760,6 @@ function getallheaders(): false|array {}
  * @link https://php.net/manual/en/function.connection-aborted.php
  * @return int 1 if client disconnected, 0 otherwise.
  */
-#[Pure(true)]
 function connection_aborted(): int {}
 
 /**
@@ -770,7 +769,6 @@ function connection_aborted(): int {}
  * CONNECTION_XXX constants to determine the connection
  * status.
  */
-#[Pure(true)]
 function connection_status(): int {}
 
 /**


### PR DESCRIPTION
in chunked requests/response mode, connection status can change in flight

see e.g. https://github.com/sabre-io/http/pull/207