### PR TITLE
Fix DomElement::attributes type

### DIFF
--- a/dom/dom_c.php
+++ b/dom/dom_c.php
@@ -1720,7 +1720,7 @@ class DOMElement extends DOMNode implements DOMParentNode, DOMChildNode
     public $nextSibling;
 
     /**
-     * @var DOMNamedNodeMap<DOMAttr>
+     * @var DOMNamedNodeMap<DOMAttr>|null
      * A <classname>DOMNamedNodeMap</classname> containing the attributes of this node (if it is a <classname>DOMElement</classname>) or NULL otherwise.
      * @link https://php.net/manual/en/class.domnode.php#domnode.props.attributes
      */


### PR DESCRIPTION
Hi @isfedorov

The description say
```
A <classname>DOMNamedNodeMap</classname> containing the attributes of this node (if it is a <classname>DOMElement</classname>) or NULL otherwise.
```
and the signature should be the same than DomNode.