### PR TITLE
Restrict type of DomDocument::ownerDocument

### DIFF
--- a/dom/dom_c.php
+++ b/dom/dom_c.php
@@ -850,6 +850,14 @@ class DOMDocument extends DOMNode implements DOMParentNode
     public $firstElementChild;
 
     /**
+     * @var null
+     * The <classname>DOMDocument</classname> object associated with this node, or NULL if this node is a <classname>DOMDocument</classname>.
+     * @link https://php.net/manual/en/class.domnode.php#domnode.props.ownerdocument
+     */
+    #[LanguageLevelTypeAware(['8.1' => 'null'], default: '')]
+    public $ownerDocument;
+
+    /**
      * Create new element node
      * @link https://php.net/manual/en/domdocument.createelement.php
      * @param string $localName <p>


### PR DESCRIPTION
The description is
```
The [DOMDocument](https://www.php.net/manual/en/class.domdocument.php) object associated with this node, or [null](https://www.php.net/manual/en/reserved.constants.php#constant.null) if this node is a [DOMDocument](https://www.php.net/manual/en/class.domdocument.php)
```
so ownerDocument is always null for a DomDocument.

This is by design, as the document is the root container and doesn't have an owner document.