### PR TITLE
fix: ArrayObject::offsetGet return type

### DIFF
--- a/SPL/SPL.php
+++ b/SPL/SPL.php
@@ -1572,7 +1572,7 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
      * @param TKey $key <p>
      * The index with the value.
      * </p>
-     * @return TValue|false The value at the specified index or false.
+     * @return TValue|null The value at the specified index or null.
      */
     #[TentativeType]
     public function offsetGet(#[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $key): mixed {}


### PR DESCRIPTION
ArrayObject:offsetGet should return `TValue|null`

See https://www.php.net/manual/en/arrayobject.offsetget.php#refsect1-arrayobject.offsetget-returnvalues