### PR TITLE
Add @throws for request_parse_body()

### DIFF
--- a/standard/standard_10.php
+++ b/standard/standard_10.php
@@ -34,7 +34,6 @@ function http_clear_last_response_headers(): void {}
  * @param array|null $options
  * @return array<int, array>
  * @throws RequestParseBodyException if the request body uses an invalid/unsupported content type
- * @throws ValueError if <i>options</i> contains an invalid key or value
  */
 function request_parse_body(?array $options = null): array {}
 /**

--- a/standard/standard_10.php
+++ b/standard/standard_10.php
@@ -33,6 +33,8 @@ function http_clear_last_response_headers(): void {}
  * @since 8.4
  * @param array|null $options
  * @return array<int, array>
+ * @throws RequestParseBodyException if the request body uses an invalid/unsupported content type
+ * @throws ValueError if <i>options</i> contains an invalid key or value
  */
 function request_parse_body(?array $options = null): array {}
 /**


### PR DESCRIPTION
According to the [PHP docs](https://www.php.net/manual/en/function.request-parse-body.php#refsect1-function.request-parse-body-errors):

> When the request body is invalid, according to the Content-Type header, a [RequestParseBodyException](https://www.php.net/manual/en/class.requestparsebodyexception.php) is thrown.
>
> A [ValueError](https://www.php.net/manual/en/class.valueerror.php) is thrown when options contains invalid keys, or invalid values for the corresponding key.