### PR TITLE
Mark `Imagick::destroy` as deprecated

### DIFF
--- a/imagick/imagick.php
+++ b/imagick/imagick.php
@@ -2098,6 +2098,7 @@ class Imagick implements Iterator, Countable
      * @link https://php.net/manual/en/imagick.destroy.php
      * @return bool <b>TRUE</b> on success.
      */
+    #[Deprecated(replacement: "%class%->clear()")]
     public function destroy() {}
 
     /**


### PR DESCRIPTION
According to https://www.php.net/manual/en/imagick.destroy.php