### PR TITLE
Add false to gnupg::verify $signature

### DIFF
--- a/gnupg/gnupg.php
+++ b/gnupg/gnupg.php
@@ -103,7 +103,7 @@ class gnupg
      * @link https://php.net/manual/en/function.gnupg-verify.php
      *
      * @param string $text
-     * @param string $signature
+     * @param string|false $signature
      * @param string &$plaintext
      *
      * @return array|false On success, this function returns information about the signature.


### PR DESCRIPTION
"The signature. To verify a clearsigned text, set signature to false." https://www.php.net/manual/en/function.gnupg-verify.php

gnupg_verify() below already has it.