### PR TITLE
Update MongoDB stubs for 1.17

### DIFF
--- a/PhpStormStubsMap.php
+++ b/PhpStormStubsMap.php
@@ -693,6 +693,7 @@ const CLASSES = array (
   'MongoDB\\Driver\\Monitoring\\CommandStartedEvent' => 'mongodb/Monitoring/CommandStartedEvent.php',
   'MongoDB\\Driver\\Monitoring\\CommandSubscriber' => 'mongodb/Monitoring/CommandSubscriber.php',
   'MongoDB\\Driver\\Monitoring\\CommandSucceededEvent' => 'mongodb/Monitoring/CommandSucceededEvent.php',
+  'MongoDB\\Driver\\Monitoring\\LogSubscriber' => 'mongodb/Monitoring/LogSubscriber.php',
   'MongoDB\\Driver\\Monitoring\\SDAMSubscriber' => 'mongodb/Monitoring/SDAMSubscriber.php',
   'MongoDB\\Driver\\Monitoring\\ServerChangedEvent' => 'mongodb/Monitoring/ServerChangedEvent.php',
   'MongoDB\\Driver\\Monitoring\\ServerClosedEvent' => 'mongodb/Monitoring/ServerClosedEvent.php',

--- a/mongodb/BSON/Document.php
+++ b/mongodb/BSON/Document.php
@@ -28,6 +28,18 @@ final class Document implements \IteratorAggregate, \Serializable
 
     final public function toRelaxedExtendedJSON(): string {}
 
+    /** @since 1.17.0 */
+    public function offsetExists(mixed $offset): bool {}
+
+    /** @since 1.17.0 */
+    public function offsetGet(mixed $offset): mixed {}
+
+    /** @since 1.17.0 */
+    public function offsetSet(mixed $offset, mixed $value): void {}
+
+    /** @since 1.17.0 */
+    public function offsetUnset(mixed $offset): void {}
+
     final public function __toString(): string {}
 
     final public static function __set_state(array $properties): Document {}

--- a/mongodb/BSON/PackedArray.php
+++ b/mongodb/BSON/PackedArray.php
@@ -20,6 +20,18 @@ final class PackedArray implements \IteratorAggregate, \Serializable
 
     final public function toPHP(?array $typeMap = null): array|object {}
 
+    /** @since 1.17.0 */
+    public function offsetExists(mixed $offset): bool {}
+
+    /** @since 1.17.0 */
+    public function offsetGet(mixed $offset): mixed {}
+
+    /** @since 1.17.0 */
+    public function offsetSet(mixed $offset, mixed $value): void {}
+
+    /** @since 1.17.0 */
+    public function offsetUnset(mixed $offset): void {}
+
     final public function __toString(): string {}
 
     final public static function __set_state(array $properties): PackedArray {}

--- a/mongodb/BSON/Persistable.php
+++ b/mongodb/BSON/Persistable.php
@@ -2,8 +2,14 @@
 
 namespace MongoDB\BSON;
 
+use stdClass;
+
 /**
  * Classes may implement this interface to take advantage of automatic ODM (object document mapping) behavior in the driver.
  * @link https://php.net/manual/en/class.mongodb-bson-persistable.php
  */
-interface Persistable extends Unserializable, Serializable {}
+interface Persistable extends Unserializable, Serializable
+{
+    /** @since 1.17.0 */
+    public function bsonSerialize(): array|stdClass|Document;
+}

--- a/mongodb/BSON/Serializable.php
+++ b/mongodb/BSON/Serializable.php
@@ -2,6 +2,8 @@
 
 namespace MongoDB\BSON;
 
+use stdClass;
+
 /**
  * Classes that implement this interface may return data to be serialized as a BSON array or document in lieu of the object's public properties
  * @link https://php.net/manual/en/class.mongodb-bson-serializable.php
@@ -14,7 +16,6 @@ interface Serializable extends Type
      * Root documents (e.g. a MongoDB\BSON\Serializable passed to MongoDB\BSON\fromPHP()) will always be serialized as a BSON document.
      * For field values, associative arrays and stdClass instances will be serialized as a BSON document and sequential arrays (i.e. sequential, numeric indexes starting at 0) will be serialized as a BSON array.
      * @link https://php.net/manual/en/mongodb-bson-serializable.bsonserialize.php
-     * @return array|object An array or stdClass to be serialized as a BSON array or document.
      */
-    public function bsonSerialize();
+    public function bsonSerialize(): array|stdClass|Document|PackedArray;
 }

--- a/mongodb/Monitoring/LogSubscriber.php
+++ b/mongodb/Monitoring/LogSubscriber.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace MongoDB\Driver\Monitoring;
+
+/**
+ * @since 1.17.0
+ * @link https://www.php.net/manual/en/class.mongodb-driver-monitoring-logsubscriber.php
+ */
+interface LogSubscriber extends Subscriber
+{
+    public const LEVEL_ERROR = 0;
+    public const LEVEL_CRITICAL = 1;
+    public const LEVEL_WARNING = 2;
+    public const LEVEL_MESSAGE = 3;
+    public const LEVEL_INFO = 4;
+    public const LEVEL_DEBUG = 5;
+
+    /* MONGOC_LOG_LEVEL_TRACE is intentionally omitted. Trace logs are only
+     * reported via streams (i.e. mongodb.debug INI), so the constant is not
+     * relevant to LogSubscriber implementations. */
+
+    public function log(int $level, string $domain, string $message): void;
+}

--- a/mongodb/ReadConcern.php
+++ b/mongodb/ReadConcern.php
@@ -5,6 +5,7 @@ namespace MongoDB\Driver;
 use MongoDB\BSON\Serializable;
 use MongoDB\Driver\Exception\InvalidArgumentException;
 use MongoDB\Driver\Exception\UnexpectedValueException;
+use stdClass;
 
 /**
  * MongoDB\Driver\ReadConcern controls the level of isolation for read operations for replica sets and replica set shards. This option requires the WiredTiger storage engine and MongoDB 3.2 or later.
@@ -51,7 +52,7 @@ final class ReadConcern implements Serializable, \Serializable
      * @link https://php.net/manual/en/mongodb-driver-readconcern.bsonserialize.php
      * @since 1.2.0
      */
-    final public function bsonSerialize(): array|object {}
+    final public function bsonSerialize(): stdClass {}
 
     /**
      * Checks if this is the default read concern

--- a/mongodb/ReadPreference.php
+++ b/mongodb/ReadPreference.php
@@ -5,6 +5,7 @@ namespace MongoDB\Driver;
 use MongoDB\BSON\Serializable;
 use MongoDB\Driver\Exception\InvalidArgumentException;
 use MongoDB\Driver\Exception\UnexpectedValueException;
+use stdClass;
 
 /**
  * Class ReadPreference
@@ -99,7 +100,7 @@ final class ReadPreference implements Serializable, \Serializable
      * @return object Returns an object for serializing the WriteConcern as BSON.
      * @throws InvalidArgumentException
      */
-    final public function bsonSerialize(): array|object {}
+    final public function bsonSerialize(): stdClass {}
 
     /**
      * Serialize a ReadPreference

--- a/mongodb/ServerApi.php
+++ b/mongodb/ServerApi.php
@@ -2,6 +2,8 @@
 
 namespace MongoDB\Driver;
 
+use stdClass;
+
 final class ServerApi implements \MongoDB\BSON\Serializable, \Serializable
 {
     public const V1 = 1;
@@ -14,5 +16,5 @@ final class ServerApi implements \MongoDB\BSON\Serializable, \Serializable
 
     final public function serialize(): string {}
 
-    final public function bsonSerialize(): array|object {}
+    final public function bsonSerialize(): stdClass {}
 }

--- a/mongodb/WriteConcern.php
+++ b/mongodb/WriteConcern.php
@@ -5,6 +5,7 @@ namespace MongoDB\Driver;
 use MongoDB\BSON\Serializable;
 use MongoDB\Driver\Exception\InvalidArgumentException;
 use MongoDB\Driver\Exception\UnexpectedValueException;
+use stdClass;
 
 /**
  * WriteConcern controls the acknowledgment of a write operation, specifies the level of write guarantee for Replica Sets.
@@ -53,7 +54,7 @@ final class WriteConcern implements Serializable, \Serializable
      * @return array|object Returns an object for serializing the WriteConcern as BSON.
      * @throws InvalidArgumentException
      */
-    final public function bsonSerialize(): array|object {}
+    final public function bsonSerialize(): stdClass {}
 
     /**
      * Serialize a WriteConcern


### PR DESCRIPTION
Updates stubs for the latest minor version of ext-mongodb.

Note that I wasn't able to run any checks locally:
```
docker-compose -f docker-compose.yml run -e PHP_VERSION=8.0 test_runner composer cs
WARN[0000] The "PHP_VERSION" variable is not set. Defaulting to a blank string.
[...]
PHP needs to be a minimum version of PHP 7.4.0 and maximum version of PHP 8.1.*.
Current PHP version: 8.3.0RC6.
To ignore this requirement please set `PHP_CS_FIXER_IGNORE_ENV`.
If you use PHP version higher than supported, you may experience code modified in a wrong way.
Please report such cases at https://github.com/PHP-CS-Fixer/PHP-CS-Fixer .
Script php-cs-fixer fix -v --diff --dry-run handling the cs event returned with error code 1
```

Notice how despite me passing `PHP_VERSION` as is done in CI and other places, the variable was still ignored. Is that a known issue?