### PR TITLE
Add `MongoDB\BSON\UTCDateTime::toDateTimeImmutable()`

### DIFF
--- a/mongodb/BSON/UTCDateTime.php
+++ b/mongodb/BSON/UTCDateTime.php
@@ -27,6 +27,13 @@ final class UTCDateTime implements Type, UTCDateTimeInterface, \Serializable, \J
     final public function toDateTime(): \DateTime {}
 
     /**
+     * Returns the DateTimeImmutable representation of this UTCDateTime
+     * @since 1.20.0
+     * @link https://php.net/manual/en/mongodb-bson-utcdatetime.todatetimeimmutable.php
+     */
+    final public function toDateTimeImmutable(): \DateTimeImmutable {}
+
+    /**
      * Returns the string representation of this UTCDateTime
      * @link https://php.net/manual/en/mongodb-bson-utcdatetime.tostring.php
      */


### PR DESCRIPTION
New method in ext-mongodb 1.20.0

https://www.php.net/manual/en/mongodb-bson-utcdatetime.todatetimeimmutable.php

Added by https://github.com/mongodb/mongo-php-driver/pull/1611
Documented by https://github.com/php/doc-en/pull/3578