### PR TITLE
Fix SPL ArrayObject::__construct(, $flags, $iteratorClass)

### DIFF
--- a/SPL/SPL.php
+++ b/SPL/SPL.php
@@ -1551,8 +1551,8 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
      */
     public function __construct(
         #[LanguageLevelTypeAware(['8.0' => 'object|array'], default: '')] $array = [],
-        #[PhpStormStubsElementAvailable(from: '7.0')] #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $flags = 0,
-        #[PhpStormStubsElementAvailable(from: '7.0')] #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $iteratorClass = "ArrayIterator"
+        #[PhpStormStubsElementAvailable(from: '5.3')] #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $flags = 0,
+        #[PhpStormStubsElementAvailable(from: '5.3')] #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $iteratorClass = "ArrayIterator"
     ) {}
 
     /**

--- a/tests/TestData/mutedProblems.json
+++ b/tests/TestData/mutedProblems.json
@@ -1670,6 +1670,25 @@
       ]
     },
     {
+      "name": "ArrayObject",
+      "methods": [
+        {
+          "name": "__construct",
+          "problems": [
+            {
+              "description": "parameter mismatch",
+              "versions": [
+                5.3,
+                5.4,
+                5.5,
+                5.6
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
       "name": "RecursiveRegexIterator",
       "methods": [
         {


### PR DESCRIPTION
Element is available from PHP 5.1, not 7.0. [1]

The lowest common denominator is 5.3.

[1]: https://github.com/php/php-src/blob/php-5.1.0/ext/spl/spl_array.c#L787