### PR TITLE
DomImplementation::getFeature is removed in PHP 8.4

### DIFF
--- a/dom/dom_c.php
+++ b/dom/dom_c.php
@@ -500,6 +500,7 @@ class DOMImplementation
      * @param string $feature
      * @param string $version
      * @return mixed
+     * @removed 8.4
      */
     #[TentativeType]
     public function getFeature(


### PR DESCRIPTION
References:
1. https://github.com/php/php-src/commit/d9eb3783bdd6947a635f132f8c240de8f40e8704#diff-7ee66c4f1536ac84dc5bbff1b8312e2eef24b974b3e48a5c5c2bcfdf2eb8f3ceR17
2. https://wiki.php.net/rfc/deprecations_php_8_4