### PR TITLE
Remove DateTimeInterface::setMicrosecond

### DIFF
--- a/date/date_c.php
+++ b/date/date_c.php
@@ -167,11 +167,6 @@ interface DateTimeInterface
      * @since 8.4
      */
     public function getMicrosecond(): int;
-
-    /**
-     * @since 8.4
-     */
-    public function setMicrosecond();
 }
 
 /**


### PR DESCRIPTION
Hi,

- In php stubs the method doesn't exists https://github.com/php/php-src/blob/master/ext/date/php_date.stub.php#L331
- No setter are defined in DateTimeInterface since the behavior is different for mutable and immutable classes