### PR TITLE
Fix xTrim threshold parameter

### DIFF
--- a/redis/Redis.php
+++ b/redis/Redis.php
@@ -5527,7 +5527,7 @@ class Redis
      * (this is more efficient)
      *
      * @param string $stream    The STREAM key to trim.
-     * @param string $threshold This can either be a maximum length, or a minimum id.
+     * @param int    $threshold This can either be a maximum length, or a minimum id.
      *                          MAXLEN - An integer describing the maximum desired length of the stream after the command.
      *                          MINID  - An ID that will become the new minimum ID in the stream, as Redis will trim all
      *                          messages older than this ID.

--- a/redis/Redis.php
+++ b/redis/Redis.php
@@ -5522,34 +5522,26 @@ class Redis
     public function xRevRange($stream, $end, $start, $count = -1) {}
 
     /**
-     * Trim the stream length to a given maximum.
-     * If the "approximate" flag is pasesed, Redis will use your size as a hint but only trim trees in whole nodes
-     * (this is more efficient)
+     * Truncate a STREAM key in various ways.
      *
-     * @param string $stream    The STREAM key to trim.
-     * @param int    $threshold This can either be a maximum length, or a minimum id.
+     * @param string $key       The STREAM key to trim.
+     * @param string $threshold This can either be a maximum length, or a minimum id.
      *                          MAXLEN - An integer describing the maximum desired length of the stream after the command.
      *                          MINID  - An ID that will become the new minimum ID in the stream, as Redis will trim all
-     *                          messages older than this ID.
+     *                                   messages older than this ID.
      * @param bool   $approx    Whether redis is allowed to do an approximate trimming of the stream.  This is
      *                          more efficient for Redis given how streams are stored internally.
      * @param bool   $minid     When set to `true`, users should pass a minimum ID to the `$threshold` argument.
      * @param int    $limit     An optional upper bound on how many entries to trim during the command.
      *
-     * @return false|int|Redis The number of messages trimed from the stream or Redis if in multimode
+     * @return Redis|int|false  The number of entries deleted from the stream.
      *
-     * @throws RedisException
+     * @see https://redis.io/commands/xtrim
      *
-     * @link    https://redis.io/commands/xtrim
-     * @example
-     * <pre>
-     * // Trim to exactly 100 messages
-     * $redis->xTrim('mystream', 100);
-     * // Let Redis approximate the trimming
-     * $redis->xTrim('mystream', 100, true);
-     * </pre>
+     * @example $redis->xTrim('stream', 3);
+     * @example $redis->xTrim('stream', '2-1', false, true);
      */
-    public function xTrim($stream, $threshold, $approx = false, $minid = false, $limit = -1) {}
+    public function xtrim(string $key, string $threshold, bool $approx = false, bool $minid = false, int $limit = -1): Redis|int|false;
 
     /**
      * Adds a values to the set value stored at key.


### PR DESCRIPTION
threshold accept both int and string.

I'M not sure if a whole update from https://github.com/phpredis/phpredis/blob/5d293245cdd55cc16b8735a788f06d4cb98bf65c/redis.stub.php#L3964 make sense. But it look like there is a big diff between them.