### PR TITLE
`mb_get_info` can return `null`

### DIFF
--- a/mbstring/mbstring.php
+++ b/mbstring/mbstring.php
@@ -904,7 +904,7 @@ function mb_send_mail(string $to, string $subject, string $message, array|string
  * "http_input", "internal_encoding", "func_overload",
  * the specified setting parameter will be returned.
  * </p>
- * @return array|string|int|false An array of type information if type
+ * @return array|string|int|false|null An array of type information if type
  * is not specified, otherwise a specific type.
  */
 #[Pure]
@@ -923,7 +923,7 @@ function mb_send_mail(string $to, string $subject, string $message, array|string
     'substitute_character' => 'string',
     'strict_detection' => 'string',
 ])]
-function mb_get_info(string $type = 'all'): array|string|int|false {}
+function mb_get_info(string $type = 'all'): array|string|int|false|null {}
 
 /**
  * Check if the string is valid for the specified encoding


### PR DESCRIPTION
Accidentally noticed the [test doesn't pass](https://github.com/JetBrains/phpstorm-stubs/actions/runs/7385050348/job/20089071420#step:6:722) on CI

I looked at the [stubs](https://github.com/php/php-src/blob/8e38226abf78758152c6097104f63ae7ff73fae4/ext/mbstring/mbstring.stub.php#L182) in `php-src` and `mb_get_info` really can return `null`. This should be the case since version [5.4](https://github.com/php/php-src/issues/12753#issuecomment-1826811933) https://onlinephp.io/c/80664

Before PR [#12787](https://github.com/php/php-src/issues/12753), it just wasn't specified.