### PR TITLE
Fix round() stub: duplicate $mode parameter for PHP 8.4+

### DIFF
--- a/standard/standard_3.php
+++ b/standard/standard_3.php
@@ -134,7 +134,7 @@ function floor(int|float $num) {}
 function round(
     int|float $num,
     int $precision = 0,
-    #[PhpStormStubsElementAvailable(from: '5.3', to: '8.4')] #[LanguageLevelTypeAware(['8.4' => 'RoundingMode|int'], default: 'int')] $mode = 0,
+    #[PhpStormStubsElementAvailable(from: '5.3', to: '8.3')] #[LanguageLevelTypeAware(['8.4' => 'RoundingMode|int'], default: 'int')] $mode = 0,
     #[PhpStormStubsElementAvailable(from: '8.5')] RoundingMode|int $mode = \RoundingMode::HalfAwayFromZero
 ): float {}
 


### PR DESCRIPTION
The current stub for `round()` in `standard/standard_3.php` defines `$mode` twice, which causes inspections in PhpStorm to report "Function has a parameter whose default value is incompatible with its declared type".