### PR TITLE
fix LuaSandboxFunction::call notation

### DIFF
--- a/LuaSandbox/LuaSandbox.php
+++ b/LuaSandbox/LuaSandbox.php
@@ -371,7 +371,7 @@ class LuaSandboxFunction
      * which may be empty, or false on error.</p>
      * @since luasandbox >= 1.0.0
      */
-    public function call($arguments) {}
+    public function call(string ...$args) {}
 
     /**
      * Dump the function as a binary blob.


### PR DESCRIPTION
LuaSandboxFunction::call can be called [without any parameter](https://www.php.net/manual/en/luasandboxfunction.call.php), but it generated error as it was before