### PR TITLE
Document return type value of set_error_handler and error handler chaining

### DIFF
--- a/Core/Core.php
+++ b/Core/Core.php
@@ -668,6 +668,10 @@ function user_error(string $message, int $error_level = E_USER_NOTICE): bool {}
  * <i>errno</i>
  * The first parameter, <i>errno</i>, contains the
  * level of the error raised, as an integer.</p>
+ * The user function should stop execution if necessary by calling `exit()`.
+ * If the function returns a value other than false, script execution will
+ * continue with the next statement after the one that caused an error.
+ * If the function returns false, the standard PHP error handler is called.
  * @param int $error_levels [optional] <p>
  * Can be used to mask the triggering of the
  * <i>error_handler</i> function just like the error_reporting ini setting
@@ -680,6 +684,17 @@ function user_error(string $message, int $error_level = E_USER_NOTICE): bool {}
  * in case of an error such as an invalid callback. If the previous error handler
  * was a class method, this function will return an indexed array with the class
  * and the method name.
+ *
+ * Note that error_handler chaining is possible by passing the output value as a reference:
+ * ```
+ * $previousErrorHandler = set_error_handler(
+ *     static function (int $errNo, string $errstr, string $errFile, int $errLine) use (&$previousErrorHandler): bool {
+ *         // Handle specific scenarios
+ *
+ *         return $previousErrorHandler !== null ? (bool) $previousErrorHandler(...func_get_args()) : false;
+ *     }
+ * );
+ * ```
  */
 function set_error_handler(?callable $callback, int $error_levels = E_ALL|E_STRICT) {}
 


### PR DESCRIPTION
Add documentation for return type value of set_error_handler and error handler chaining based on [PHP documentation](https://www.php.net/manual/en/function.set-error-handler.php).