### PR TITLE
Made `ReflectionProperty::setAccessible()` non-`Pure`

### DIFF
--- a/Reflection/ReflectionProperty.php
+++ b/Reflection/ReflectionProperty.php
@@ -239,7 +239,6 @@ class ReflectionProperty implements Reflector
      * @param bool $accessible A boolean {@see true} to allow accessibility, or {@see false}
      * @return void No value is returned.
      */
-    #[Pure]
     #[PhpStormStubsElementAvailable(from: "8.1")]
     #[TentativeType]
     public function setAccessible(bool $accessible): void {}


### PR DESCRIPTION
The `ReflectionProperty::setAccessible()` method is no value returns. This method cannot be `Pure`.