### PR TITLE
fix SplHeap::extract phpdoc return type

### DIFF
--- a/SPL/SPL_c1.php
+++ b/SPL/SPL_c1.php
@@ -1372,7 +1372,7 @@ abstract class SplHeap implements Iterator, Countable
     /**
      * Extracts a node from top of the heap and sift up.
      * @link https://php.net/manual/en/splheap.extract.php
-     * @return mixed The value of the extracted node.
+     * @return TValue The value of the extracted node.
      */
     #[TentativeType]
     public function extract(): mixed {}


### PR DESCRIPTION
It looks like `SplHeap::extract` was accidentally overlooked when the generic type was added.

BTW: There's also an inconsistency between `SplMinHeap` and `SplMaxHeap`. `SplMinHeap` has some of the `SplHeap` methods duplicated, whereas `SplMaxHeap` doesn't have the duplicated methods.