### PR TITLE
Imagick::writeImageFile supporting format parameter

### DIFF
--- a/imagick/imagick.php
+++ b/imagick/imagick.php
@@ -1243,10 +1243,13 @@ class Imagick implements Iterator, Countable
      * @param resource $filehandle <p>
      * Filehandle where to write the images
      * </p>
+     * @param string|null $format <p>
+     * The image format. The list of valid format specifiers depends on the compiled feature set of ImageMagick, and can be queried at runtime via Imagick::queryFormats().
+     * </p>
      * @return bool <b>TRUE</b> on success.
      * @throws ImagickException on error.
      */
-    public function writeImagesFile($filehandle) {}
+    public function writeImagesFile($filehandle, ?string $format = null) {}
 
     /**
      * (No version information available, might only be in SVN)<br/>

--- a/imagick/imagick.php
+++ b/imagick/imagick.php
@@ -1228,10 +1228,13 @@ class Imagick implements Iterator, Countable
      * @param resource $filehandle <p>
      * Filehandle where to write the image
      * </p>
+     * @param string|null $format <p>
+     * The image format. The list of valid format specifiers depends on the compiled feature set of ImageMagick, and can be queried at runtime via Imagick::queryFormats().
+     * </p>
      * @return bool <b>TRUE</b> on success.
      * @throws ImagickException on error.
      */
-    public function writeImageFile($filehandle) {}
+    public function writeImageFile($filehandle, ?string $format = null) {}
 
     /**
      * (No version information available, might only be in SVN)<br/>


### PR DESCRIPTION
See: 
- https://www.php.net/manual/en/imagick.writeimagefile.php
- https://www.php.net/manual/en/imagick.writeimagesfile.php
- https://pecl.php.net/package-info.php?package=imagick&version=3.2.0b1#:~:text=Added%20additional%20parameter%20to%20writeImageFile%20to%20allow%20setting%20format