### PR TITLE
get rid of misleading version string

### DIFF
--- a/standard/standard_9.php
+++ b/standard/standard_9.php
@@ -113,7 +113,6 @@ function array_values(array $array): array {}
 function array_count_values(array $array): array {}
 
 /**
- * (PHP 5 &gt;=5.5.0)<br/>
  * Return the values from a single column in the input array
  * @link https://secure.php.net/manual/en/function.array-column.php
  * @param array $array <p>A multi-dimensional array (record set) from which to pull a column of values.</p>


### PR DESCRIPTION
Rather than adding PHP 7 and PHP 8 to the top here, just remove the line