### PR TITLE
Fixes types on $unique on Gearman task methods

### DIFF
--- a/gearman/gearman.php
+++ b/gearman/gearman.php
@@ -1479,7 +1479,7 @@ class GearmanClient
      * @link https://php.net/manual/en/gearmanclient.dohigh.php
      * @param string $function_name
      * @param string $workload
-     * @param string $unique
+     * @param string|null $unique
      * @return string A string representing the results of running a task
      */
     public function doHigh($function_name, $workload, $unique = null) {}
@@ -1490,10 +1490,10 @@ class GearmanClient
      * of the result. Normal and high priority tasks will get precedence over low
      * priority tasks in the job queue.
      *
-     * @link https://php.net/manual/en/gearmanclient.dolow.php
+     * @link https://php.net/manual/en/gearmanclient.donormal.php
      * @param string $function_name
      * @param string $workload
-     * @param string $unique
+     * @param string|null $unique
      * @return string A string representing the results of running a task
      */
     public function doNormal($function_name, $workload, $unique = null) {}
@@ -1593,7 +1593,7 @@ class GearmanClient
      * @param string $function_name
      * @param string $workload
      * @param mixed $context
-     * @param string $unique
+     * @param string|null $unique
      * @return GearmanTask|false A GearmanTask object or false if the task could not be added
      */
     public function addTask($function_name, $workload, $context = null, $unique = null) {}
@@ -1608,7 +1608,7 @@ class GearmanClient
      * @param string $function_name
      * @param string $workload
      * @param mixed $context
-     * @param string $unique
+     * @param string|null $unique
      * @return GearmanTask|false A GearmanTask object or false if the task could not be added
      */
     public function addTaskHigh($function_name, $workload, $context = null, $unique = null) {}
@@ -1623,7 +1623,7 @@ class GearmanClient
      * @param string $function_name
      * @param string $workload
      * @param mixed $context
-     * @param string $unique
+     * @param string|null $unique
      * @return GearmanTask|false A GearmanTask object or false if the task could not be added
      */
     public function addTaskLow($function_name, $workload, $context = null, $unique = null) {}
@@ -1637,7 +1637,7 @@ class GearmanClient
      * @param string $function_name
      * @param string $workload
      * @param mixed $context
-     * @param string $unique
+     * @param string|null $unique
      * @return GearmanTask|false A GearmanTask object or false if the task could not be added
      */
     public function addTaskBackground($function_name, $workload, $context = null, $unique = null) {}
@@ -1652,7 +1652,7 @@ class GearmanClient
      * @param string $function_name
      * @param string $workload
      * @param mixed $context
-     * @param string $unique
+     * @param string|null $unique
      * @return GearmanTask|false A GearmanTask object or false if the task could not be added
      */
     public function addTaskHighBackground($function_name, $workload, $context = null, $unique = null) {}
@@ -1667,7 +1667,7 @@ class GearmanClient
      * @param string $function_name
      * @param string $workload
      * @param mixed $context
-     * @param string $unique
+     * @param string|null $unique
      * @return GearmanTask|false A GearmanTask object or false if the task could not be added
      */
     public function addTaskLowBackground($function_name, $workload, $context = null, $unique = null) {}


### PR DESCRIPTION
Fixes the type for `$unique` on a handful of task methods.

This corrects them, as well as an incorrect link in the docs.

---

As you can see below, a small handful already had $unique as `string|null` but the majority did not.

https://github.com/JetBrains/phpstorm-stubs/blob/5686f9ceebde3d9338bea53b78d70ebde5fb5710/gearman/gearman.php#L1510-L1510

https://github.com/JetBrains/phpstorm-stubs/blob/5686f9ceebde3d9338bea53b78d70ebde5fb5710/gearman/gearman.php#L1542-L1542

https://github.com/JetBrains/phpstorm-stubs/blob/5686f9ceebde3d9338bea53b78d70ebde5fb5710/gearman/gearman.php#L1555-L1555

https://github.com/donatj/phpstorm-stubs/blob/5686f9ceebde3d9338bea53b78d70ebde5fb5710/gearman/gearman.php#L1568-L1568
