### PR TITLE
E_USER_ERROR is deprecated in PHP 8.4

### DIFF
--- a/Core/Core_d.php
+++ b/Core/Core_d.php
@@ -93,6 +93,7 @@ define('E_COMPILE_WARNING', 128);
  * <b>E_ERROR</b>, except it is generated in PHP code by
  * using the PHP function <b>trigger_error</b>.
  * @link https://php.net/manual/en/errorfunc.constants.php
+ * @deprecated 8.4
  */
 define('E_USER_ERROR', 256);
 


### PR DESCRIPTION
see https://wiki.php.net/rfc/deprecations_php_8_4#deprecate_passing_e_user_error_to_trigger_error

technically this constant is not deprecated yet, but only its use with `trigger_error`.