### PR TITLE
Rework PDO::fetchAll

### DIFF
--- a/PDO/PDO.php
+++ b/PDO/PDO.php
@@ -1732,8 +1732,16 @@ namespace {
          * column, bitwise-OR <b>PDO::FETCH_COLUMN</b> with
          * <b>PDO::FETCH_GROUP</b>.
          * </p>
-         * @param mixed ...$args <p>
-         * Arguments of custom class constructor when the <i>fetch_style</i>
+         * @param int|string|callable $fetch_argument <p>
+         * Dynamic parameter that is depending on the fetch mode:
+         * - column: Used with PDO::FETCH_COLUMN. Returns the indicated 0-indexed column.
+         * - class: Used with PDO::FETCH_CLASS. Returns instances of the specified class,
+         *   mapping the columns of each row to named properties in the class.
+         * - callback: Used with PDO::FETCH_FUNC. Returns the results of calling the
+         *   specified function, using each row's columns as parameters in the call.
+         * </p>
+         * @param array|null $constructorArgs <p>
+         * Argument of custom class constructor when the <i>fetch_style</i>
          * parameter is <b>PDO::FETCH_CLASS</b>.
          * </p>
          * @return array <b>PDOStatement::fetchAll</b> returns an array containing
@@ -1756,8 +1764,8 @@ namespace {
         #[TentativeType]
         public function fetchAll(
             #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $mode = PDO::FETCH_DEFAULT,
-            #[PhpStormStubsElementAvailable(from: '5.3', to: '7.4')] $fetch_argument = null,
-            #[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] ...$args
+            #[LanguageLevelTypeAware(['8.0' => 'int|string|callable|null'], default: '')] $fetch_argument = null,
+            #[LanguageLevelTypeAware(['8.0' => 'array|null'], default: '')] $constructorArgs = null
         ): array {}
 
         /**


### PR DESCRIPTION
Hi @isfedorov 

Cf https://www.php.net/manual/en/pdostatement.fetchall

PDO::fetchAll has 4 signatures
```
public PDOStatement::fetchAll(int $mode = PDO::FETCH_DEFAULT): array
public PDOStatement::fetchAll(int $mode = PDO::FETCH_COLUMN, int $column): array
public PDOStatement::fetchAll(int $mode = PDO::FETCH_CLASS, string $class, ?array $constructorArgs): array
public PDOStatement::fetchAll(int $mode = PDO::FETCH_FUNC, callable $callback): array
```
So instead of 
```
PDOStatement::fetchAll(int $mode, mixed ...$args);
```
we could be more precise with
```
PDOStatement::fetchAll(int $mode, int|string|callable|null $arg = null, ?array constructorArgs = null);
```

This will report error for code like
```
PDOStatement::fetchAll(PDO::FETCH_DEFAULT, true) // 2nd param cannot be a bool
PDOStatement::fetchAll(PDO::FETCH_DEFAULT, 42, 42) // 3rd param cannot be an int
PDOStatement::fetchAll(PDO::FETCH_DEFAULT, 'class', null, null) // 4th param is useless
```
for both PHPStorm, and PHPStan (and solve https://github.com/phpstan/phpstan/issues/5509)