### PR TITLE
Fix missing null return type for Generator::current() & Generator::key()

### DIFF
--- a/standard/_types.php
+++ b/standard/_types.php
@@ -176,13 +176,13 @@ namespace {
 
         /**
          * Returns whatever was passed to yield or null if nothing was passed or the generator is already closed.
-         * @return TYield
+         * @return TYield|null
          */
         public function current(): mixed {}
 
         /**
          * Returns the yielded key or, if none was specified, an auto-incrementing key or null if the generator is already closed.
-         * @return TKey
+         * @return TKey|null
          */
         #[LanguageLevelTypeAware(['8.0' => 'mixed'], default: 'string|float|int|bool|null')]
         public function key() {}


### PR DESCRIPTION
For some reason https://github.com/JetBrains/phpstorm-stubs/pull/1280 changed the return type of `Generator::current()` from `TYield|null` to `TYield`, which is not correct.
Similarly, `Generator::key()` can return `null` as well.

For reference: https://3v4l.org/aSMe8
```php
$generator = (function () {
    yield 0;
})();

var_dump($generator->current()); // 0
var_dump($generator->key()); // 0

$generator->next();

var_dump($generator->current()); // null
var_dump($generator->key()); // null
```
