### PR TITLE
Revert "Remove second parameter incorrect nullable"

### DIFF
--- a/standard/standard_1.php
+++ b/standard/standard_1.php
@@ -1008,14 +1008,14 @@ function explode(string $separator, string $string, int $limit = PHP_INT_MAX) {}
  * implode as glue would be
  * the second parameter and thus, the bad prototype would be used.
  * </p>
- * @param array $array <p>
+ * @param array|null $array <p>
  * The array of strings to implode.
  * </p>
  * @return string a string containing a string representation of all the array
  * elements in the same order, with the glue string between each element.
  */
 #[Pure]
-function implode(array|string $separator = "", array $array): string {}
+function implode(array|string $separator = "", ?array $array): string {}
 
 /**
  * Alias:
@@ -1026,14 +1026,14 @@ function implode(array|string $separator = "", array $array): string {}
  * implode as glue would be
  * the second parameter and thus, the bad prototype would be used.
  * </p>
- * @param array $array <p>
+ * @param array|null $array <p>
  * The array of strings to implode.
  * </p>
  * @return string a string containing a string representation of all the array
  * elements in the same order, with the glue string between each element.
  */
 #[Pure]
-function join(array|string $separator = "", array $array): string {}
+function join(array|string $separator = "", ?array $array): string {}
 
 /**
  * Set locale information


### PR DESCRIPTION
Reverts JetBrains/phpstorm-stubs#1728

I made a mistake when accepted these changes. I checked what reflection returns and what is in the [PHP source code](https://github.com/search?q=repo%3Aphp%2Fphp-src%20implode&type=code). It turns out that $array is indeed an optional parameter and it's default value is null.

`<?php`

`namespace B;`

`use ReflectionFunction;`

`$reflection = new ReflectionFunction('implode');`
`$parameters = $reflection->getParameters();`

`foreach ($parameters as $param) {`
`    echo "Parameter: " . $param->getName();`
`    echo "\nRequired: " . ($param->isOptional() ? "No" : "Yes");`
`    echo "\n\n";`
`}`

Output:
`Parameter: separator`
`Required: Yes`

`Parameter: array`
`Required: No`