### PR TITLE
Fix bad `Pure` attributes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,4 +50,4 @@ jobs:
         run: docker compose -f docker-compose.yml run test_runner vendor/bin/phpunit --no-progress --testsuite Structure
 
       - name: run cs fixer
-        run:  docker run --rm -v .:/opt/project -w /opt/project php:8.3-cli sh -c 'curl -sS https://getcomposer.org/installer | php && php composer.phar run cs'
+        run:  docker run --rm -e PHP_CS_FIXER_IGNORE_ENV=1 -v .:/opt/project -w /opt/project php:8.4-cli sh -c 'curl -sS https://getcomposer.org/installer | php && php composer.phar run cs'

--- a/Core/Core.php
+++ b/Core/Core.php
@@ -605,7 +605,7 @@ function get_class_vars(string $class): array {}
  * for the specified <i>object</i> in scope. If a property have
  * not been assigned a value, it will be returned with a null value.
  */
-#[Pure(true)]
+#[Pure]
 function get_object_vars(object $object): array {}
 
 /**
@@ -813,7 +813,7 @@ function create_function(string $args, string $code): false|string {}
  * by this function, the return value will be the string
  * Unknown.
  */
-#[Pure(true)]
+#[Pure]
 function get_resource_type($resource): string {}
 
 /**

--- a/Core/Core.php
+++ b/Core/Core.php
@@ -445,7 +445,6 @@ function property_exists($object_or_class, string $property): bool {}
  * @link https://secure.php.net/manual/en/function.trait-exists.php
  * @since 5.4
  */
-#[Pure(true)]
 function trait_exists(string $trait, bool $autoload = true): bool {}
 
 /**
@@ -460,7 +459,6 @@ function trait_exists(string $trait, bool $autoload = true): bool {}
  * @return bool true if <i>class_name</i> is a defined class,
  * false otherwise.
  */
-#[Pure(true)]
 function class_exists(string $class, bool $autoload = true): bool {}
 
 /**
@@ -476,7 +474,6 @@ function class_exists(string $class, bool $autoload = true): bool {}
  * <i>interface_name</i> has been defined, false otherwise.
  * @since 5.0.2
  */
-#[Pure(true)]
 function interface_exists(string $interface, bool $autoload = true): bool {}
 
 /**
@@ -508,7 +505,6 @@ function function_exists(string $function): bool {}
  * false otherwise.
  * @since 8.1
  */
-#[Pure(true)]
 function enum_exists(string $enum, bool $autoload = true): bool {}
 
 /**

--- a/meta/attributes/Pure.php
+++ b/meta/attributes/Pure.php
@@ -7,6 +7,7 @@ use Attribute;
 /**
  * The attribute marks the function that has no impact on the program state or passed parameters used after the function execution.
  * This means that a function call that resolves to such a function can be safely removed if the execution result is not used in code afterwards.
+ * Functions that take a callable which is called should not have this attribute applied.
  *
  * @since 8.0
  */

--- a/standard/standard_8.php
+++ b/standard/standard_8.php
@@ -244,7 +244,6 @@ function ob_end_clean(): bool {}
  * @link https://php.net/manual/en/function.ob-get-flush.php
  * @return string|false the output buffer or false if no buffering is active.
  */
-#[Pure(true)]
 function ob_get_flush(): string|false {}
 
 /**
@@ -253,7 +252,6 @@ function ob_get_flush(): string|false {}
  * @return string|false the contents of the output buffer and end output buffering.
  * If output buffering isn't active then false is returned.
  */
-#[Pure(true)]
 function ob_get_clean(): string|false {}
 
 /**

--- a/standard/standard_9.php
+++ b/standard/standard_9.php
@@ -445,7 +445,6 @@ function array_intersect_uassoc(
  * array1 that are present in all the arguments.
  * @meta
  */
-#[Pure]
 function array_uintersect_uassoc(
     array $array,
     #[PhpStormStubsElementAvailable(from: '5.3', to: '7.4')] array $array2,


### PR DESCRIPTION
This PR is based on *my* interpretation of the documentation on the attribute that `Pure(true)` means a function:

* Does **not** have any side effects on external state or the supplied parameters
* **and** the result depends on some external state outside of the supplied parameters.

This contradicts with the interpretation in #1724 by @zonuexe which was accepted:

> Added the missing `#[Pure(true)]` attribute to some functions **that have side effects** [emphasis mine] but whose return value is important.

The reasoning for each change is documented in the commit messages.

As such it reverts some of the changes made in that PR. If my interpretation is wrong then reject this, but please improve the documentation.