### PR TITLE
php-ds: add missed return types for the getIterator() methods

### DIFF
--- a/ds/ds.php
+++ b/ds/ds.php
@@ -563,6 +563,9 @@ namespace Ds;
          */
         public function get(int $index) {}
 
+        /**
+         * @return Traversable<TValue>
+         */
         public function getIterator(): Traversable {}
 
         /**
@@ -871,6 +874,9 @@ namespace Ds;
          */
         public function copy(): Collection {}
 
+        /**
+         * @return Traversable<TValue>
+         */
         public function getIterator(): Traversable {}
 
         /**
@@ -1342,6 +1348,9 @@ namespace Ds;
          */
         public function get($key, $default = null) {}
 
+        /**
+         * @return Traversable<TValue>
+         */
         public function getIterator(): Traversable {}
 
         /**
@@ -2019,6 +2028,9 @@ namespace Ds;
          */
         public function get(int $index) {}
 
+        /**
+         * @return Traversable<TValue>
+         */
         public function getIterator(): Traversable {}
 
         /**
@@ -2364,6 +2376,9 @@ namespace Ds;
          */
         public function copy(): Stack {}
 
+        /**
+         * @return Traversable<TValue>
+         */
         public function getIterator(): Traversable {}
 
         /**
@@ -2659,6 +2674,9 @@ namespace Ds;
          */
         public function copy() {}
 
+        /**
+         * @return Traversable<TValue>
+         */
         public function getIterator(): Traversable {}
 
         /**


### PR DESCRIPTION
Image that you have a method which returns a generic collection:
```
/**
 * @return Vector<Communication>
 */
public function getCollection(): Vector{
  return new Vector([new Communication(), new Communication()]);
}
```
And also you have another method where you iterate over that collection:
```
public function test()
{
  $list = $this->getCollection();
  foreach($collection as $item){
    ..
  }
}
```
If both methods are in the same class, everything works good. But if these classes are in different classes, phpstorm will no understand a time of collection's item inside foreach.

Everything works properly for the Queue collection, but there is problems with other collections. I see that there is a phpdoc for the Queue::getIterator() method:
```
/**
 * @return Traversable<TValue>
 */
 public function getIterator(): Traversable {}
```
but there is no such ones for other collection.

So this MR fixes this issue