### PR TITLE
DomNode unimplemented methods have been removed in PHP 8.0

### DIFF
--- a/dom/dom_c.php
+++ b/dom/dom_c.php
@@ -270,6 +270,7 @@ class DOMNode
 
     /**
      * @return int
+     * @removed 8.0
      */
     #[LanguageLevelTypeAware(['8.4' => 'int'], default: '')]
     public function compareDocumentPosition(DOMNode $other) {}
@@ -334,14 +335,24 @@ class DOMNode
     /**
      * @param DOMNode|null $arg
      * @return bool
+     * @removed 8.0
      */
     #[LanguageLevelTypeAware(['8.3' => 'bool'], default: '')]
     public function isEqualNode(#[LanguageLevelTypeAware(['8.3' => 'DOMNode|null'], default: 'DOMNode')] $otherNode) {}
 
+    /**
+     * @removed 8.0
+     */
     public function getFeature($feature, $version) {}
 
+    /**
+     * @removed 8.0
+     */
     public function setUserData($key, $data, $handler) {}
 
+    /**
+     * @removed 8.0
+     */
     public function getUserData($key) {}
 
     /**

--- a/dom/dom_c.php
+++ b/dom/dom_c.php
@@ -270,7 +270,6 @@ class DOMNode
 
     /**
      * @return int
-     * @removed 8.0
      */
     #[LanguageLevelTypeAware(['8.4' => 'int'], default: '')]
     public function compareDocumentPosition(DOMNode $other) {}
@@ -335,7 +334,6 @@ class DOMNode
     /**
      * @param DOMNode|null $arg
      * @return bool
-     * @removed 8.0
      */
     #[LanguageLevelTypeAware(['8.3' => 'bool'], default: '')]
     public function isEqualNode(#[LanguageLevelTypeAware(['8.3' => 'DOMNode|null'], default: 'DOMNode')] $otherNode) {}


### PR DESCRIPTION
Reference: https://www.php.net/manual/en/class.domnode.php

> 8.0.0 | The unimplemented methods DOMNode::compareDocumentPosition(), DOMNode::isEqualNode(), DOMNode::getFeature(), DOMNode::setUserData() and DOMNode::getUserData() have been removed.