### PR TITLE
Force array_first/-last input types through template

### DIFF
--- a/meta/.phpstorm.meta.php
+++ b/meta/.phpstorm.meta.php
@@ -67,6 +67,8 @@ namespace PHPSTORM_META {
   override(\array_reduce(0), type(2));
   override(\array_slice(0), type(0));
   override(\array_diff(0), type(0));
+  override(\array_first(0), elementType(0));
+  override(\array_last(0), elementType(0));
   override(\array_diff_assoc(0), type(0));
   override(\array_diff_uassoc(0), type(0));
   override(\array_diff_key(0), type(0));

--- a/standard/standard_8.php
+++ b/standard/standard_8.php
@@ -1110,11 +1110,21 @@ function array_merge(
 ): array {}
 
 /**
+ * @template TKey
+ * @template TValue
+ * @param array<TKey, TValue> $array
+ * @return TValue|null
  * @since 8.5
+ * @meta
  */
 function array_first(array $array): mixed {}
 
 /**
+ * @template TKey
+ * @template TValue
+ * @param array<TKey, TValue> $array
+ * @return TValue|null
  * @since 8.5
+ * @meta
  */
 function array_last(array $array): mixed {}


### PR DESCRIPTION
Prior to this change, PHPStorm's type inference would always return `mixed` for the return types of `array_first` and `array_last`. By upgrading the input types to templates, we implicitly enforce the use of a more advanced generics type provider that deals with array elements correctly.