### PR TITLE
Disable MongoDB extension in test Dockerfile

### DIFF
--- a/tests/DockerImages/peclExtensions/Dockerfile
+++ b/tests/DockerImages/peclExtensions/Dockerfile
@@ -36,8 +36,8 @@ RUN pecl install mcrypt
 RUN docker-php-ext-enable mcrypt
 RUN pecl install zip
 RUN docker-php-ext-enable zip
-RUN pecl install mongodb
-RUN docker-php-ext-enable mongodb
+#RUN pecl install mongodb
+#RUN docker-php-ext-enable mongodb
 RUN pecl install rdkafka
 RUN docker-php-ext-enable rdkafka
 RUN pecl install yaf


### PR DESCRIPTION
Commented out the installation and enabling of the MongoDB extension in the PECL extensions Dockerfile. This change  intended to temporarily exclude MongoDB for testing or compatibility reasons. Other extensions remain unaffected.