### PR TITLE
Use more precise return type for eio_

### DIFF
--- a/eio/eio.php
+++ b/eio/eio.php
@@ -559,7 +559,7 @@ function eio_cancel($req): void {}
  * @link https://www.php.net/manual/en/function.eio-grp.php
  * @param mixed $callback function is called when the request is done
  * @param mixed $data Arbitrary variable passed to callback
- * @return resource returns request group resource on success, or false on failure.
+ * @return resource|false returns request group resource on success, or false on failure.
  */
 function eio_grp(mixed $callback, mixed $data = null) {}
 

--- a/eio/eio.php
+++ b/eio/eio.php
@@ -113,7 +113,7 @@ function eio_mkdir(string $path, int $mode, int $pri = 0, mixed $callback = null
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX
  * @param mixed $callback function is called when the request is done
  * @param mixed $data Arbitrary variable passed to callback
- * @return resource|bool returns request resource on success, or false on failure.
+ * @return resource|false returns request resource on success, or false on failure.
  */
 function eio_rmdir(string $path, int $pri = 0, mixed $callback = null, mixed $data = null) {}
 
@@ -124,7 +124,7 @@ function eio_rmdir(string $path, int $pri = 0, mixed $callback = null, mixed $da
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX
  * @param mixed $callback function is called when the request is done
  * @param mixed $data Arbitrary variable passed to callback
- * @return resource|bool returns request resource on success, or false on failure.
+ * @return resource|false returns request resource on success, or false on failure.
  */
 function eio_unlink(string $path, int $pri = 0, mixed $callback = null, mixed $data = null) {}
 
@@ -137,7 +137,7 @@ function eio_unlink(string $path, int $pri = 0, mixed $callback = null, mixed $d
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX
  * @param mixed $callback function is called when the request is done
  * @param mixed $data Arbitrary variable passed to callback
- * @return resource|bool returns request resource on success, or false on failure.
+ * @return resource|false returns request resource on success, or false on failure.
  */
 function eio_utime(string $path, float $atime, float $mtime, int $pri = 0, mixed $callback = null, mixed $data = null) {}
 
@@ -150,7 +150,7 @@ function eio_utime(string $path, float $atime, float $mtime, int $pri = 0, mixed
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX
  * @param mixed $callback function is called when the request is done
  * @param mixed $data Arbitrary variable passed to callback
- * @return resource|bool returns request resource on success, or false on failure.
+ * @return resource|false returns request resource on success, or false on failure.
  */
 function eio_mknod(string $path, int $mode, int $dev, int $pri = 0, mixed $callback = null, mixed $data = null) {}
 
@@ -162,7 +162,7 @@ function eio_mknod(string $path, int $mode, int $dev, int $pri = 0, mixed $callb
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX
  * @param mixed $callback function is called when the request is done
  * @param mixed $data Arbitrary variable passed to callback
- * @return resource|bool returns request resource on success, or false on failure.
+ * @return resource|false returns request resource on success, or false on failure.
  */
 function eio_link(string $path, string $new_path, int $pri = 0, mixed $callback = null, mixed $data = null) {}
 
@@ -174,7 +174,7 @@ function eio_link(string $path, string $new_path, int $pri = 0, mixed $callback 
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX
  * @param mixed $callback function is called when the request is done
  * @param mixed $data Arbitrary variable passed to callback
- * @return resource|bool returns request resource on success, or false on failure.
+ * @return resource|false returns request resource on success, or false on failure.
  */
 function eio_symlink(string $path, string $new_path, int $pri = 0, mixed $callback = null, mixed $data = null) {}
 
@@ -186,7 +186,7 @@ function eio_symlink(string $path, string $new_path, int $pri = 0, mixed $callba
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX
  * @param mixed $callback function is called when the request is done
  * @param mixed $data Arbitrary variable passed to callback
- * @return resource|bool returns request resource on success, or false on failure.
+ * @return resource|false returns request resource on success, or false on failure.
  */
 function eio_rename(string $path, string $new_path, int $pri = 0, mixed $callback = null, mixed $data = null) {}
 
@@ -197,7 +197,7 @@ function eio_rename(string $path, string $new_path, int $pri = 0, mixed $callbac
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX
  * @param mixed $callback function is called when the request is done
  * @param mixed $data Arbitrary variable passed to callback
- * @return resource|bool returns request resource on success, or false on failure.
+ * @return resource|false returns request resource on success, or false on failure.
  */
 function eio_close(mixed $fd, int $pri = 0, mixed $callback = null, mixed $data = null) {}
 
@@ -207,7 +207,7 @@ function eio_close(mixed $fd, int $pri = 0, mixed $callback = null, mixed $data 
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX
  * @param mixed $callback function is called when the request is done
  * @param mixed $data Arbitrary variable passed to callback
- * @return resource|bool returns request resource on success, or false on failure.
+ * @return resource|false returns request resource on success, or false on failure.
  */
 function eio_sync(int $pri = 0, mixed $callback = null, mixed $data = null) {}
 
@@ -218,7 +218,7 @@ function eio_sync(int $pri = 0, mixed $callback = null, mixed $data = null) {}
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX
  * @param mixed $callback function is called when the request is done
  * @param mixed $data Arbitrary variable passed to callback
- * @return resource|bool returns request resource on success, or false on failure.
+ * @return resource|false returns request resource on success, or false on failure.
  */
 function eio_fsync(mixed $fd, int $pri = 0, mixed $callback = null, mixed $data = null) {}
 
@@ -229,7 +229,7 @@ function eio_fsync(mixed $fd, int $pri = 0, mixed $callback = null, mixed $data 
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX
  * @param mixed $callback function is called when the request is done
  * @param mixed $data Arbitrary variable passed to callback
- * @return resource|bool returns request resource on success, or false on failure.
+ * @return resource|false returns request resource on success, or false on failure.
  */
 function eio_fdatasync(mixed $fd, int $pri = 0, mixed $callback = null, mixed $data = null) {}
 
@@ -242,7 +242,7 @@ function eio_fdatasync(mixed $fd, int $pri = 0, mixed $callback = null, mixed $d
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX
  * @param mixed $callback function is called when the request is done
  * @param mixed $data Arbitrary variable passed to callback
- * @return resource|bool returns request resource on success, or false on failure.
+ * @return resource|false returns request resource on success, or false on failure.
  */
 function eio_futime(mixed $fd, float $atime, float $mtime, int $pri = 0, mixed $callback = null, mixed $data = null) {}
 
@@ -254,7 +254,7 @@ function eio_futime(mixed $fd, float $atime, float $mtime, int $pri = 0, mixed $
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX
  * @param mixed $callback function is called when the request is done
  * @param mixed $data Arbitrary variable passed to callback
- * @return resource|bool returns request resource on success, or false on failure.
+ * @return resource|false returns request resource on success, or false on failure.
  */
 function eio_ftruncate(mixed $fd, int $offset = 0, int $pri = 0, mixed $callback = null, mixed $data = null) {}
 
@@ -266,7 +266,7 @@ function eio_ftruncate(mixed $fd, int $offset = 0, int $pri = 0, mixed $callback
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX
  * @param mixed $callback function is called when the request is done
  * @param mixed $data Arbitrary variable passed to callback
- * @return resource|bool returns request resource on success, or false on failure.
+ * @return resource|false returns request resource on success, or false on failure.
  */
 function eio_chmod(string $path, int $mode, int $pri = 0, mixed $callback = null, mixed $data = null) {}
 
@@ -278,7 +278,7 @@ function eio_chmod(string $path, int $mode, int $pri = 0, mixed $callback = null
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX
  * @param mixed $callback function is called when the request is done
  * @param mixed $data Arbitrary variable passed to callback
- * @return resource|bool returns request resource on success, or false on failure.
+ * @return resource|false returns request resource on success, or false on failure.
  */
 function eio_fchmod(mixed $fd, int $mode, int $pri = 0, mixed $callback = null, mixed $data = null) {}
 
@@ -291,7 +291,7 @@ function eio_fchmod(mixed $fd, int $mode, int $pri = 0, mixed $callback = null, 
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX
  * @param mixed $callback function is called when the request is done
  * @param mixed $data Arbitrary variable passed to callback
- * @return resource|bool returns request resource on success, or false on failure.
+ * @return resource|false returns request resource on success, or false on failure.
  */
 function eio_chown(string $path, int $uid, int $gid = -1, int $pri = 0, mixed $callback = null, ?mixed $data = null) {}
 
@@ -304,7 +304,7 @@ function eio_chown(string $path, int $uid, int $gid = -1, int $pri = 0, mixed $c
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX
  * @param mixed $callback function is called when the request is done
  * @param mixed $data Arbitrary variable passed to callback
- * @return resource|bool returns request resource on success, or false on failure.
+ * @return resource|false returns request resource on success, or false on failure.
  */
 function eio_fchown(mixed $fd, int $uid, int $gid = -1, int $pri = 0, mixed $callback = null, mixed $data = null) {}
 
@@ -316,7 +316,7 @@ function eio_fchown(mixed $fd, int $uid, int $gid = -1, int $pri = 0, mixed $cal
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX
  * @param mixed $callback function is called when the request is done
  * @param mixed $data Arbitrary variable passed to callback
- * @return resource|bool returns request resource on success, or false on failure.
+ * @return resource|false returns request resource on success, or false on failure.
  */
 function eio_dup2(mixed $fd, mixed $fd2, int $pri = 0, mixed $callback = null, mixed $data = null) {}
 
@@ -329,7 +329,7 @@ function eio_dup2(mixed $fd, mixed $fd2, int $pri = 0, mixed $callback = null, m
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX
  * @param mixed $callback function is called when the request is done
  * @param mixed $data Arbitrary variable passed to callback
- * @return resource|bool returns request resource on success, or false on failure.
+ * @return resource|false returns request resource on success, or false on failure.
  */
 function eio_read(mixed $fd, int $length, int $offset, int $pri, mixed $callback, mixed $data = null) {}
 
@@ -343,7 +343,7 @@ function eio_read(mixed $fd, int $length, int $offset, int $pri, mixed $callback
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX
  * @param mixed $callback function is called when the request is done
  * @param mixed $data Arbitrary variable passed to callback
- * @return resource|bool returns request resource on success, or false on failure.
+ * @return resource|false returns request resource on success, or false on failure.
  */
 function eio_write(mixed $fd, mixed $str, int $length = 0, int $offset = 0, int $pri = 0, mixed $callback = null, mixed $data = null) {}
 
@@ -354,7 +354,7 @@ function eio_write(mixed $fd, mixed $str, int $length = 0, int $offset = 0, int 
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX
  * @param mixed $callback function is called when the request is done
  * @param mixed $data Arbitrary variable passed to callback
- * @return resource|bool returns request resource on success, or false on failure.
+ * @return resource|false returns request resource on success, or false on failure.
  */
 function eio_readlink(string $path, int $pri, mixed $callback, mixed $data = null) {}
 
@@ -365,7 +365,7 @@ function eio_readlink(string $path, int $pri, mixed $callback, mixed $data = nul
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX
  * @param mixed $callback function is called when the request is done
  * @param mixed $data Arbitrary variable passed to callback
- * @return resource|bool returns request resource on success, or false on failure.
+ * @return resource|false returns request resource on success, or false on failure.
  */
 function eio_realpath(string $path, int $pri, mixed $callback, mixed $data = null) {}
 
@@ -376,7 +376,7 @@ function eio_realpath(string $path, int $pri, mixed $callback, mixed $data = nul
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX
  * @param mixed $callback function is called when the request is done
  * @param mixed $data Arbitrary variable passed to callback
- * @return resource|bool returns request resource on success, or false on failure.
+ * @return resource|false returns request resource on success, or false on failure.
  */
 function eio_stat(string $path, int $pri, mixed $callback, mixed $data = null) {}
 
@@ -387,7 +387,7 @@ function eio_stat(string $path, int $pri, mixed $callback, mixed $data = null) {
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX
  * @param mixed $callback function is called when the request is done
  * @param mixed $data Arbitrary variable passed to callback
- * @return resource|bool returns request resource on success, or false on failure.
+ * @return resource|false returns request resource on success, or false on failure.
  */
 function eio_lstat(string $path, int $pri, mixed $callback, mixed $data = null) {}
 
@@ -398,7 +398,7 @@ function eio_lstat(string $path, int $pri, mixed $callback, mixed $data = null) 
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX
  * @param mixed $callback function is called when the request is done
  * @param mixed $data Arbitrary variable passed to callback
- * @return resource|bool returns request resource on success, or false on failure.
+ * @return resource|false returns request resource on success, or false on failure.
  */
 function eio_fstat(mixed $fd, int $pri, mixed $callback, mixed $data = null) {}
 
@@ -409,7 +409,7 @@ function eio_fstat(mixed $fd, int $pri, mixed $callback, mixed $data = null) {}
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX
  * @param mixed $callback function is called when the request is done
  * @param mixed $data Arbitrary variable passed to callback
- * @return resource|bool returns request resource on success, or false on failure.
+ * @return resource|false returns request resource on success, or false on failure.
  */
 function eio_statvfs(string $path, int $pri, mixed $callback, mixed $data = null) {}
 
@@ -420,7 +420,7 @@ function eio_statvfs(string $path, int $pri, mixed $callback, mixed $data = null
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX
  * @param mixed $callback function is called when the request is done
  * @param mixed $data Arbitrary variable passed to callback
- * @return resource|bool returns request resource on success, or false on failure.
+ * @return resource|false returns request resource on success, or false on failure.
  */
 function eio_fstatvfs(mixed $fd, int $pri, mixed $callback, mixed $data = null) {}
 
@@ -432,7 +432,7 @@ function eio_fstatvfs(mixed $fd, int $pri, mixed $callback, mixed $data = null) 
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX
  * @param mixed $callback function is called when the request is done
  * @param mixed $data Arbitrary variable passed to callback
- * @return resource|bool returns request resource on success, or false on failure.
+ * @return resource|false returns request resource on success, or false on failure.
  */
 function eio_readdir(string $path, int $flags, int $pri, mixed $callback, mixed $data = null) {}
 
@@ -446,7 +446,7 @@ function eio_readdir(string $path, int $flags, int $pri, mixed $callback, mixed 
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX
  * @param mixed $callback function is called when the request is done
  * @param mixed $data Arbitrary variable passed to callback
- * @return resource|bool returns request resource on success, or false on failure.
+ * @return resource|false returns request resource on success, or false on failure.
  */
 function eio_sendfile(mixed $out_fd, mixed $in_fd, int $offset, int $length, int $pri, mixed $callback, mixed $data = null) {}
 
@@ -459,7 +459,7 @@ function eio_sendfile(mixed $out_fd, mixed $in_fd, int $offset, int $length, int
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX
  * @param mixed $callback function is called when the request is done
  * @param mixed $data Arbitrary variable passed to callback
- * @return resource|bool returns request resource on success, or false on failure.
+ * @return resource|false returns request resource on success, or false on failure.
  */
 function eio_readahead(mixed $fd, int $offset, int $length, int $pri = EIO_PRI_DEFAULT, mixed $callback = null, mixed $data = null) {}
 
@@ -472,7 +472,7 @@ function eio_readahead(mixed $fd, int $offset, int $length, int $pri = EIO_PRI_D
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX
  * @param mixed $callback function is called when the request is done
  * @param mixed $data Arbitrary variable passed to callback
- * @return resource|bool returns request resource on success, or false on failure.
+ * @return resource|false returns request resource on success, or false on failure.
  */
 function eio_seek(mixed $fd, int $offset, int $length, int $pri = EIO_PRI_DEFAULT, mixed $callback = null, mixed $data = null) {}
 
@@ -483,7 +483,7 @@ function eio_seek(mixed $fd, int $offset, int $length, int $pri = EIO_PRI_DEFAUL
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX
  * @param mixed $callback function is called when the request is done
  * @param mixed $data Arbitrary variable passed to callback
- * @return resource|bool returns request resource on success, or false on failure.
+ * @return resource|false returns request resource on success, or false on failure.
  */
 function eio_syncfs(mixed $fd, int $pri = EIO_PRI_DEFAULT, mixed $callback = null, mixed $data = null) {}
 
@@ -497,7 +497,7 @@ function eio_syncfs(mixed $fd, int $pri = EIO_PRI_DEFAULT, mixed $callback = nul
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX
  * @param mixed $callback function is called when the request is done
  * @param mixed $data Arbitrary variable passed to callback
- * @return resource|bool returns request resource on success, or false on failure.
+ * @return resource|false returns request resource on success, or false on failure.
  */
 function eio_sync_file_range(mixed $fd, int $offset, int $nbytes, int $flags, int $pri = EIO_PRI_DEFAULT, mixed $callback = null, mixed $data = null) {}
 
@@ -511,7 +511,7 @@ function eio_sync_file_range(mixed $fd, int $offset, int $nbytes, int $flags, in
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX
  * @param mixed $callback function is called when the request is done
  * @param mixed $data Arbitrary variable passed to callback
- * @return resource|bool returns request resource on success, or false on failure.
+ * @return resource|false returns request resource on success, or false on failure.
  */
 function eio_fallocate(mixed $fd, int $mode, int $offset, int $length, int $pri = EIO_PRI_DEFAULT, mixed $callback = null, mixed $data = null) {}
 
@@ -522,7 +522,7 @@ function eio_fallocate(mixed $fd, int $mode, int $offset, int $length, int $pri 
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX
  * @param mixed $callback function is called when the request is done
  * @param mixed $data Arbitrary variable passed to callback
- * @return resource|bool returns request resource on success, or false on failure.
+ * @return resource|false returns request resource on success, or false on failure.
  */
 function eio_custom(mixed $execute, int $pri, mixed $callback, mixed $data = null) {}
 
@@ -533,7 +533,7 @@ function eio_custom(mixed $execute, int $pri, mixed $callback, mixed $data = nul
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX
  * @param mixed $callback function is called when the request is done
  * @param mixed $data Arbitrary variable passed to callback
- * @return resource|bool returns request resource on success, or false on failure.
+ * @return resource|false returns request resource on success, or false on failure.
  */
 function eio_busy(int $delay, int $pri = EIO_PRI_DEFAULT, mixed $callback = null, mixed $data = null) {}
 
@@ -543,7 +543,7 @@ function eio_busy(int $delay, int $pri = EIO_PRI_DEFAULT, mixed $callback = null
  * @param int $pri The request priority: EIO_PRI_DEFAULT, EIO_PRI_MIN, EIO_PRI_MAX
  * @param mixed $callback function is called when the request is done
  * @param mixed $data Arbitrary variable passed to callback
- * @return resource|bool returns request resource on success, or false on failure.
+ * @return resource|false returns request resource on success, or false on failure.
  */
 function eio_nop(int $pri = EIO_PRI_DEFAULT, mixed $callback = null, mixed $data = null) {}
 


### PR DESCRIPTION
cc @isfedorov 

All the descriptions are `returns request resource on success, or false on failure.`.