### PR TITLE
mysqli_store_result second parameter is deprecated in PHP 8.4

### DIFF
--- a/mysqli/mysqli.php
+++ b/mysqli/mysqli.php
@@ -932,7 +932,9 @@ class mysqli
      * statement should have produced a non-empty result set.
      */
     #[TentativeType]
-    public function store_result(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $mode = 0): mysqli_result|false {}
+    public function store_result(
+        #[Deprecated(since: '8.4'), LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $mode = 0
+    ): mysqli_result|false {}
 
     /**
      * Returns whether thread safety is given or not
@@ -2858,7 +2860,7 @@ function mysqli_stmt_store_result(mysqli_stmt $statement): bool {}
  * @param int $mode [optional] The option that you want to set
  * @return mysqli_result|false
  */
-function mysqli_store_result(mysqli $mysql, int $mode = 0): mysqli_result|false {}
+function mysqli_store_result(mysqli $mysql, #[Deprecated(since: "8.4")] int $mode = 0): mysqli_result|false {}
 
 /**
  * Returns the thread ID for the current connection
@@ -3654,6 +3656,9 @@ define('MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT', 64);
 define('MYSQLI_CLIENT_CAN_HANDLE_EXPIRED_PASSWORDS', 4194304);
 define('MYSQLI_OPT_CAN_HANDLE_EXPIRED_PASSWORDS', 37);
 define('MYSQLI_OPT_READ_TIMEOUT', 11);
+/**
+ * @deprecated 8.4
+ */
 define('MYSQLI_STORE_RESULT_COPY_DATA', 16);
 define('MYSQLI_TYPE_JSON', 245);
 define('MYSQLI_TRANS_COR_AND_CHAIN', 1);


### PR DESCRIPTION
References: 
1. https://github.com/php/php-src/commit/4f58d5b0df823dbdc4e629d98b3d564050e9173e#diff-ce0c5eab4a0f9d6523a97713c8bfdff9f1067e3955c745902cbd3cb3a187cbefL142
2. https://www.php.net/manual/en/mysqli.store-result.php

> 8.4.0 | Passing the mode parameter is now deprecated. The parameter has had no effect as of PHP 8.1.0.