### PR TITLE
Update PDO fetchAll return type.

### DIFF
--- a/PDO/PDO.php
+++ b/PDO/PDO.php
@@ -1718,7 +1718,7 @@ class PDOStatement implements IteratorAggregate
      * Arguments of custom class constructor when the <i>fetch_style</i>
      * parameter is <b>PDO::FETCH_CLASS</b>.
      * </p>
-     * @return array|false <b>PDOStatement::fetchAll</b> returns an array containing
+     * @return array <b>PDOStatement::fetchAll</b> returns an array containing
      * all of the remaining rows in the result set. The array represents each
      * row as either an array of column values or an object with properties
      * corresponding to each column name.


### PR DESCRIPTION
Hi!
Please consider this PR if you think is feasible.

I was getting confused by a warning made in PhpStorm in the PDO fetchAll method, because phpstan was letting me know that it should only return and array and not false.

Looking into [PHP documentation](https://www.php.net/manual/en/pdostatement.fetchall.php) this method should return an array.

Thanks!

