### PR TITLE
Narrow ReflectionClass::getConstant() return-type

### DIFF
--- a/Reflection/ReflectionClass.php
+++ b/Reflection/ReflectionClass.php
@@ -305,7 +305,7 @@ class ReflectionClass implements Reflector
      *
      * @link https://php.net/manual/en/reflectionclass.getconstants.php
      * @param int|null $filter [optional] allows the filtering of constants defined in a class by their visibility. Since 8.0.
-     * @return array An array of constants, where the keys hold the name and
+     * @return array<string, bool|int|float|string|array<bool|int|float|string>> An array of constants, where the keys hold the name and
      * the values the value of the constants.
      */
     #[Pure]
@@ -317,7 +317,7 @@ class ReflectionClass implements Reflector
      *
      * @link https://php.net/manual/en/reflectionclass.getconstant.php
      * @param string $name Name of the constant.
-     * @return mixed|false Value of the constant with the name name.
+     * @return bool|int|float|string|array<bool|int|float|string> Value of the constant with the name name.
      * Returns {@see false} if the constant was not found in the class.
      */
     #[Pure]

--- a/Reflection/ReflectionClass.php
+++ b/Reflection/ReflectionClass.php
@@ -305,7 +305,7 @@ class ReflectionClass implements Reflector
      *
      * @link https://php.net/manual/en/reflectionclass.getconstants.php
      * @param int|null $filter [optional] allows the filtering of constants defined in a class by their visibility. Since 8.0.
-     * @return array<string, bool|int|float|string|array<bool|int|float|string>> An array of constants, where the keys hold the name and
+     * @return array<string, scalar|array<scalar>> An array of constants, where the keys hold the name and
      * the values the value of the constants.
      */
     #[Pure]
@@ -317,7 +317,7 @@ class ReflectionClass implements Reflector
      *
      * @link https://php.net/manual/en/reflectionclass.getconstant.php
      * @param string $name Name of the constant.
-     * @return bool|int|float|string|array<bool|int|float|string> Value of the constant with the name name.
+     * @return scalar|array<scalar> Value of the constant with the name name.
      * Returns {@see false} if the constant was not found in the class.
      */
     #[Pure]


### PR DESCRIPTION
per https://www.php.net/manual/en/language.oop5.constants.php constants can only ever hold certain values

> class constants can have a scalar type such as bool, int, float, string, or even array. When using array, the contents can only be other scalar types. 