### PR TITLE
Make ReflectionMethod->getClosure() always return Closure

### DIFF
--- a/Reflection/ReflectionMethod.php
+++ b/Reflection/ReflectionMethod.php
@@ -189,8 +189,10 @@ class ReflectionMethod extends ReflectionFunctionAbstract
      * Returns a dynamically created closure for the method
      *
      * @link https://php.net/manual/en/reflectionmethod.getclosure.php
-     * @param object $object Forbidden for static methods, required for other methods or nothing.
-     * @return Closure|null Returns {@see Closure} or {@see null} in case of an error.
+     * @param object|null $object Forbidden for static methods, required for other methods or nothing.
+     * @return Closure Returns the newly created {@see Closure}.
+     * @throws ValueError if object is null but the method is non-static.
+     * @throws ReflectionException if object is not an instance of the class this method was declared in.
      * @since 5.4
      */
     #[Pure]


### PR DESCRIPTION
phpstan reports that `getClosure()` may return null and this creates unnecessary false reporting. New versions of PHP don't return null and instead throw an exceptions