### PR TITLE
Fix DateTimeInterface::createFromTimestamp() stub

### DIFF
--- a/date/date_c.php
+++ b/date/date_c.php
@@ -166,7 +166,7 @@ interface DateTimeInterface
     /**
      * @since 8.4
      */
-    public function createFromTimestamp();
+    public static function createFromTimestamp(int|float $timestamp): static;
 
     /**
      * @since 8.4


### PR DESCRIPTION
This should fix the [two errors](https://phpstan.org/r/84a3800a-d36b-4c08-9da1-9416fc051340) I'm getting from PHPStan but I'm not sure if the method should be defined in the DateTimeInterface stub. It doesn't appear to be a part of the interface in the [PHP-source](https://github.com/php/php-src/blob/master/ext/date/php_date_arginfo.h#L671-L682):

```
static const zend_function_entry class_DateTimeInterface_methods[] = {
	ZEND_RAW_FENTRY("format", NULL, arginfo_class_DateTimeInterface_format, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
	ZEND_RAW_FENTRY("getTimezone", NULL, arginfo_class_DateTimeInterface_getTimezone, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
	ZEND_RAW_FENTRY("getOffset", NULL, arginfo_class_DateTimeInterface_getOffset, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
	ZEND_RAW_FENTRY("getTimestamp", NULL, arginfo_class_DateTimeInterface_getTimestamp, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
	ZEND_RAW_FENTRY("getMicrosecond", NULL, arginfo_class_DateTimeInterface_getMicrosecond, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
	ZEND_RAW_FENTRY("diff", NULL, arginfo_class_DateTimeInterface_diff, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
	ZEND_RAW_FENTRY("__wakeup", NULL, arginfo_class_DateTimeInterface___wakeup, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
	ZEND_RAW_FENTRY("__serialize", NULL, arginfo_class_DateTimeInterface___serialize, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
	ZEND_RAW_FENTRY("__unserialize", NULL, arginfo_class_DateTimeInterface___unserialize, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
	ZEND_FE_END
};
```