### PR TITLE
Fix variable arguments on RedisCluster::rawCommand()

### DIFF
--- a/redis/RedisCluster.php
+++ b/redis/RedisCluster.php
@@ -3247,13 +3247,13 @@ class RedisCluster
     /**
      * Send arbitrary things to the redis server at the specified node
      *
-     * @param string|array $nodeParams key or [host,port]
-     * @param string       $command    Required command to send to the server.
-     * @param mixed        $arguments  Optional variable amount of arguments to send to the server.
+     * @param string|array $nodeParams    key or [host,port]
+     * @param string       $command       Required command to send to the server.
+     * @param mixed        ...$arguments  Optional variable amount of arguments to send to the server.
      *
      * @return  mixed
      */
-    public function rawCommand($nodeParams, $command, $arguments) {}
+    public function rawcommand($nodeParams, $command, ...$arguments) {}
 
     /**
      * @since redis >= 3.0


### PR DESCRIPTION
`RedisCluster->rawCommand()` method stub currently indicated that exactly 3 parameters would be required, but it actually requires 2 or more arguments

Code like
```
$redisCluster->rawCommand($key, 'expire', $key, $timeout, $mode);
```
gets highlighted with inspection warning
```
Method RedisCluster::rawCommand() invoked with 5 parameters, 3 required
```
although perfectly valid. Note that the original method name is not camelCase but all lower case as well (verified via reflection)

See the [official phpredis stub](https://github.com/phpredis/phpredis/blob/46b8074216fcf862db7769270653ec1465bca77e/redis_cluster.stub.php#L727) for comparison.

This PR addresses [WI-81080](https://youtrack.jetbrains.com/issue/WI-81080)