### PR TITLE
Fix incorrect @param type for $previous in ErrorException::__construct docblock

### DIFF
--- a/Core/Core_c.php
+++ b/Core/Core_c.php
@@ -610,7 +610,7 @@ class ErrorException extends Exception
      * @param int $severity [optional] The severity level of the exception.
      * @param string $filename [optional] The filename where the exception is thrown.
      * @param int $line [optional] The line number where the exception is thrown.
-     * @param Exception $previous [optional] The previous exception used for the exception chaining.
+     * @param Throwable $previous [optional] The previous throwable used for exception chaining.
      */
     #[Pure]
     public function __construct(


### PR DESCRIPTION
This PR updates the PHPDoc for the ErrorException::__construct method to correctly reflect the accepted type for the $previous parameter.

The actual constructor accepts ?Throwable, not just Exception. Updating the PHPDoc aligns the documentation with the method signature and resolves static analysis issues in tools like PHPStan and Psalm, which currently detect a mismatch.

This improves type accuracy and ensures better compatibility with exception chaining involving Error.