### PR TITLE
Remove compareDocumentPosition

### DIFF
--- a/dom/dom_c.php
+++ b/dom/dom_c.php
@@ -254,6 +254,7 @@ class DOMNode
 
     /**
      * @param DOMNode $other
+     * @removed 8.0
      */
     public function compareDocumentPosition(DOMNode $other) {}
 


### PR DESCRIPTION
This was never implemented in PHP, and got removed as a consequence in PHP 8.0. This might be introduced later, but for now the stubs shouldn't contain a method that isn't there.