### PR TITLE
Hide command progress bars in CI job output

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
           PHP_VERSION: ${{matrix.php}}
 
       - name: Composer Install
-        run: docker-compose -f docker-compose.yml run -e PHP_VERSION=${{matrix.php}} test_runner composer install
+        run: docker-compose -f docker-compose.yml run -e PHP_VERSION=${{matrix.php}} test_runner composer install --no-progress
         env:
           PHP_VERSION: ${{matrix.php}}
 
@@ -30,7 +30,7 @@ jobs:
           PHP_VERSION: ${{matrix.php}}
 
       - name: Run Tests
-        run: docker-compose -f docker-compose.yml run -e PHP_VERSION=${{matrix.php}} test_runner vendor/bin/phpunit --testsuite PHP_${{matrix.php}}
+        run: docker-compose -f docker-compose.yml run -e PHP_VERSION=${{matrix.php}} test_runner vendor/bin/phpunit --no-progress --testsuite PHP_${{matrix.php}}
         env:
           PHP_VERSION: ${{matrix.php}}
   additional:
@@ -41,13 +41,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Composer Install
-        run: docker-compose -f docker-compose.yml run test_runner composer install
+        run: docker-compose -f docker-compose.yml run test_runner composer install --no-progress
 
       - name: Test PhpDoc
-        run: docker-compose -f docker-compose.yml run test_runner vendor/bin/phpunit --testsuite PhpDoc
+        run: docker-compose -f docker-compose.yml run test_runner vendor/bin/phpunit --no-progress --testsuite PhpDoc
 
       - name: Test Stubs Map, Structure and Reflection
-        run: docker-compose -f docker-compose.yml run test_runner vendor/bin/phpunit --testsuite Structure
+        run: docker-compose -f docker-compose.yml run test_runner vendor/bin/phpunit --no-progress --testsuite Structure
 
       - name: run cs fixer
-        run: docker-compose -f docker-compose.yml run test_runner composer cs
+        run: docker-compose -f docker-compose.yml run test_runner composer cs -- --show-progress=none


### PR DESCRIPTION
Each of these jobs prints a progress bar of the completion of the tasks.  While the composer install usually completes within a few seconds and only logs 4-5 lines of output, the phpunit job takes several minutes and outputs over 800 lines (about 64 kb) of progress bars.  This change removes the printing of progress bars in CI only--local runs are not affected.  This should reduce storage needs and make logs easier to read by humans.