### PR TITLE
Update actions/checkout to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     name: Run tests against php ${{matrix.php}}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Build Docker Container
         run: docker-compose -f docker-compose.yml build >/dev/null
@@ -38,7 +38,7 @@ jobs:
     name: Run cs-fixer and stubs structure tests
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Composer Install
         run: docker-compose -f docker-compose.yml run test_runner composer install

--- a/.github/workflows/testLinks.yml
+++ b/.github/workflows/testLinks.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Composer Install
         run: docker-compose -f docker-compose.yml run test_runner composer install

--- a/.github/workflows/testPeclExtensions.yml
+++ b/.github/workflows/testPeclExtensions.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Build Docker Container
         run: docker-compose -f docker-compose.yml build >/dev/null


### PR DESCRIPTION
This resolves the [`The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2` warning seen](https://github.com/JetBrains/phpstorm-stubs/actions/runs/7505906968) when running Actions.

See also: [actions/checkout changelog](https://github.com/actions/checkout/blob/main/CHANGELOG.md)