### PR TITLE
BackedEnum::from() can also throw TypeError

### DIFF
--- a/Core/Core_c.php
+++ b/Core/Core_c.php
@@ -933,6 +933,7 @@ interface BackedEnum extends UnitEnum
      * <code>ValueError</code>.
      * @param int|string $value
      * @throws ValueError
+     * @throws TypeError
      * @return static
      * @link https://www.php.net/manual/en/backedenum.from.php
      */


### PR DESCRIPTION
See: https://3v4l.org/taNPv