### PR TITLE
Add `#[Pure(true)]` to some functions where the return value is important

### DIFF
--- a/Core/Core.php
+++ b/Core/Core.php
@@ -445,6 +445,7 @@ function property_exists($object_or_class, string $property): bool {}
  * @link https://secure.php.net/manual/en/function.trait-exists.php
  * @since 5.4
  */
+#[Pure(true)]
 function trait_exists(string $trait, bool $autoload = true): bool {}
 
 /**
@@ -459,6 +460,7 @@ function trait_exists(string $trait, bool $autoload = true): bool {}
  * @return bool true if <i>class_name</i> is a defined class,
  * false otherwise.
  */
+#[Pure(true)]
 function class_exists(string $class, bool $autoload = true): bool {}
 
 /**
@@ -474,6 +476,7 @@ function class_exists(string $class, bool $autoload = true): bool {}
  * <i>interface_name</i> has been defined, false otherwise.
  * @since 5.0.2
  */
+#[Pure(true)]
 function interface_exists(string $interface, bool $autoload = true): bool {}
 
 /**
@@ -505,6 +508,7 @@ function function_exists(string $function): bool {}
  * false otherwise.
  * @since 8.1
  */
+#[Pure(true)]
 function enum_exists(string $enum, bool $autoload = true): bool {}
 
 /**
@@ -605,7 +609,7 @@ function get_class_vars(string $class): array {}
  * for the specified <i>object</i> in scope. If a property have
  * not been assigned a value, it will be returned with a null value.
  */
-#[Pure]
+#[Pure(true)]
 function get_object_vars(object $object): array {}
 
 /**
@@ -617,7 +621,7 @@ function get_object_vars(object $object): array {}
  * @return string[] an array of method names defined for the class specified by
  * <i>class_name</i>. In case of an error, it returns null.
  */
-#[Pure]
+#[Pure(true)]
 function get_class_methods(object|string $object_or_class): array {}
 
 /**
@@ -813,6 +817,7 @@ function create_function(string $args, string $code): false|string {}
  * by this function, the return value will be the string
  * Unknown.
  */
+#[Pure(true)]
 function get_resource_type($resource): string {}
 
 /**
@@ -1032,6 +1037,7 @@ function get_defined_constants(bool $categorize = false): array {}
  * </tr>
  * </table>
  */
+#[Pure(true)]
 function debug_backtrace(int $options = DEBUG_BACKTRACE_PROVIDE_OBJECT, int $limit = 0): array {}
 
 /**

--- a/fileinfo/fileinfo.php
+++ b/fileinfo/fileinfo.php
@@ -56,7 +56,7 @@ class finfo
      * @return string a textual description of the contents of the
      * <i>filename</i> argument, or <b>FALSE</b> if an error occurred.
      */
-    #[Pure]
+    #[Pure(true)]
     #[TentativeType]
     public function file(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $filename,
@@ -79,7 +79,7 @@ class finfo
      * @return string a textual description of the <i>string</i>
      * argument, or <b>FALSE</b> if an error occurred.
      */
-    #[Pure]
+    #[Pure(true)]
     #[TentativeType]
     public function buffer(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $string,

--- a/json/json.php
+++ b/json/json.php
@@ -232,7 +232,7 @@ function json_last_error(): int {}
  * @return string Returns the error message on success, "No error" if no error has occurred.
  * @since 5.5
  */
-#[Pure]
+#[Pure(true)]
 function json_last_error_msg(): string {}
 
 /**

--- a/standard/standard_8.php
+++ b/standard/standard_8.php
@@ -244,6 +244,7 @@ function ob_end_clean(): bool {}
  * @link https://php.net/manual/en/function.ob-get-flush.php
  * @return string|false the output buffer or false if no buffering is active.
  */
+#[Pure(true)]
 function ob_get_flush(): string|false {}
 
 /**
@@ -252,6 +253,7 @@ function ob_get_flush(): string|false {}
  * @return string|false the contents of the output buffer and end output buffering.
  * If output buffering isn't active then false is returned.
  */
+#[Pure(true)]
 function ob_get_clean(): string|false {}
 
 /**
@@ -260,6 +262,7 @@ function ob_get_clean(): string|false {}
  * @return int|false the length of the output buffer contents or false if no
  * buffering is active.
  */
+#[Pure(true)]
 function ob_get_length(): int|false {}
 
 /**
@@ -268,6 +271,7 @@ function ob_get_length(): int|false {}
  * @return int the level of nested output buffering handlers or zero if output
  * buffering is not active.
  */
+#[Pure(true)]
 function ob_get_level(): int {}
 
 /**
@@ -349,6 +353,7 @@ function ob_get_level(): int {}
     "buffer_size" => "int",
     "buffer_used" => "int",
 ])]
+#[Pure(true)]
 function ob_get_status(bool $full_status = false): array {}
 
 /**


### PR DESCRIPTION
Added the missing `#[Pure(true)]` attribute to some functions that have side effects but whose return value is important.

We could add it to more functions, but this PR only marks functions that are well-known and whose return value is obviously something you should use.