### PR TITLE
Add @throws tag on createFromFormat

### DIFF
--- a/date/date.php
+++ b/date/date.php
@@ -979,6 +979,20 @@ function date_create_immutable(string $datetime = 'now', ?DateTimeZone $timezone
  * @return DateTimeImmutable|false
  */
 #[Pure(true)]
+#[PhpStormStubsElementAvailable(from: '5.3', to: '7.4')]
+function date_create_immutable_from_format(string $format, string $datetime, ?DateTimeZone $timezone): DateTimeImmutable|false {}
+
+/**
+ * Returns new DateTimeImmutable object formatted according to the specified format
+ * @link https://php.net/manual/en/function.date-create-immutable-from-format.php
+ * @param string $format
+ * @param string $datetime
+ * @param DateTimeZone|null $timezone [optional]
+ * @return DateTimeImmutable|false
+ * @throws ValueError when the datetime contains NULL-bytes.
+ */
+#[Pure(true)]
+#[PhpStormStubsElementAvailable(from: '8.0')]
 function date_create_immutable_from_format(string $format, string $datetime, ?DateTimeZone $timezone): DateTimeImmutable|false {}
 
 /**

--- a/date/date.php
+++ b/date/date.php
@@ -995,6 +995,25 @@ function date_create_immutable_from_format(string $format, string $datetime, ?Da
  * {@see DateTime} instance or <b>FALSE</b> on failure.</p>
  */
 #[Pure(true)]
+#[PhpStormStubsElementAvailable(from: '5.3', to: '7.4')]
+function date_create_from_format(string $format, string $datetime, ?DateTimeZone $timezone): DateTime|false {}
+
+/**
+ * Alias:
+ * {@see DateTime::createFromFormat}
+ * @link https://php.net/manual/en/function.date-create-from-format.php
+ * @param string $format Format accepted by  <a href="https://secure.php.net/manual/en/function.date.php">date()</a>.
+ * <p>If format does not contain the character ! then portions of the generated time which are not specified in format will be set to the current system time.</p>
+ * <p>If format contains the character !, then portions of the generated time not provided in format, as well as values to the left-hand side of the !, will be set to corresponding values from the Unix epoch.</p>
+ * <p>The Unix epoch is 1970-01-01 00:00:00 UTC.</p>
+ * @param string $datetime String representing the time.
+ * @param DateTimeZone|null $timezone [optional] A DateTimeZone object representing the desired time zone.
+ * @return DateTime|false <p> Returns a new
+ * {@see DateTime} instance or <b>FALSE</b> on failure.</p>
+ * @throws ValueError when the datetime contains NULL-bytes.
+ */
+#[Pure(true)]
+#[PhpStormStubsElementAvailable(from: '8.0')]
 function date_create_from_format(string $format, string $datetime, ?DateTimeZone $timezone): DateTime|false {}
 
 /**

--- a/date/date_c.php
+++ b/date/date_c.php
@@ -819,6 +819,24 @@ class DateTime implements DateTimeInterface
      * @link https://php.net/manual/en/datetime.createfromformat.php
      */
     #[TentativeType]
+    #[PhpStormStubsElementAvailable(from: '5.3', to: '7.4')]
+    public static function createFromFormat(
+        #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $format,
+        #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $datetime,
+        #[LanguageLevelTypeAware(['8.0' => 'DateTimeZone|null'], default: 'DateTimeZone')] $timezone = null
+    ): DateTime|false {}
+
+    /**
+     * Parse a string into a new DateTime object according to the specified format
+     * @param string $format Format accepted by date().
+     * @param string $datetime String representing the time.
+     * @param null|DateTimeZone $timezone A DateTimeZone object representing the desired time zone.
+     * @return DateTime|false
+     * @link https://php.net/manual/en/datetime.createfromformat.php
+     * @throws ValueError when the datetime contains NULL-bytes.
+     */
+    #[TentativeType]
+    #[PhpStormStubsElementAvailable(from: '8.0')]
     public static function createFromFormat(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $format,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $datetime,

--- a/date/date_c.php
+++ b/date/date_c.php
@@ -240,6 +240,25 @@ class DateTimeImmutable implements DateTimeInterface
      * @return DateTimeImmutable|false
      */
     #[TentativeType]
+    #[PhpStormStubsElementAvailable(from: '5.3', to: '7.4')]
+    public static function createFromFormat(
+        #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $format,
+        #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $datetime,
+        #[LanguageLevelTypeAware(['8.0' => 'DateTimeZone|null'], default: 'DateTimeZone')] $timezone = null
+    ): DateTimeImmutable|false {}
+
+    /**
+     * (PHP 5 &gt;=5.5.0)<br/>
+     * Returns new DateTimeImmutable object formatted according to the specified format
+     * @link https://secure.php.net/manual/en/datetimeimmutable.createfromformat.php
+     * @param string $format
+     * @param string $datetime
+     * @param null|DateTimeZone $timezone [optional]
+     * @return DateTimeImmutable|false
+     * @throws ValueError when the datetime contains NULL-bytes.
+     */
+    #[TentativeType]
+    #[PhpStormStubsElementAvailable(from: '8.0')]
     public static function createFromFormat(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $format,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $datetime,


### PR DESCRIPTION
According to https://www.php.net/manual/en/datetime.createfromformat.php#refsect1-datetime.createfromformat-errors
since PHP 8, `createFromFormat` can throws ValueError when the datetime contains NULL-bytes.