### PR TITLE
E_STRICT is deprecated as of PHP 8.4

### DIFF
--- a/Core/Core_d.php
+++ b/Core/Core_d.php
@@ -47,6 +47,7 @@ define('E_NOTICE', 8);
  * to your code which will ensure the best interoperability
  * and forward compatibility of your code.
  * @link https://php.net/manual/en/errorfunc.constants.php
+ * @deprecated 8.4
  */
 define('E_STRICT', 2048);
 


### PR DESCRIPTION
Refs:

- https://3v4l.org/qfNga/rfc#vgit.master
- https://wiki.php.net/rfc/deprecations_php_8_4#remove_e_strict_error_level_and_deprecate_e_strict_constant