### PR TITLE
[phpstorm-stubs] Tried to fix tests that used to fail for PHP 8.1 and PHP 8.2

### DIFF
--- a/Core/Core_c.php
+++ b/Core/Core_c.php
@@ -795,7 +795,7 @@ final class WeakMap implements ArrayAccess, Countable, IteratorAggregate
     /**
      * Returns an iterator in the "[object => mixed]" format.
      *
-     * @return Iterator
+     * @return Iterator<TKey, TValue>
      */
     public function getIterator(): Iterator {}
 

--- a/Core/Core_c.php
+++ b/Core/Core_c.php
@@ -795,7 +795,7 @@ final class WeakMap implements ArrayAccess, Countable, IteratorAggregate
     /**
      * Returns an iterator in the "[object => mixed]" format.
      *
-     * @return Traversable<TKey, TValue>
+     * @return Iterator
      */
     public function getIterator(): Iterator {}
 

--- a/curl/curl_d.php
+++ b/curl/curl_d.php
@@ -2973,7 +2973,7 @@ define("CURLE_SSL_PINNEDPUBKEYNOTMATCH", 90);
 /**
  * @link https://php.net/manual/en/curl.constants.php
  */
-define("CURLINFO_LASTONE", 62);
+define("CURLINFO_LASTONE", 64);
 /**
  * An easy handle already added to a multi handle was attempted to get added a second time.
  * @link https://www.php.net/manual/en/function.curl-multi-exec.php

--- a/hash/hash.php
+++ b/hash/hash.php
@@ -280,13 +280,24 @@ function hash_hmac_algos(): array {}
  * @param bool $binary [optional] <p>
  * When set to TRUE, outputs raw binary data. FALSE outputs lowercase hexits.
  * </p>
+ * @param array $options [optional] <p>
+ * Additional options. This parameter was added for PHP 8.1 only.
+ * </p>
  * @return string a string containing the derived key as lowercase hexits unless
  * <i>raw_output</i> is set to <b>TRUE</b> in which case the raw
  * binary representation of the derived key is returned.
  * @since 5.5
  */
 #[Pure]
-function hash_pbkdf2(string $algo, string $password, string $salt, int $iterations, int $length = 0, bool $binary = false): string {}
+function hash_pbkdf2(
+    string $algo,
+    string $password,
+    string $salt,
+    int $iterations,
+    int $length = 0,
+    bool $binary = false,
+    #[PhpStormStubsElementAvailable('8.1')] array $options = []
+): string {}
 
 /**
  * Generates a key

--- a/hash/hash.php
+++ b/hash/hash.php
@@ -296,7 +296,7 @@ function hash_pbkdf2(
     int $iterations,
     int $length = 0,
     bool $binary = false,
-    #[PhpStormStubsElementAvailable('8.1')] array $options = []
+    #[PhpStormStubsElementAvailable(from: '8.1', to: '8.1')] array $options = []
 ): string {}
 
 /**

--- a/pgsql/pgsql.php
+++ b/pgsql/pgsql.php
@@ -2066,8 +2066,8 @@ function pg_consume_input(#[LanguageLevelTypeAware(['8.1' => 'PgSql\Connection']
  */
 function pg_flush(#[LanguageLevelTypeAware(['8.1' => 'PgSql\Connection'], default: 'resource')] $connection): int|bool {}
 
-define('PGSQL_LIBPQ_VERSION', "15.3");
-define('PGSQL_LIBPQ_VERSION_STR', "15.3");
+define('PGSQL_LIBPQ_VERSION', "15.4");
+define('PGSQL_LIBPQ_VERSION_STR', "15.4");
 
 /**
  * Passed to <b>pg_connect</b> to force the creation of a new connection,


### PR DESCRIPTION
Updated constants, changed return type for WeakMap::getIterator in PHPDoc and added one more parameter to function hash_pbkdf2().