### PR TITLE
Fix wrong parameter name for MongoDB\Driver\Manager class

### DIFF
--- a/mongodb/Manager.php
+++ b/mongodb/Manager.php
@@ -24,12 +24,12 @@ final class Manager
      * Manager constructor.
      * @link https://php.net/manual/en/mongodb-driver-manager.construct.php
      * @param string|null $uri A mongodb:// connection URI
-     * @param array|null $options Connection string options
+     * @param array|null $uriOptions Connection string options
      * @param array|null $driverOptions Any driver-specific options not included in MongoDB connection spec.
      * @throws InvalidArgumentException on argument parsing errors
      * @throws RuntimeException if the uri format is invalid
      */
-    final public function __construct(?string $uri = null, ?array $options = null, ?array $driverOptions = null) {}
+    final public function __construct(?string $uri = null, ?array $uriOptions = null, ?array $driverOptions = null) {}
 
     final public function __wakeup() {}
 


### PR DESCRIPTION
See https://github.com/mongodb/mongo-php-driver/blob/0ced119f9d95da5d1c1a06fe412f9d26bce982e8/src/MongoDB/Manager.stub.php#L12 for the signature used in the driver.