### PR TITLE
Adding \Swoole\Coroutine\{run, go} functions

### DIFF
--- a/swoole/functions.php
+++ b/swoole/functions.php
@@ -2,6 +2,11 @@
 
 declare(strict_types=1);
 
+namespace Swoole\Coroutine {
+    function run(callable $func, mixed ...$params): bool { }
+    function go(callable $func, mixed ...$params): int|false { }
+}
+
 /**
  * Gets the current Swoole version. This information is also available in the predefined constant SWOOLE_VERSION.
  *


### PR DESCRIPTION
The functions `go` and `run` are not available from the `\Swoole\Coroutine\` namespace in the stubs. This PR adds them.