### PR TITLE
Revert #1741 - \DOMElement::$attributes is never null

### DIFF
--- a/dom/dom_c.php
+++ b/dom/dom_c.php
@@ -1720,7 +1720,7 @@ class DOMElement extends DOMNode implements DOMParentNode, DOMChildNode
     public $nextSibling;
 
     /**
-     * @var DOMNamedNodeMap<DOMAttr>|null
+     * @var DOMNamedNodeMap<DOMAttr>
      * A <classname>DOMNamedNodeMap</classname> containing the attributes of this node (if it is a <classname>DOMElement</classname>) or NULL otherwise.
      * @link https://php.net/manual/en/class.domnode.php#domnode.props.attributes
      */

--- a/dom/dom_c.php
+++ b/dom/dom_c.php
@@ -1724,7 +1724,7 @@ class DOMElement extends DOMNode implements DOMParentNode, DOMChildNode
      * A <classname>DOMNamedNodeMap</classname> containing the attributes of this node (if it is a <classname>DOMElement</classname>) or NULL otherwise.
      * @link https://php.net/manual/en/class.domnode.php#domnode.props.attributes
      */
-    #[LanguageLevelTypeAware(['8.1' => 'DOMNamedNodeMap|null'], default: '')]
+    #[LanguageLevelTypeAware(['8.1' => 'DOMNamedNodeMap'], default: '')]
     public $attributes;
 
     /**


### PR DESCRIPTION
See https://github.com/phpstan/phpstan/issues/13076

This reverts #1741
From the PHP docs: https://www.php.net/manual/en/class.domnode.php#domnode.props.attributes

> A [DOMNamedNodeMap](https://www.php.net/manual/en/class.domnamednodemap.php) containing the attributes of this node (if it is a [DOMElement](https://www.php.net/manual/en/class.domelement.php)) or [null](https://www.php.net/manual/en/reserved.constants.php#constant.null) otherwise.

So, on `\DOMElement` it's correct to override and mark it as not nullable.