### PR TITLE
Correct the `result_code` argument name

### DIFF
--- a/standard/standard_2.php
+++ b/standard/standard_2.php
@@ -660,7 +660,7 @@ function unlink(string $filename, $context): bool {}
  * exec.
  * </p>
  * @param int &$result_code [optional] <p>
- * If the return_var argument is present
+ * If the result_code argument is present
  * along with the output argument, then the
  * return status of the executed command will be written to this
  * variable.
@@ -682,7 +682,7 @@ function exec(string $command, &$output, &$result_code): string|false {}
  * The command that will be executed.
  * </p>
  * @param int &$result_code [optional] <p>
- * If the return_var argument is present, then the
+ * If the result_code argument is present, then the
  * return status of the executed command will be written to this
  * variable.
  * </p>
@@ -720,7 +720,7 @@ function escapeshellarg(string $arg): string {}
  * The command that will be executed.
  * </p>
  * @param int &$result_code [optional] <p>
- * If the return_var argument is present, the
+ * If the result_code argument is present, the
  * return status of the Unix command will be placed here.
  * </p>
  * @return bool|null null on success or false on failure.


### PR DESCRIPTION
In the methods `passthru`, `exec` and `system`, the argument `result_code` was incorrectly named `return_var` in the function description