### PR TITLE
Let EvLoop::defaultLoop() return an EvLoop instance

### DIFF
--- a/Ev/Ev.php
+++ b/Ev/Ev.php
@@ -1576,11 +1576,12 @@ final class EvLoop
      * @param mixed $data
      * @param float $io_interval
      * @param float $timeout_interval
+     * @return EvLoop 
      */
     public static function defaultLoop(
         int $flags = Ev::FLAG_AUTO,
         mixed $data = null,
         float $io_interval = 0.0,
         float $timeout_interval = 0.0
-    ) {}
+    ): EvLoop {}
 }


### PR DESCRIPTION
Currently in PHPStorm: 'void' method 'defaultLoop' result used.

According to the documentation it either returns the default loop, or creates + returns it.