### PR TITLE
Add missing key `ec` in return for function `openssl_pkey_get_details`

### DIFF
--- a/openssl/openssl.php
+++ b/openssl/openssl.php
@@ -142,7 +142,7 @@ function openssl_pkey_get_public(#[LanguageLevelTypeAware(['8.0' => 'OpenSSLAsym
  * Depending on the key type used, additional details may be returned. Note that
  * some elements may not always be available.
  */
-#[ArrayShape(["bits" => "int", "key" => "string", "rsa" => "array", "dsa" => "array", "dh" => "array", "type" => "int"])]
+#[ArrayShape(["bits" => "int", "key" => "string", "rsa" => "array", "dsa" => "array", "dh" => "array", "ec" => "array", "type" => "int"])]
 function openssl_pkey_get_details(#[LanguageLevelTypeAware(["8.0" => "OpenSSLAsymmetricKey"], default: "resource")] $key): array|false {}
 
 /**


### PR DESCRIPTION
OPENSSL_KEYTYPE_EC, an additional array key named "ec", containing the key data is returned. 

Source:
https://www.php.net/manual/en/function.openssl-pkey-get-details.php