### PR TITLE
Fix: `Spoofchecker::areConfusable()` `$errorCode` param is int

### DIFF
--- a/intl/intl.php
+++ b/intl/intl.php
@@ -2543,7 +2543,7 @@ class Spoofchecker
      * </p>
      * @param string $string2 <p>
      * </p>
-     * @param string &$errorCode [optional] <p>
+     * @param int &$errorCode [optional] <p>
      * </p>
      * @return bool
      */


### PR DESCRIPTION
Updating this to match the manual: https://www.php.net/manual/en/spoofchecker.areconfusable.php

This was updated in the manual by php/doc-en#907

