### PR TITLE
protocol_version was always an int property

### DIFF
--- a/mysqli/mysqli.php
+++ b/mysqli/mysqli.php
@@ -169,7 +169,7 @@ class mysqli
     public $sqlstate;
 
     /**
-     * @var string
+     * @var int
      */
     #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
     public $protocol_version;


### PR DESCRIPTION
https://www.php.net/manual/en/mysqli.get-proto-info.php The stubs were wrong. 