### PR TITLE
Add type declaration for argument 3 in `php_user_filter::filter()`

### DIFF
--- a/standard/standard_0.php
+++ b/standard/standard_0.php
@@ -74,7 +74,7 @@ class php_user_filter
     public function filter(
         $in,
         $out,
-        &$consumed,
+        #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] &$consumed,
         #[LanguageLevelTypeAware(['8.0' => 'bool'], default: '')] $closing
     ): int {}
 


### PR DESCRIPTION
BTW, I don't know if this change should be provided through `LanguageLevelTypeAware`, as I am not aware when this type was defined.

See: https://github.com/php/php-src/pull/12924#pullrequestreview-1777059768.