### PR TITLE
Add stubs for FrankenPHP

### DIFF
--- a/tests/TestData/Providers/Stubs/PhpCoreStubsProvider.php
+++ b/tests/TestData/Providers/Stubs/PhpCoreStubsProvider.php
@@ -176,6 +176,7 @@ class PhpCoreStubsProvider
             'fann',
             'FFI',
             'ffmpeg',
+            'frankenphp',
             'geos',
             'gnupg',
             'grpc',


### PR DESCRIPTION
Try to fix https://github.com/JetBrains/phpstorm-stubs/actions/runs/10575852193/job/29300999760 (failure introduced in #1665).

I don't manage to run tests locally.