### PR TITLE
MongoDB BSON classes implementing ArrayAccess

### DIFF
--- a/mongodb/BSON/Document.php
+++ b/mongodb/BSON/Document.php
@@ -6,7 +6,7 @@ namespace MongoDB\BSON;
  * @since 1.16.0
  * @link https://secure.php.net/manual/en/class.mongodb-bson-document.php
  */
-final class Document implements \IteratorAggregate, \Serializable
+final class Document implements \ArrayAccess, \IteratorAggregate, \Serializable
 {
     private function __construct() {}
 

--- a/mongodb/BSON/PackedArray.php
+++ b/mongodb/BSON/PackedArray.php
@@ -6,7 +6,7 @@ namespace MongoDB\BSON;
  * @since 1.16.0
  * @link https://secure.php.net/manual/en/class.mongodb-bson-packedarray.php
  */
-final class PackedArray implements \IteratorAggregate, \Serializable
+final class PackedArray implements \ArrayAccess, \IteratorAggregate, \Serializable
 {
     private function __construct() {}
 


### PR DESCRIPTION
Missing from https://github.com/JetBrains/phpstorm-stubs/pull/1590

The classes `MongoDB\BSON\Document` and `MongoDB\BSON\PackedArray` implement `ArrayAccess` since [ext-mongodb v1.17.0](https://github.com/mongodb/mongo-php-driver/releases/tag/1.17.0) by https://github.com/mongodb/mongo-php-driver/commit/2a3a9d8ce50ce4aa5ce125a2e23cdc5d43e1f625
