### PR TITLE
Update types for setcookie parameters

### DIFF
--- a/standard/standard_4.php
+++ b/standard/standard_4.php
@@ -603,7 +603,7 @@ function restore_include_path() {}
  * setcookie successfully runs, it will return true.
  * This does not indicate whether the user accepted the cookie.
  */
-function setcookie(string $name, $value = "", $expires_or_options = 0, $path = "", $domain = "", $secure = false, $httponly = false): bool {}
+function setcookie(string $name, string $value = "", int $expires_or_options = 0, string $path = "", string $domain = "", bool $secure = false, bool $httponly = false): bool {}
 
 /**
  * Send a cookie
@@ -626,7 +626,7 @@ function setcookie(string $name, $value = "", $expires_or_options = 0, $path = "
  *                        This does not indicate whether the user accepted the cookie.
  * @since 7.3
  */
-function setcookie(string $name, $value = '', array $options = []): bool {}
+function setcookie(string $name, string $value = '', array $options = []): bool {}
 
 /**
  * Send a cookie without urlencoding the cookie value


### PR DESCRIPTION
Add data type to every `setcookie` parameters to reflect its requirements.

```php
<?php

declare(strict_types=1);

// Type Error: setcookie() expects parameter 2 to be string, int given
setcookie('IS_WEBP_SUPPORTED', 1, ['httponly' => true, 'samesite' => 'Lax']);
```
Function `setcookie` requires strict types for every parameter. Current PHPStorm `PhpStorm-231.8109.199/plugins/php-impl/lib/php.jar!/stubs/standard/standard_4.php` does not reflect that, which may results to a fatal in production in case of unaware developer.