### PR TITLE
Add language injection for JSON strings

### DIFF
--- a/json/json.php
+++ b/json/json.php
@@ -2,6 +2,7 @@
 
 // Start of json v.1.3.1
 use JetBrains\PhpStorm\Internal\TentativeType;
+use JetBrains\PhpStorm\Language;
 use JetBrains\PhpStorm\Pure;
 
 /**
@@ -130,7 +131,7 @@ function json_encode(mixed $value, int $flags = 0, int $depth = 512): string|fal
  * <i>json</i> cannot be decoded or if the encoded
  * data is deeper than the recursion limit.
  */
-function json_decode(string $json, ?bool $associative = null, int $depth = 512, int $flags = 0): mixed {}
+function json_decode(#[Language("JSON")] string $json, ?bool $associative = null, int $depth = 512, int $flags = 0): mixed {}
 
 /**
  * Returns the last error occurred
@@ -238,7 +239,7 @@ function json_last_error_msg(): string {}
 /**
  * @since 8.3
  */
-function json_validate(string $json, int $depth = 512, int $flags = 0): bool {}
+function json_validate(#[Language("JSON")] string $json, int $depth = 512, int $flags = 0): bool {}
 
 /**
  * All &lt; and &gt; are converted to \u003C and \u003E.


### PR DESCRIPTION
This adds language injection annotations to `json_decode` and `json_validate`, so we get syntax highlighting when using them.

Similar to a previous commit for XPath: 90461cd8f895b0112b2804b1a8cc578b4af27f24

<img width="951" height="289" alt="Syntax highlighting of json_decode with a JSON string" src="https://github.com/user-attachments/assets/ee6fe337-6e44-46a1-84b7-dd28d95f61af" />