### PR TITLE
Correct missing defaults for optional arguments

### DIFF
--- a/Core/Core.php
+++ b/Core/Core.php
@@ -321,7 +321,7 @@ function each(&$array): array {}
  * level or the current level if no <i>level</i> parameter is
  * given.
  */
-function error_reporting(?int $error_level): int {}
+function error_reporting(?int $error_level = null): int {}
 
 /**
  * Defines a named constant
@@ -1139,7 +1139,7 @@ function gc_mem_caches(): int {}
  * @since 7.0
  */
 #[Pure(true)]
-function get_resources(?string $type): array {}
+function get_resources(?string $type = null): array {}
 
 /**
  * @since 8.4

--- a/Ev/Ev.php
+++ b/Ev/Ev.php
@@ -664,7 +664,7 @@ final class EvEmbed extends EvWatcher
      */
     public function __construct(
         EvLoop $other,
-        #[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $callback,
+        #[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $callback = null,
         #[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $data = null,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $priority = 0
     ) {}
@@ -693,7 +693,7 @@ final class EvEmbed extends EvWatcher
      *
      * @return EvEmbed
      */
-    final public static function createStopped(EvLoop $other, mixed $callback, mixed $data = null, int $priority = 0) {}
+    final public static function createStopped(EvLoop $other, mixed $callback = null, mixed $data = null, int $priority = 0) {}
 }
 
 /**
@@ -1398,7 +1398,7 @@ final class EvLoop
      * @param int $priority
      * @return EvEmbed
      */
-    final public function embed(EvLoop $other, callable $callback, $data = null, $priority = 0) {}
+    final public function embed(EvLoop $other, ?callable $callback = null, $data = null, $priority = 0) {}
 
     /**
      * Creates EvFork object associated with the current event loop instance.

--- a/Phar/Phar.php
+++ b/Phar/Phar.php
@@ -782,7 +782,7 @@ class Phar extends RecursiveDirectoryIterator implements RecursiveIterator, Seek
      * @return string the filename if valid, empty string otherwise.
      */
     final public static function running(
-        #[PhpStormStubsElementAvailable(from: '5.3', to: '5.6')] $returnPhar,
+        #[PhpStormStubsElementAvailable(from: '5.3', to: '5.6')] $returnPhar = true,
         #[PhpStormStubsElementAvailable(from: '7.0')] bool $returnPhar = true
     ): string {}
 

--- a/SPL/SPL.php
+++ b/SPL/SPL.php
@@ -327,7 +327,7 @@ class RecursiveIteratorIterator implements OuterIterator
      * @return RecursiveIterator|null The current active sub iterator.
      */
     #[TentativeType]
-    public function getSubIterator(#[LanguageLevelTypeAware(['8.0' => 'int|null'], default: '')] $level): ?RecursiveIterator {}
+    public function getSubIterator(#[LanguageLevelTypeAware(['8.0' => 'int|null'], default: '')] $level = null): ?RecursiveIterator {}
 
     /**
      * Get inner iterator

--- a/SPL/SPL_c1.php
+++ b/SPL/SPL_c1.php
@@ -2359,7 +2359,7 @@ class MultipleIterator implements Iterator
      * @param int $flags Defaults to MultipleIterator::MIT_NEED_ALL | MultipleIterator::MIT_KEYS_NUMERIC
      */
     public function __construct(
-        #[PhpStormStubsElementAvailable(from: '5.3', to: '7.4')] $flags,
+        #[PhpStormStubsElementAvailable(from: '5.3', to: '7.4')] $flags = 1,
         #[PhpStormStubsElementAvailable(from: '8.0')] int $flags = MultipleIterator::MIT_NEED_ALL|MultipleIterator::MIT_KEYS_NUMERIC
     ) {}
 

--- a/SPL/SPL_f.php
+++ b/SPL/SPL_f.php
@@ -25,7 +25,7 @@ function spl_classes(): array {}
  * @return void
  * @since 5.1.2
  */
-function spl_autoload(string $class, ?string $file_extensions): void {}
+function spl_autoload(string $class, ?string $file_extensions = null): void {}
 
 /**
  * Register and return default file extensions for spl_autoload
@@ -41,7 +41,7 @@ function spl_autoload(string $class, ?string $file_extensions): void {}
  * spl_autoload.
  * @since 5.1.2
  */
-function spl_autoload_extensions(?string $file_extensions): string {}
+function spl_autoload_extensions(?string $file_extensions = null): string {}
 
 /**
  * Register given function as __autoload() implementation
@@ -59,7 +59,7 @@ function spl_autoload_extensions(?string $file_extensions): string {}
  * @throws TypeError Since 8.0.
  * @since 5.1.2
  */
-function spl_autoload_register(?callable $callback, bool $throw = true, bool $prepend = false): bool {}
+function spl_autoload_register(?callable $callback = null, bool $throw = true, bool $prepend = false): bool {}
 
 /**
  * Unregister given function as __autoload() implementation
@@ -182,7 +182,7 @@ function iterator_count(#[LanguageLevelTypeAware(['8.2' => 'Traversable|array'],
  * </p>
  * @return int the iteration count.
  */
-function iterator_apply(Traversable $iterator, callable $callback, ?array $args): int {}
+function iterator_apply(Traversable $iterator, callable $callback, ?array $args = null): int {}
 
 // End of SPL v.0.2
 

--- a/SQLite/SQLite.php
+++ b/SQLite/SQLite.php
@@ -49,7 +49,7 @@ class SQLiteDatabase
      * {@see sqlite_unbuffered_query()} instead.
      * </p>
      */
-    public function query($query, $result_type, &$error_message) {}
+    public function query($query, $result_type = SQLITE_BOTH, &$error_message) {}
 
     /**
      * (PHP 5 &lt; 5.4.0, PECL sqlite &gt;= 1.0.0)
@@ -107,7 +107,7 @@ class SQLiteDatabase
      * {@link https://php.net/manual/en/sqlite.configuration.php#ini.sqlite.assoc-case sqlite.assoc_case} configuration
      * option.</p>
      */
-    public function arrayQuery($query, $result_type, $decode_binary) {}
+    public function arrayQuery($query, $result_type = SQLITE_BOTH, $decode_binary = true) {}
 
     /**
      * (PHP 5 &lt; 5.4.0, PECL sqlite &gt;= 1.0.1)
@@ -118,7 +118,7 @@ class SQLiteDatabase
      * @param bool $decode_binary [optional]
      * @return array
      */
-    public function singleQuery($query, $first_row_only, $decode_binary) {}
+    public function singleQuery($query, $first_row_only = true, $decode_binary = true) {}
 
     /**
      * (PHP 5 &lt; 5.4.0, PECL sqlite &gt;= 1.0.0)
@@ -277,7 +277,7 @@ final class SQLiteResult implements Iterator, Countable
      * @param bool $decode_binary [optional]
      * @return object
      */
-    public function fetchObject($class_name, $ctor_params, $decode_binary = true) {}
+    public function fetchObject($class_name = 'stdClass', $ctor_params = [], $decode_binary = true) {}
 
     /**
      * (PHP 5 &lt; 5.4.0, PECL sqlite &gt;= 1.0.1)
@@ -301,7 +301,7 @@ final class SQLiteResult implements Iterator, Countable
      * You should normally leave this value at its default, unless you are interoperating with databases created by other sqlite capable applications.</p>
      * @return object
      */
-    public function fetchAll($result_type, $decode_binary = true) {}
+    public function fetchAll($result_type = SQLITE_BOTH, $decode_binary = true) {}
 
     /**
      * (PHP 5 &lt; 5.4.0, PECL sqlite &gt;= 1.0.0)
@@ -472,7 +472,7 @@ final class SQLiteUnbuffered
      * @param int $result_type [optional]
      * @param bool $decode_binary [optional]
      */
-    public function fetch($result_type, $decode_binary) {}
+    public function fetch($result_type = SQLITE_BOTH, $decode_binary = true) {}
 
     /**
      * @link https://www.php.net/manual/en/function.sqlite-fetch-object.php
@@ -480,24 +480,24 @@ final class SQLiteUnbuffered
      * @param array $ctor_params [optional]
      * @param bool $decode_binary [optional]
      */
-    public function fetchObject($class_name, $ctor_params, $decode_binary) {}
+    public function fetchObject($class_name = 'stdClass', $ctor_params = [], $decode_binary = true) {}
 
     /**
      * @param bool $decode_binary [optional]
      */
-    public function fetchSingle($decode_binary) {}
+    public function fetchSingle($decode_binary = true) {}
 
     /**
      * @param int $result_type [optional]
      * @param bool $decode_binary [optional]
      */
-    public function fetchAll($result_type, $decode_binary) {}
+    public function fetchAll($result_type = SQLITE_BOTH, $decode_binary = true) {}
 
     /**
      * @param $index_or_name
      * @param $decode_binary [optional]
      */
-    public function column($index_or_name, $decode_binary) {}
+    public function column($index_or_name, $decode_binary = true) {}
 
     public function numFields() {}
 
@@ -510,7 +510,7 @@ final class SQLiteUnbuffered
      * @param int $result_type [optional]
      * @param bool $decode_binary [optional]
      */
-    public function current($result_type, $decode_binary) {}
+    public function current($result_type = SQLITE_BOTH, $decode_binary = true) {}
 
     public function next() {}
 

--- a/amqp/amqp.php
+++ b/amqp/amqp.php
@@ -522,7 +522,7 @@ class AMQPChannel
      *
      * @return void
      */
-    public function setConfirmCallback(callable $ack_callback = null, callable $nack_callback = null) {}
+    public function setConfirmCallback(?callable $ack_callback = null, ?callable $nack_callback = null) {}
 
     /**
      * Wait until all messages published since the last call have been either ack'd or nack'd by the broker.
@@ -555,7 +555,7 @@ class AMQPChannel
      *
      * @return void
      */
-    public function setReturnCallback(callable $return_callback = null) {}
+    public function setReturnCallback(?callable $return_callback = null) {}
 
     /**
      * Start wait loop for basic.return AMQP server methods
@@ -1494,7 +1494,7 @@ class AMQPQueue
      * @return void
      */
     public function consume(
-        callable $callback = null,
+        ?callable $callback = null,
         $flags = null,
         $consumerTag = null
     ) {}

--- a/bcmath/bcmath.php
+++ b/bcmath/bcmath.php
@@ -187,7 +187,7 @@ namespace {
      */
     #[Pure]
     #[LanguageLevelTypeAware(["8.0" => "string"], default: "string|null")]
-    function bcsqrt(string $num, ?int $scale) {}
+    function bcsqrt(string $num, ?int $scale = null) {}
 
     /**
      * Set default scale parameter for all bc math functions

--- a/bz2/bz2.php
+++ b/bz2/bz2.php
@@ -55,7 +55,7 @@ function bzread($bz, int $length = 1024): string|false {}
  * </p>
  * @return int|false the number of bytes written, or <b>FALSE</b> on error.
  */
-function bzwrite($bz, string $data, ?int $length): int|false {}
+function bzwrite($bz, string $data, ?int $length = null): int|false {}
 
 /**
  * Force a write of all buffered data

--- a/calendar/calendar.php
+++ b/calendar/calendar.php
@@ -170,7 +170,7 @@ function jdmonthname(int $julian_day, int $mode): string {}
  * @param int $mode [optional] Allows Easter dates to be calculated based on the Julian calendar when set to CAL_EASTER_ALWAYS_JULIAN
  * @return int The easter date as a unix timestamp.
  */
-function easter_date(?int $year, #[PhpStormStubsElementAvailable(from: '8.0')] int $mode = CAL_EASTER_DEFAULT): int {}
+function easter_date(?int $year = null, #[PhpStormStubsElementAvailable(from: '8.0')] int $mode = CAL_EASTER_DEFAULT): int {}
 
 /**
  * Get number of days after March 21 on which Easter falls for a given year
@@ -187,7 +187,7 @@ function easter_date(?int $year, #[PhpStormStubsElementAvailable(from: '8.0')] i
  * @return int The number of days after March 21st that the Easter Sunday
  * is in the given <i>year</i>.
  */
-function easter_days(?int $year, int $mode = CAL_EASTER_DEFAULT): int {}
+function easter_days(?int $year = null, int $mode = CAL_EASTER_DEFAULT): int {}
 
 /**
  * Convert Unix timestamp to Julian Day

--- a/cassandra/cassandra.php
+++ b/cassandra/cassandra.php
@@ -6182,7 +6182,7 @@ namespace Cassandra\Exception {
          * @link https://docs.datastax.com/en/developer/php-driver/latest/api/Cassandra/Exception/class.DomainException/#method-__construct
          */
         #[Pure]
-        public function __construct($message, $code, $previous) {}
+        public function __construct($message = '', $code = 0, $previous = null) {}
 
         /**
          * @return mixed
@@ -6272,7 +6272,7 @@ namespace Cassandra\Exception {
          * @link https://docs.datastax.com/en/developer/php-driver/latest/api/Cassandra/Exception/class.InvalidArgumentException/#method-__construct
          */
         #[Pure]
-        public function __construct($message, $code, $previous) {}
+        public function __construct($message = '', $code = 0, $previous = null) {}
 
         /**
          * @return mixed
@@ -6332,7 +6332,7 @@ namespace Cassandra\Exception {
          * @link https://docs.datastax.com/en/developer/php-driver/latest/api/Cassandra/Exception/class.RangeException/#method-__construct
          */
         #[Pure]
-        public function __construct($message, $code, $previous) {}
+        public function __construct($message = '', $code = 0, $previous = null) {}
 
         /**
          * @return mixed
@@ -6391,7 +6391,7 @@ namespace Cassandra\Exception {
          * @link https://docs.datastax.com/en/developer/php-driver/latest/api/Cassandra/Exception/class.LogicException/#method-__construct
          */
         #[Pure]
-        public function __construct($message, $code, $previous) {}
+        public function __construct($message = '', $code = 0, $previous = null) {}
 
         /**
          * @return mixed
@@ -6665,7 +6665,7 @@ namespace Cassandra\Exception {
          * @link https://docs.datastax.com/en/developer/php-driver/latest/api/Cassandra/Exception/class.RuntimeException/#method-__construct
          */
         #[Pure]
-        public function __construct($message, $code, $previous) {}
+        public function __construct($message = '', $code = 0, $previous = null) {}
 
         /**
          * @return mixed

--- a/couchbase/couchbase.php
+++ b/couchbase/couchbase.php
@@ -2351,7 +2351,7 @@ class SearchOptions implements JsonSerializable
      * @see \SearchHighlightMode::ANSI
      * @see \SearchHighlightMode::SIMPLE
      */
-    public function highlight(string $style = null, array $fields = null): SearchOptions {}
+    public function highlight(?string $style = null, ?array $fields = null): SearchOptions {}
 
     /**
      * Configures the list of collections to use for restricting results.
@@ -2593,7 +2593,7 @@ class GeoDistanceSearchQuery implements JsonSerializable, SearchQuery
 {
     public function jsonSerialize() {}
 
-    public function __construct(float $longitude, float $latitude, string $distance = null) {}
+    public function __construct(float $longitude, float $latitude, ?string $distance = null) {}
 
     /**
      * @param float $boost
@@ -2999,7 +2999,7 @@ class NumericRangeSearchFacet implements JsonSerializable, SearchFacet
      * @param float $max
      * @return NumericRangeSearchFacet
      */
-    public function addRange(string $name, float $min = null, float $max = null): NumericRangeSearchFacet {}
+    public function addRange(string $name, ?float $min = null, ?float $max = null): NumericRangeSearchFacet {}
 }
 
 /**

--- a/cubrid/cubrid.php
+++ b/cubrid/cubrid.php
@@ -772,7 +772,7 @@ function cubrid_column_types($req_identifier) {}
  * Returns true on success or false on failure.
  * </p>
  */
-function cubrid_field_seek($result, $field_offset) {}
+function cubrid_field_seek($result, $field_offset = 0) {}
 
 /**
  * (PHP 5, CUBRID &gt;= 8.3.0)<br/>

--- a/curl/curl.php
+++ b/curl/curl.php
@@ -106,7 +106,7 @@ final class CurlSharePersistentHandle
  * @return resource|false|CurlHandle a cURL handle on success, false on errors.
  */
 #[LanguageLevelTypeAware(['8.0' => 'CurlHandle|false'], default: 'resource|false')]
-function curl_init(?string $url) {}
+function curl_init(?string $url = null) {}
 
 /**
  * Copy a cURL handle along with all of its preferences
@@ -2542,7 +2542,7 @@ function curl_exec(#[LanguageLevelTypeAware(['8.0' => 'CurlHandle'], default: 'r
  * </ul>
  */
 #[Pure(true)]
-function curl_getinfo(#[LanguageLevelTypeAware(['8.0' => 'CurlHandle'], default: 'resource')] $handle, ?int $option): mixed {}
+function curl_getinfo(#[LanguageLevelTypeAware(['8.0' => 'CurlHandle'], default: 'resource')] $handle, ?int $option = null): mixed {}
 
 /**
  * Return a string containing the last error for the current session
@@ -2768,7 +2768,7 @@ function curl_multi_getcontent(#[LanguageLevelTypeAware(['8.0' => 'CurlHandle'],
  */
 #[Pure]
 #[ArrayShape(["msg" => "int", "result" => "int", "handle" => "resource"])]
-function curl_multi_info_read(#[LanguageLevelTypeAware(['8.0' => 'CurlMultiHandle'], default: 'resource')] $multi_handle, &$queued_messages): array|false {}
+function curl_multi_info_read(#[LanguageLevelTypeAware(['8.0' => 'CurlMultiHandle'], default: 'resource')] $multi_handle, &$queued_messages = null): array|false {}
 
 /**
  * Close a set of cURL handles

--- a/date/date.php
+++ b/date/date.php
@@ -23,7 +23,7 @@ use JetBrains\PhpStorm\Pure;
  * this function would return -1 on failure.
  */
 #[Pure(true)]
-function strtotime(string $datetime, ?int $baseTimestamp): int|false {}
+function strtotime(string $datetime, ?int $baseTimestamp = null): int|false {}
 
 /**
  * Format a local time/date
@@ -295,7 +295,7 @@ function strtotime(string $datetime, ?int $baseTimestamp): int|false {}
  */
 #[Pure(true)]
 #[LanguageLevelTypeAware(["8.0" => "string"], default: "string|false")]
-function date(string $format, ?int $timestamp) {}
+function date(string $format, ?int $timestamp = null) {}
 
 /**
  * Format a local time/date as integer
@@ -392,7 +392,7 @@ function date(string $format, ?int $timestamp) {}
  * </p>
  */
 #[Pure(true)]
-function idate(string $format, ?int $timestamp): int|false {}
+function idate(string $format, ?int $timestamp = null): int|false {}
 
 /**
  * Format a GMT/UTC date/time
@@ -409,7 +409,7 @@ function idate(string $format, ?int $timestamp): int|false {}
  */
 #[Pure(true)]
 #[LanguageLevelTypeAware(["8.0" => "string"], default: "string|false")]
-function gmdate(string $format, ?int $timestamp) {}
+function gmdate(string $format, ?int $timestamp = null) {}
 
 /**
  * Get Unix timestamp for a date
@@ -788,7 +788,7 @@ function checkdate(int $month, int $day, int $year): bool {}
  * with setlocale.
  */
 #[Deprecated(since: '8.1')]
-function strftime(string $format, ?int $timestamp): string|false {}
+function strftime(string $format, ?int $timestamp = null): string|false {}
 
 /**
  * Format a GMT/UTC time/date according to locale settings
@@ -805,7 +805,7 @@ function strftime(string $format, ?int $timestamp): string|false {}
  * @deprecated 8.1
  */
 #[Deprecated(since: '8.1')]
-function gmstrftime(string $format, ?int $timestamp): string|false {}
+function gmstrftime(string $format, ?int $timestamp = null): string|false {}
 
 /**
  * Return current Unix timestamp
@@ -841,7 +841,7 @@ function time(): int {}
     'tm_yday' => 'int',
     'tm_isdst' => 'int',
 ])]
-function localtime(?int $timestamp, bool $associative = false): array {}
+function localtime(?int $timestamp = null, bool $associative = false): array {}
 
 /**
  * Get date/time information
@@ -936,7 +936,7 @@ function localtime(?int $timestamp, bool $associative = false): array {}
     'month' => 'string',
     0 => 'int',
 ])]
-function getdate(?int $timestamp): array {}
+function getdate(?int $timestamp = null): array {}
 
 /**
  * Returns new DateTime object
@@ -950,7 +950,7 @@ function getdate(?int $timestamp): array {}
  * @return DateTime|false DateTime object on success or false on failure.
  */
 #[Pure(true)]
-function date_create(string $datetime = 'now', ?DateTimeZone $timezone): DateTime|false {}
+function date_create(string $datetime = 'now', ?DateTimeZone $timezone = null): DateTime|false {}
 
 /**
  * (PHP 5.5)<br/>
@@ -968,7 +968,7 @@ function date_create(string $datetime = 'now', ?DateTimeZone $timezone): DateTim
  * @return DateTimeImmutable|false DateTime object on success or false on failure.
  */
 #[Pure(true)]
-function date_create_immutable(string $datetime = 'now', ?DateTimeZone $timezone): DateTimeImmutable|false {}
+function date_create_immutable(string $datetime = 'now', ?DateTimeZone $timezone = null): DateTimeImmutable|false {}
 
 /**
  * Returns new DateTimeImmutable object formatted according to the specified format
@@ -1407,7 +1407,7 @@ function timezone_location_get(DateTimeZone $object): array|false {}
  */
 #[Pure(true)]
 #[LanguageLevelTypeAware(["8.0" => "array"], default: "array|false")]
-function timezone_identifiers_list(int $timezoneGroup = DateTimeZone::ALL, ?string $countryCode) {}
+function timezone_identifiers_list(int $timezoneGroup = DateTimeZone::ALL, ?string $countryCode = null) {}
 
 /**
  * Returns associative array containing dst, offset and the timezone name
@@ -1526,7 +1526,7 @@ function date_default_timezone_get(): string {}
  */
 #[Pure(true)]
 #[Deprecated(reason: 'in 8.1.  Use date_sun_info instead', since: '8.1')]
-function date_sunrise(int $timestamp, int $returnFormat = SUNFUNCS_RET_STRING, ?float $latitude, ?float $longitude, ?float $zenith, ?float $utcOffset): string|int|float|false {}
+function date_sunrise(int $timestamp, int $returnFormat = SUNFUNCS_RET_STRING, ?float $latitude = null, ?float $longitude = null, ?float $zenith = null, ?float $utcOffset = null): string|int|float|false {}
 
 /**
  * Returns time of sunset for a given day and location
@@ -1577,7 +1577,7 @@ function date_sunrise(int $timestamp, int $returnFormat = SUNFUNCS_RET_STRING, ?
  */
 #[Pure(true)]
 #[Deprecated(reason: 'in 8.1.  Use date_sun_info instead', since: '8.1')]
-function date_sunset(int $timestamp, int $returnFormat = SUNFUNCS_RET_STRING, ?float $latitude, ?float $longitude, ?float $zenith, ?float $utcOffset): string|int|float|false {}
+function date_sunset(int $timestamp, int $returnFormat = SUNFUNCS_RET_STRING, ?float $latitude = null, ?float $longitude = null, ?float $zenith = null, ?float $utcOffset = null): string|int|float|false {}
 /**
  * Returns an array with information about sunset/sunrise and twilight begin/end
  * @link https://php.net/manual/en/function.date-sun-info.php

--- a/date/date_c.php
+++ b/date/date_c.php
@@ -988,8 +988,8 @@ class DateTimeZone
      */
     #[TentativeType]
     public function getTransitions(
-        #[PhpStormStubsElementAvailable(from: '5.3', to: '5.6')] $timestampBegin,
-        #[PhpStormStubsElementAvailable(from: '5.3', to: '5.6')] $timestampEnd,
+        #[PhpStormStubsElementAvailable(from: '5.3', to: '5.6')] $timestampBegin = PHP_INT_MIN,
+        #[PhpStormStubsElementAvailable(from: '5.3', to: '5.6')] $timestampEnd = 2147483647,
         #[PhpStormStubsElementAvailable(from: '7.0')] #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $timestampBegin = PHP_INT_MIN,
         #[PhpStormStubsElementAvailable(from: '7.0')] #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $timestampEnd = PHP_INT_MAX
     ): array|false {}

--- a/dba/dba.php
+++ b/dba/dba.php
@@ -129,7 +129,7 @@ const DBA_LMDB_NO_SUB_DIR = 0;
  * @return resource|false a positive handle on success or <b>FALSE</b> on failure.
  */
 #[PhpStormStubsElementAvailable(from: '5.3', to: '8.1')]
-function dba_open($path, $mode, $handler, ...$handler_params) {}
+function dba_open($path, $mode, $handler = null, ...$handler_params) {}
 
 #[PhpStormStubsElementAvailable(from: '8.2')]
 #[LanguageLevelTypeAware(["8.4" => "Dba\Connection|false"], default: "resource|false")]
@@ -157,7 +157,7 @@ function dba_open(string $path, string $mode, ?string $handler = null, int $perm
  * @return resource|false a positive handle on success or <b>FALSE</b> on failure.
  */
 #[PhpStormStubsElementAvailable(from: '5.3', to: '8.1')]
-function dba_popen($path, $mode, $handler, ...$handler_params) {}
+function dba_popen($path, $mode, $handler = null, ...$handler_params) {}
 
 #[PhpStormStubsElementAvailable(from: '8.2')]
 #[LanguageLevelTypeAware(["8.4" => "Dba\Connection|false"], default: "resource|false")]

--- a/ds/ds.php
+++ b/ds/ds.php
@@ -378,7 +378,7 @@ namespace Ds;
          * @return Sequence<TValue> A sub-sequence of the given range.
          * @link https://www.php.net/manual/en/ds-sequence.slice.php
          */
-        public function slice(int $index, int $length = null);
+        public function slice(int $index, ?int $length = null);
 
         /**
          * Sorts the sequence in-place, using an optional comparator function.
@@ -723,7 +723,7 @@ namespace Ds;
          * between the index and the end of the sequence.
          * @return Vector<TValue>
          */
-        public function slice(int $index, int $length = null): Vector {}
+        public function slice(int $index, ?int $length = null): Vector {}
 
         /**
          * Sorts the sequence in-place, using an optional comparator function.
@@ -1130,7 +1130,7 @@ namespace Ds;
          * @return Deque<TValue> A sub-deque of the given range.
          * @link https://www.php.net/manual/en/ds-deque.slice.php
          */
-        public function slice(int $index, int $length = null): Deque {}
+        public function slice(int $index, ?int $length = null): Deque {}
 
         /**
          * Sorts the deque in-place, using an optional comparator function.

--- a/exif/exif.php
+++ b/exif/exif.php
@@ -77,7 +77,7 @@ use JetBrains\PhpStorm\Deprecated;
  * those headers. If no data can be returned,
  * <b>exif_read_data</b> will return <b>FALSE</b>.
  */
-function exif_read_data($file, ?string $required_sections, bool $as_arrays = false, bool $read_thumbnail = false): array|false {}
+function exif_read_data($file, ?string $required_sections = null, bool $as_arrays = false, bool $read_thumbnail = false): array|false {}
 
 /**
  * Alias of <b>exif_read_data</b>
@@ -123,7 +123,7 @@ function exif_tagname(int $index): string|false {}
  * @return string|false the embedded thumbnail, or <b>FALSE</b> if the image contains no
  * thumbnail.
  */
-function exif_thumbnail($file, &$width, &$height, &$image_type): string|false {}
+function exif_thumbnail($file, &$width = null, &$height = null, &$image_type = null): string|false {}
 
 /**
  * Determine the type of an image

--- a/fileinfo/fileinfo.php
+++ b/fileinfo/fileinfo.php
@@ -15,7 +15,7 @@ class finfo
      */
     public function __construct(
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $flags = 0,
-        #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $magic_database
+        #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $magic_database = null
     ) {}
 
     /**
@@ -158,7 +158,7 @@ function finfo_set_flags(#[LanguageLevelTypeAware(['8.1' => 'finfo'], default: '
  * @return string|false a textual description of the contents of the
  * <i>filename</i> argument, or <b>FALSE</b> if an error occurred.
  */
-function finfo_file(#[LanguageLevelTypeAware(['8.1' => 'finfo'], default: 'resource')] $finfo, string $filename, int $flags = 0, $context): string|false {}
+function finfo_file(#[LanguageLevelTypeAware(['8.1' => 'finfo'], default: 'resource')] $finfo, string $filename, int $flags = 0, $context = null): string|false {}
 
 /**
  * (PHP 5 &gt;= 5.3.0, PECL fileinfo &gt;= 0.1.0)<br/>
@@ -176,7 +176,7 @@ function finfo_file(#[LanguageLevelTypeAware(['8.1' => 'finfo'], default: 'resou
  * @return string|false a textual description of the <i>string</i>
  * argument, or <b>FALSE</b> if an error occurred.
  */
-function finfo_buffer(#[LanguageLevelTypeAware(['8.1' => 'finfo'], default: 'resource')] $finfo, string $string, int $flags = FILEINFO_NONE, #[\JetBrains\PhpStorm\Deprecated('Deprecated: it has no effect', since: '8.5')] $context): string|false {}
+function finfo_buffer(#[LanguageLevelTypeAware(['8.1' => 'finfo'], default: 'resource')] $finfo, string $string, int $flags = FILEINFO_NONE, #[\JetBrains\PhpStorm\Deprecated('Deprecated: it has no effect', since: '8.5')] $context = null): string|false {}
 
 /**
  * Detect MIME Content-type for a file

--- a/ftp/ftp.php
+++ b/ftp/ftp.php
@@ -214,7 +214,7 @@ function ftp_chmod(#[LanguageLevelTypeAware(['8.1' => 'FTP\Connection'], default
  * </p>
  * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
  */
-function ftp_alloc(#[LanguageLevelTypeAware(['8.1' => 'FTP\Connection'], default: 'resource')] $ftp, int $size, &$response): bool {}
+function ftp_alloc(#[LanguageLevelTypeAware(['8.1' => 'FTP\Connection'], default: 'resource')] $ftp, int $size, &$response = null): bool {}
 
 /**
  * Returns a list of files in the given directory

--- a/gd/gd.php
+++ b/gd/gd.php
@@ -1206,7 +1206,7 @@ function imagefilledpolygon(
     GdImage $image,
     array $points,
     #[Deprecated(since: "8.1")] int $num_points_or_color,
-    ?int $color
+    ?int $color = null
 ): bool {}
 
 /**
@@ -1227,7 +1227,7 @@ function imagefilledpolygon(
 function imagefilledpolygon(
     GdImage $image,
     array $points,
-    ?int $color
+    ?int $color = null
 ): bool {}
 
 /**
@@ -1424,7 +1424,7 @@ function imagepolygon(
     GdImage $image,
     array $points,
     int $num_points_or_color,
-    #[PhpStormStubsElementAvailable(from: '5.3', to: '7.4')] ?int $color,
+    #[PhpStormStubsElementAvailable(from: '5.3', to: '7.4')] ?int $color = null,
     #[PhpStormStubsElementAvailable(from: '8.0')] ?int $color = null
 ): bool {}
 
@@ -2339,7 +2339,7 @@ function imageopenpolygon(
     GdImage $image,
     array $points,
     #[Deprecated(since: "8.1")] int $num_points_or_color,
-    #[PhpStormStubsElementAvailable(from: '5.3', to: '7.4')] ?int $color,
+    #[PhpStormStubsElementAvailable(from: '5.3', to: '7.4')] ?int $color = null,
     #[PhpStormStubsElementAvailable(from: '8.0')] ?int $color = null
 ): bool {}
 

--- a/gearman/gearman.php
+++ b/gearman/gearman.php
@@ -2051,7 +2051,7 @@ class GearmanWorker
      * @param int $timeout An interval of time in seconds
      * @return bool A standard Gearman return value
      */
-    public function register($function_name, $timeout) {}
+    public function register($function_name, $timeout = 0) {}
 
     /**
      * Unregisters a function name with the job servers ensuring that no more jobs (for

--- a/geos/geos.php
+++ b/geos/geos.php
@@ -312,7 +312,7 @@ class GEOSGeometry
      * @return bool|string
      * @throws Exception
      */
-    public function relate(GEOSGeometry $geom, string $pattern = null) {}
+    public function relate(GEOSGeometry $geom, ?string $pattern = null) {}
 
     /**
      * @param GEOSGeometry $geom

--- a/grpc/grpc.php
+++ b/grpc/grpc.php
@@ -514,9 +514,9 @@ namespace Grpc;
          * @throws \InvalidArgumentException
          */
         public static function createSsl(
-            string $pem_root_certs = null,
-            string $pem_private_key = null,
-            string $pem_cert_chain = null
+            ?string $pem_root_certs = null,
+            ?string $pem_private_key = null,
+            ?string $pem_cert_chain = null
         ) {}
 
         /**

--- a/hash/hash.php
+++ b/hash/hash.php
@@ -183,7 +183,7 @@ function hash_update_stream(#[LanguageLevelTypeAware(["7.2" => "HashContext"], d
  * </p>
  * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
  */
-function hash_update_file(#[LanguageLevelTypeAware(["7.2" => "HashContext"], default: "resource")] $context, string $filename, $stream_context): bool {}
+function hash_update_file(#[LanguageLevelTypeAware(["7.2" => "HashContext"], default: "resource")] $context, string $filename, $stream_context = null): bool {}
 
 /**
  * (PHP 5 &gt;= 5.1.2, PECL hash &gt;= 1.1)<br/>
@@ -386,7 +386,7 @@ function mhash_count(): int {}
  */
 #[Pure]
 #[Deprecated(since: '8.1')]
-function mhash(int $algo, string $data, ?string $key): string|false {}
+function mhash(int $algo, string $data, ?string $key = null): string|false {}
 
 /**
  * Optional flag for <b>hash_init</b>.

--- a/http/http3.php
+++ b/http/http3.php
@@ -88,7 +88,7 @@ class Client implements \SplSubject, \Countable
      * @throws \http\Exception\UnexpectedValueException
      * @throws \http\Exception\RuntimeException
      */
-    public function __construct(string $driver = null, string $persistent_handle_id = null) {}
+    public function __construct(?string $driver = null, ?string $persistent_handle_id = null) {}
 
     /**
      * Add custom cookies.
@@ -98,7 +98,7 @@ class Client implements \SplSubject, \Countable
      * @throws \http\Exception\InvalidArgumentException
      * @return \http\Client self.
      */
-    public function addCookies(array $cookies = null) {}
+    public function addCookies(?array $cookies = null) {}
 
     /**
      * Add specific SSL options.
@@ -108,7 +108,7 @@ class Client implements \SplSubject, \Countable
      * @throws \http\Exception\InvalidArgumentException
      * @return \http\Client self.
      */
-    public function addSslOptions(array $ssl_options = null) {}
+    public function addSslOptions(?array $ssl_options = null) {}
 
     /**
      * Implements SplSubject. Attach another observer.
@@ -214,7 +214,7 @@ class Client implements \SplSubject, \Countable
      * @throws \http\Exception\RuntimeException
      * @return \http\Client self.
      */
-    public function enqueue(Client\Request $request, callable $cb = null) {}
+    public function enqueue(Client\Request $request, ?callable $cb = null) {}
 
     /**
      * Get a list of available configuration options and their default values.
@@ -353,7 +353,7 @@ class Client implements \SplSubject, \Countable
      * @throws \http\Exception\RuntimeException
      * @return \http\Client self.
      */
-    public function requeue(Client\Request $request, callable $cb = null) {}
+    public function requeue(Client\Request $request, ?callable $cb = null) {}
 
     /**
      * Reset the client to the initial state.
@@ -380,7 +380,7 @@ class Client implements \SplSubject, \Countable
      * @throws \http\Exception\InvalidArgumentException
      * @return \http\Client self.
      */
-    public function setCookies(array $cookies = null) {}
+    public function setCookies(?array $cookies = null) {}
 
     /**
      * Set client debugging callback.
@@ -406,7 +406,7 @@ class Client implements \SplSubject, \Countable
      * @throws \http\Exception\InvalidArgumentException
      * @return \http\Client self.
      */
-    public function setOptions(array $options = null) {}
+    public function setOptions(?array $options = null) {}
 
     /**
      * Specifically set SSL options.
@@ -416,7 +416,7 @@ class Client implements \SplSubject, \Countable
      * @throws \http\Exception\InvalidArgumentException
      * @return \http\Client self.
      */
-    public function setSslOptions(array $ssl_options = null) {}
+    public function setSslOptions(?array $ssl_options = null) {}
 
     /**
      * Wait for $timeout seconds for transfers to provide data.
@@ -456,7 +456,7 @@ class Cookie
      * @throws \http\Exception\InvalidArgumentException
      * @throws \http\Exception\RuntimeException
      */
-    public function __construct($cookies = null, int $flags = 0, array $allowed_extras = null) {}
+    public function __construct($cookies = null, int $flags = 0, ?array $allowed_extras = null) {}
 
     /**
      * String cast handler. Alias of http\Cookie::toString().
@@ -610,7 +610,7 @@ class Cookie
      * @throws \http\Exception\InvalidArgumentException
      * @return \http\Cookie self.
      */
-    public function setCookies(array $cookies = null) {}
+    public function setCookies(?array $cookies = null) {}
 
     /**
      * Set the effective domain of the cookie list.
@@ -620,7 +620,7 @@ class Cookie
      * @throws \http\Exception\InvalidArgumentException
      * @return \http\Cookie self.
      */
-    public function setDomain(string $value = null) {}
+    public function setDomain(?string $value = null) {}
 
     /**
      * Set the traditional expires timestamp.
@@ -644,7 +644,7 @@ class Cookie
      * @throws \http\Exception\InvalidArgumentException
      * @return \http\Cookie self.
      */
-    public function setExtra(string $extra_name, string $extra_value = null) {}
+    public function setExtra(string $extra_name, ?string $extra_value = null) {}
 
     /**
      * (Re)set the extra attributes.
@@ -654,7 +654,7 @@ class Cookie
      * @throws \http\Exception\InvalidArgumentException
      * @return \http\Cookie self.
      */
-    public function setExtras(array $extras = null) {}
+    public function setExtras(?array $extras = null) {}
 
     /**
      * Set the flags to specified $value.
@@ -685,7 +685,7 @@ class Cookie
      * @throws \http\Exception\InvalidArgumentException
      * @return \http\Cookie self.
      */
-    public function setPath(string $path = null) {}
+    public function setPath(?string $path = null) {}
 
     /**
      * Get the cookie list as array.
@@ -720,7 +720,7 @@ class Env
      * @throws \http\Exception\UnexpectedValueException
      * @return \http\Message\Body instance representing the request body
      */
-    public function getRequestBody(string $body_class_name = null) {}
+    public function getRequestBody(?string $body_class_name = null) {}
 
     /**
      * Retrieve one or all headers of the current HTTP request.
@@ -730,7 +730,7 @@ class Env
      * 		 or string the compound header when $header_name was found
      * 		 or array of all headers if $header_name was not specified
      */
-    public function getRequestHeader(string $header_name = null) {}
+    public function getRequestHeader(?string $header_name = null) {}
 
     /**
      * Get the HTTP response code to send.
@@ -747,7 +747,7 @@ class Env
      * 		 or NULL if the header was not found
      * 		 or array of all response headers, if $header_name was not specified
      */
-    public function getResponseHeader(string $header_name = null) {}
+    public function getResponseHeader(?string $header_name = null) {}
 
     /**
      * Retrieve a list of all known HTTP response status.
@@ -781,7 +781,7 @@ class Env
      * @return string|null NULL if negotiation fails.
      * 		 or string the closest match negotiated, or the default (first entry of $supported).
      */
-    public function negotiate(string $params, array $supported, string $prim_typ_sep = null, array &$result = null) {}
+    public function negotiate(string $params, array $supported, ?string $prim_typ_sep = null, ?array &$result = null) {}
 
     /**
      * Negotiate the client's preferred character set.
@@ -856,7 +856,7 @@ class Env
      * @param bool $replace
      * @return bool Success.
      */
-    public function setResponseHeader(string $header_name, $header_value = null, int $response_code = null, bool $replace = null) {}
+    public function setResponseHeader(string $header_name, $header_value = null, ?int $response_code = null, ?bool $replace = null) {}
 }
 /**
  * The http extension's Exception interface.
@@ -918,7 +918,7 @@ class Header implements \Serializable
      *
      * # Throws:
      */
-    public function __construct(string $name = null, $value = null) {}
+    public function __construct(?string $name = null, $value = null) {}
 
     /**
      * String cast handler. Alias of http\Header::serialize().
@@ -936,7 +936,7 @@ class Header implements \Serializable
      * @param int $flags The modus operandi. See http\Params constants.
      * @return \http\Params instance
      */
-    public function getParams($ps = null, $as = null, $vs = null, int $flags = null) {}
+    public function getParams($ps = null, $as = null, $vs = null, ?int $flags = null) {}
 
     /**
      * Match the HTTP header's value against provided $value according to $flags.
@@ -945,7 +945,7 @@ class Header implements \Serializable
      * @param int $flags The modus operandi. See http\Header constants.
      * @return bool whether $value matches the header value according to $flags.
      */
-    public function match(string $value, int $flags = null) {}
+    public function match(string $value, ?int $flags = null) {}
 
     /**
      * Negotiate the header's value against a list of supported values in $supported.
@@ -973,7 +973,7 @@ class Header implements \Serializable
      * @return array|false array of parsed headers, where the elements are instances of $header_class if specified.
      * 		 or false if parsing fails.
      */
-    public function parse(string $header, string $header_class = null) {}
+    public function parse(string $header, ?string $header_class = null) {}
 
     /**
      * Implements Serializable.
@@ -1169,7 +1169,7 @@ class Message implements \Countable, \Serializable, \Iterator
      * @return mixed|\http\Header mixed the header value if $into_class is NULL.
      * 		 or \http\Header descendant.
      */
-    public function getHeader(string $header, string $into_class = null) {}
+    public function getHeader(string $header, ?string $into_class = null) {}
 
     /**
      * Retrieve all message headers.
@@ -1357,7 +1357,7 @@ class Message implements \Countable, \Serializable, \Iterator
      * @param array $headers The message's headers.
      * @return \http\Message null.
      */
-    public function setHeaders(array $headers = null) {}
+    public function setHeaders(?array $headers = null) {}
 
     /**
      * Set the HTTP protocol version of the message.
@@ -1599,7 +1599,7 @@ class Params implements \ArrayAccess
      * @throws \http\Exception\InvalidArgumentException
      * @throws \http\Exception\RuntimeException
      */
-    public function __construct($params = null, $ps = null, $as = null, $vs = null, int $flags = null) {}
+    public function __construct($params = null, $ps = null, $as = null, $vs = null, ?int $flags = null) {}
 
     /**
      * String cast handler. Alias of http\Params::toString().
@@ -1733,7 +1733,7 @@ class QueryString implements \Serializable, \ArrayAccess, \IteratorAggregate
      * 		 or mixed the querystring value cast to $type if $type was specified and the key $name exists.
      * 		 or string the querystring value if the key $name exists and $type is not specified or equals http\QueryString::TYPE_STRING.
      */
-    public function get(string $name = null, $type = null, $defval = null, bool $delete = false) {}
+    public function get(?string $name = null, $type = null, $defval = null, bool $delete = false) {}
 
     /**
      * Retrieve an array value with at offset $name.
@@ -2313,7 +2313,7 @@ class Request extends \http\Message
      * @throws \http\Exception\InvalidArgumentException
      * @throws \http\Exception\UnexpectedValueException
      */
-    public function __construct(string $meth = null, string $url = null, array $headers = null, \http\Message\Body $body = null) {}
+    public function __construct(?string $meth = null, ?string $url = null, ?array $headers = null, ?\http\Message\Body $body = null) {}
 
     /**
      * Add querystring data.
@@ -2334,7 +2334,7 @@ class Request extends \http\Message
      * @throws \http\Exception\InvalidArgumentException
      * @return \http\Client\Request self.
      */
-    public function addSslOptions(array $ssl_options = null) {}
+    public function addSslOptions(?array $ssl_options = null) {}
 
     /**
      * Extract the currently set "Content-Type" header.
@@ -2392,7 +2392,7 @@ class Request extends \http\Message
      * @throws \http\Exception\InvalidArgumentException
      * @return \http\Client\Request self.
      */
-    public function setOptions(array $options = null) {}
+    public function setOptions(?array $options = null) {}
 
     /**
      * (Re)set the querystring.
@@ -2413,7 +2413,7 @@ class Request extends \http\Message
      * @throws \http\Exception\InvalidArgumentException
      * @return \http\Client\Request self.
      */
-    public function setSslOptions(array $ssl_options = null) {}
+    public function setSslOptions(?array $ssl_options = null) {}
 }
 /**
  * The http\Client\Response class represents an HTTP message the client returns as answer from a server to an http\Client\Request.
@@ -2428,7 +2428,7 @@ class Response extends \http\Message
      * @param array $allowed_extras List of keys treated as extras.
      * @return array list of http\Cookie instances.
      */
-    public function getCookies(int $flags = 0, array $allowed_extras = null) {}
+    public function getCookies(int $flags = 0, ?array $allowed_extras = null) {}
 
     /**
      * Retrieve transfer related information after the request has completed.
@@ -2441,7 +2441,7 @@ class Response extends \http\Message
      * @return object|mixed object stdClass instance with all transfer info if $name was not given.
      * 		 or mixed the specific transfer info for $name.
      */
-    public function getTransferInfo(string $name = null) {}
+    public function getTransferInfo(?string $name = null) {}
 }
 
 namespace http\Client\Curl;
@@ -2530,7 +2530,7 @@ interface User
      *
      * @param int $timeout_ms Block for at most this milliseconds.
      */
-    public function wait(int $timeout_ms = null);
+    public function wait(?int $timeout_ms = null);
 }
 /**
  * CURL feature constants.
@@ -2967,7 +2967,7 @@ class Request extends \http\Message
      * 		 or mixed the querystring value cast to $type if $type was specified and the key $name exists.
      * 		 or string the querystring value if the key $name exists and $type is not specified or equals http\QueryString::TYPE_STRING.
      */
-    public function getCookie(string $name = null, $type = null, $defval = null, bool $delete = false) {}
+    public function getCookie(?string $name = null, $type = null, $defval = null, bool $delete = false) {}
 
     /**
      * Retrieve the uploaded files list ($_FILES).
@@ -2991,7 +2991,7 @@ class Request extends \http\Message
      * 		 or mixed the querystring value cast to $type if $type was specified and the key $name exists.
      * 		 or string the querystring value if the key $name exists and $type is not specified or equals http\QueryString::TYPE_STRING.
      */
-    public function getForm(string $name = null, $type = null, $defval = null, bool $delete = false) {}
+    public function getForm(?string $name = null, $type = null, $defval = null, bool $delete = false) {}
 
     /**
      * Retrieve an URL query value ($_GET).
@@ -3008,7 +3008,7 @@ class Request extends \http\Message
      * 		 or mixed the querystring value cast to $type if $type was specified and the key $name exists.
      * 		 or string the querystring value if the key $name exists and $type is not specified or equals http\QueryString::TYPE_STRING.
      */
-    public function getQuery(string $name = null, $type = null, $defval = null, bool $delete = false) {}
+    public function getQuery(?string $name = null, $type = null, $defval = null, bool $delete = false) {}
 }
 /**
  * The http\Env\Response class' instances represent the server's current HTTP response.
@@ -3454,7 +3454,7 @@ class Body implements \Serializable
      * @throws \http\Exception\RuntimeException
      * @return \http\Message\Body self.
      */
-    public function addForm(array $fields = null, array $files = null) {}
+    public function addForm(?array $fields = null, ?array $files = null) {}
 
     /**
      * Add a part to a multipart body.
@@ -3516,7 +3516,7 @@ class Body implements \Serializable
      * @return int|object int the requested stat field.
      * 		 or object stdClass instance holding all four stat fields.
      */
-    public function stat(string $field = null) {}
+    public function stat(?string $field = null) {}
 
     /**
      * Stream the message body through a callback.

--- a/ibm_db2/ibm_db2.php
+++ b/ibm_db2/ibm_db2.php
@@ -140,7 +140,7 @@ function db2_pclose($connection): bool {}
  * AUTOCOMMIT state of the requested connection to the corresponding state.
  * true on success or false on failure.</p>
  */
-function db2_autocommit($connection, int $value = null): int|bool {}
+function db2_autocommit($connection, ?int $value = null): int|bool {}
 
 /**
  * Binds a PHP variable to an SQL statement parameter
@@ -1503,7 +1503,7 @@ function db2_result($stmt, int|string $column): mixed {}
  * @return bool true if the requested row exists in the result set. Returns
  * false if the requested row does not exist in the result set.
  */
-function db2_fetch_row($stmt, int $row_number = null) {}
+function db2_fetch_row($stmt, int $row_number = -1) {}
 
 /**
  * Returns an array, indexed by column name, representing a row in a result set
@@ -1521,7 +1521,7 @@ function db2_fetch_row($stmt, int $row_number = null) {}
  * there are no rows left in the result set, or if the row requested by
  * row_number does not exist in the result set.
  */
-function db2_fetch_assoc($stmt, int $row_number = null): array|false {}
+function db2_fetch_assoc($stmt, int $row_number = -1): array|false {}
 
 /**
  * Returns an array, indexed by column position, representing a row in a result set
@@ -1539,7 +1539,7 @@ function db2_fetch_assoc($stmt, int $row_number = null): array|false {}
  * there are no rows left in the result set, or if the row requested by
  * row_number does not exist in the result set.
  */
-function db2_fetch_array($stmt, int $row_number = null): array|false {}
+function db2_fetch_array($stmt, int $row_number = -1): array|false {}
 
 /**
  * Returns an array, indexed by both column name and position, representing a row in a result set
@@ -1558,7 +1558,7 @@ function db2_fetch_array($stmt, int $row_number = null): array|false {}
  * in the result set, or if the row requested by
  * row_number does not exist in the result set.
  */
-function db2_fetch_both($stmt, int $row_number = null): array|false {}
+function db2_fetch_both($stmt, int $row_number = -1): array|false {}
 
 /**
  * Frees resources associated with a result set
@@ -1641,7 +1641,7 @@ function db2_setoption(): bool {}
  * <p>
  * Returns false if no row was retrieved.
  */
-function db2_fetch_object($stmt, int $row_number = null): stdClass|false {}
+function db2_fetch_object($stmt, int $row_number = -1): stdClass|false {}
 
 /**
  * Returns an object with properties that describe the DB2 database server

--- a/iconv/iconv.php
+++ b/iconv/iconv.php
@@ -149,7 +149,7 @@ function iconv_strlen(string $string, ?string $encoding = null): int|false {}
  * </p>
  */
 #[Pure]
-function iconv_substr(string $string, int $offset, ?int $length, ?string $encoding = null): string|false {}
+function iconv_substr(string $string, int $offset, ?int $length = null, ?string $encoding = null): string|false {}
 
 /**
  * Finds position of first occurrence of a needle within a haystack

--- a/imagick/imagick.php
+++ b/imagick/imagick.php
@@ -1859,7 +1859,7 @@ class Imagick implements Iterator, Countable
      * @return bool
      * @throws ImagickException on error.
      */
-    public function blueShiftImage($factor) {}
+    public function blueShiftImage($factor = 1.5) {}
 
     /**
      * (No version information available, might only be in SVN)<br/>

--- a/ldap/ldap.php
+++ b/ldap/ldap.php
@@ -21,13 +21,13 @@ use LDAP\Result;
 function ldap_exop_passwd(
     #[PhpVersionAware(['8.1' => 'LDAP\Connection'], default: 'resource')] $ldap,
     #[Available(from: '7.1', to: '7.1')] string $user = "",
-    #[Available(from: '7.2', to: '7.2')] string $user,
+    #[Available(from: '7.2', to: '7.2')] string $user = "",
     #[Available(from: '7.3')] string $user = "",
     #[Available(from: '7.1', to: '7.1')] string $old_password = "",
-    #[Available(from: '7.2', to: '7.2')] string $old_password,
+    #[Available(from: '7.2', to: '7.2')] string $old_password = "",
     #[Available(from: '7.3')] string $old_password = "",
     #[Available(from: '7.1', to: '7.1')] string $new_password = "",
-    #[Available(from: '7.2', to: '7.2')] string $new_password,
+    #[Available(from: '7.2', to: '7.2')] string $new_password = "",
     #[Available(from: '7.3')] string $new_password = "",
     #[Available(from: '7.3')] &$controls = null
 ): string|bool {}
@@ -65,7 +65,7 @@ function ldap_exop_whoami(#[PhpVersionAware(['8.1' => 'LDAP\Connection'], defaul
  * @since 7.2
  */
 #[PhpVersionAware(['8.1' => 'LDAP\Result|bool'], default: 'resource|bool')]
-function ldap_exop(#[PhpVersionAware(['8.1' => 'LDAP\Connection'], default: 'resource')] $ldap, string $request_oid, ?string $request_data, #[PhpVersionAware(["8.0" => "null|array"], default: "array")] $controls = null, &$response_data, &$response_oid) {}
+function ldap_exop(#[PhpVersionAware(['8.1' => 'LDAP\Connection'], default: 'resource')] $ldap, string $request_oid, ?string $request_data = null, #[PhpVersionAware(["8.0" => "null|array"], default: "array")] $controls = null, &$response_data, &$response_oid) {}
 
 /**
  * Parse LDAP extended operation data from result object result
@@ -80,9 +80,9 @@ function ldap_exop(#[PhpVersionAware(['8.1' => 'LDAP\Connection'], default: 'res
 function ldap_parse_exop(
     #[PhpVersionAware(['8.1' => 'LDAP\Connection'], default: 'resource')] $ldap,
     #[PhpVersionAware(['8.1' => 'LDAP\Result'], default: 'resource')] $result,
-    #[Available(from: '7.2', to: '7.4')] &$response_data,
+    #[Available(from: '7.2', to: '7.4')] &$response_data = null,
     #[Available(from: '8.0')] &$response_data = null,
-    #[Available(from: '7.2', to: '7.4')] &$response_oid,
+    #[Available(from: '7.2', to: '7.4')] &$response_oid = null,
     #[Available(from: '8.0')] &$response_oid = null
 ): bool {}
 
@@ -126,7 +126,7 @@ function ldap_t61_to_8859(string $value): string {}
  * opened link will be returned.
  */
 #[PhpVersionAware(['8.1' => 'LDAP\Connection|false'], default: 'resource|false')]
-function ldap_connect(?string $uri, int $port = 389) {}
+function ldap_connect(?string $uri = null, int $port = 389) {}
 
 /**
  * Alias of <b>ldap_unbind</b>
@@ -146,7 +146,7 @@ function ldap_close(#[PhpVersionAware(['8.1' => 'LDAP\Connection'], default: 're
  * @param string|null $password [optional]
  * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
  */
-function ldap_bind(#[PhpVersionAware(['8.1' => 'LDAP\Connection'], default: 'resource')] $ldap, ?string $dn, ?string $password): bool {}
+function ldap_bind(#[PhpVersionAware(['8.1' => 'LDAP\Connection'], default: 'resource')] $ldap, ?string $dn = null, ?string $password = null): bool {}
 
 /**
  * Bind to LDAP directory
@@ -164,8 +164,8 @@ function ldap_bind(#[PhpVersionAware(['8.1' => 'LDAP\Connection'], default: 'res
 #[PhpVersionAware(['8.1' => 'LDAP\Result|false'], default: 'resource|false')]
 function ldap_bind_ext(
     #[PhpVersionAware(['8.1' => 'LDAP\Connection'], default: 'resource')] $ldap,
-    ?string $dn,
-    ?string $password,
+    ?string $dn = null,
+    ?string $password = null,
     #[PhpVersionAware(["8.0" => "null|array"], default: "array")] $controls = null
 ) {}
 
@@ -1088,7 +1088,7 @@ function ldap_rename_ext(#[PhpVersionAware(['8.1' => 'LDAP\Connection'], default
 function ldap_get_option(
     #[PhpVersionAware(['8.1' => 'LDAP\Connection', '8.5' => 'LDAP\Connection|null'], default: 'resource')] $ldap,
     int $option,
-    #[Available(from: '5.3', to: '7.4')] &$value,
+    #[Available(from: '5.3', to: '7.4')] &$value = null,
     #[Available(from: '8.0')] &$value = null
 ): bool {}
 
@@ -1253,9 +1253,9 @@ function ldap_parse_result(
     #[PhpVersionAware(['8.1' => 'LDAP\Connection'], default: 'resource')] $ldap,
     #[PhpVersionAware(['8.1' => 'LDAP\Result'], default: 'resource')] $result,
     &$error_code,
-    &$matched_dn,
-    &$error_message,
-    &$referrals,
+    &$matched_dn = null,
+    &$error_message = null,
+    &$referrals = null,
     #[Available(from: '7.3')] &$controls = null
 ): bool {}
 

--- a/mailparse/mailparse.php
+++ b/mailparse/mailparse.php
@@ -51,7 +51,7 @@ function mailparse_msg_create() {}
  * Returns FALSE on error.
  * </p>
  */
-function mailparse_msg_extract_part_file($mimemail, $filename, $callbackfunc) {}
+function mailparse_msg_extract_part_file($mimemail, $filename, $callbackfunc = null) {}
 
 /**
  * (PECL mailparse >= 0.9.0)<br/>
@@ -64,7 +64,7 @@ function mailparse_msg_extract_part_file($mimemail, $filename, $callbackfunc) {}
  * @param callable $callbackfunc [optional]
  * @return void
  */
-function mailparse_msg_extract_part($mimemail, $msgbody, $callbackfunc) {}
+function mailparse_msg_extract_part($mimemail, $msgbody, $callbackfunc = null) {}
 
 /**
  * (PECL mailparse >= 0.9.0)<br/>
@@ -77,7 +77,7 @@ function mailparse_msg_extract_part($mimemail, $msgbody, $callbackfunc) {}
  * @param callable $callbackfunc [optional]
  * @return string
  */
-function mailparse_msg_extract_whole_part_file($mimemail, $filename, $callbackfunc) {}
+function mailparse_msg_extract_whole_part_file($mimemail, $filename, $callbackfunc = null) {}
 
 /**
  * (PECL mailparse >= 0.9.0)<br/>

--- a/mbstring/mbstring.php
+++ b/mbstring/mbstring.php
@@ -25,7 +25,7 @@ use JetBrains\PhpStorm\Pure;
  * way specified by mode.
  */
 #[Pure]
-function mb_convert_case(string $string, int $mode, ?string $encoding): string {}
+function mb_convert_case(string $string, int $mode, ?string $encoding = null): string {}
 
 /**
  * Make a string uppercase
@@ -37,7 +37,7 @@ function mb_convert_case(string $string, int $mode, ?string $encoding): string {
  * @return string str with all alphabetic characters converted to uppercase.
  */
 #[Pure]
-function mb_strtoupper(string $string, ?string $encoding): string {}
+function mb_strtoupper(string $string, ?string $encoding = null): string {}
 
 /**
  * Make a string lowercase
@@ -49,7 +49,7 @@ function mb_strtoupper(string $string, ?string $encoding): string {}
  * @return string str with all alphabetic characters converted to lowercase.
  */
 #[Pure]
-function mb_strtolower(string $string, ?string $encoding): string {}
+function mb_strtolower(string $string, ?string $encoding = null): string {}
 
 /**
  * Set/Get current language
@@ -73,7 +73,7 @@ function mb_strtolower(string $string, ?string $encoding): string {}
  * name as a string. If no language is set previously, it then returns
  * false.
  */
-function mb_language(?string $language): string|bool {}
+function mb_language(?string $language = null): string|bool {}
 
 /**
  * Set/Get internal character encoding
@@ -89,7 +89,7 @@ function mb_language(?string $language): string|bool {}
  * If encoding is omitted, then
  * the current character encoding name is returned.
  */
-function mb_internal_encoding(?string $encoding): string|bool {}
+function mb_internal_encoding(?string $encoding = null): string|bool {}
 
 /**
  * Detect HTTP input character encoding
@@ -105,7 +105,7 @@ function mb_internal_encoding(?string $encoding): string|bool {}
  * HTTP input, it returns false.
  */
 #[Pure]
-function mb_http_input(?string $type): array|string|false {}
+function mb_http_input(?string $type = null): array|string|false {}
 
 /**
  * Set/Get HTTP output character encoding
@@ -125,7 +125,7 @@ function mb_http_input(?string $type): array|string|false {}
  * character encoding. Otherwise,
  * true on success or false on failure.
  */
-function mb_http_output(?string $encoding): string|bool {}
+function mb_http_output(?string $encoding = null): string|bool {}
 
 /**
  * Set/Get character encoding detection order
@@ -258,7 +258,7 @@ function mb_preferred_mime_name(string $encoding): string|false {}
  */
 #[Pure]
 #[LanguageLevelTypeAware(['8.0' => 'int'], default: 'int|false')]
-function mb_strlen(string $string, #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: 'string')] $encoding) {}
+function mb_strlen(string $string, #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: 'string')] $encoding = null) {}
 
 /**
  * Find position of first occurrence of string in a string
@@ -279,7 +279,7 @@ function mb_strlen(string $string, #[LanguageLevelTypeAware(['8.0' => 'string|nu
  * needle is not found, it returns false.
  */
 #[Pure]
-function mb_strpos(string $haystack, string $needle, int $offset = 0, ?string $encoding): int|false {}
+function mb_strpos(string $haystack, string $needle, int $offset = 0, ?string $encoding = null): int|false {}
 
 /**
  * Find position of last occurrence of a string in a string
@@ -301,7 +301,7 @@ function mb_strpos(string $haystack, string $needle, int $offset = 0, ?string $e
  * needle is not found, it returns false.
  */
 #[Pure]
-function mb_strrpos(string $haystack, string $needle, int $offset = 0, ?string $encoding): int|false {}
+function mb_strrpos(string $haystack, string $needle, int $offset = 0, ?string $encoding = null): int|false {}
 
 /**
  * Finds position of first occurrence of a string within another, case insensitive
@@ -326,7 +326,7 @@ function mb_strrpos(string $haystack, string $needle, int $offset = 0, ?string $
  * string, or false if needle is not found.
  */
 #[Pure]
-function mb_stripos(string $haystack, string $needle, int $offset = 0, ?string $encoding): int|false {}
+function mb_stripos(string $haystack, string $needle, int $offset = 0, ?string $encoding = null): int|false {}
 
 /**
  * Finds position of last occurrence of a string within another, case insensitive
@@ -352,7 +352,7 @@ function mb_stripos(string $haystack, string $needle, int $offset = 0, ?string $
  * if needle is not found.
  */
 #[Pure]
-function mb_strripos(string $haystack, string $needle, int $offset = 0, ?string $encoding): int|false {}
+function mb_strripos(string $haystack, string $needle, int $offset = 0, ?string $encoding = null): int|false {}
 
 /**
  * Finds first occurrence of a string within another
@@ -380,7 +380,7 @@ function mb_strripos(string $haystack, string $needle, int $offset = 0, ?string 
  * or false if needle is not found.
  */
 #[Pure]
-function mb_strstr(string $haystack, string $needle, bool $before_needle = false, ?string $encoding): string|false {}
+function mb_strstr(string $haystack, string $needle, bool $before_needle = false, ?string $encoding = null): string|false {}
 
 /**
  * Finds the last occurrence of a character in a string within another
@@ -408,7 +408,7 @@ function mb_strstr(string $haystack, string $needle, bool $before_needle = false
  * or false if needle is not found.
  */
 #[Pure]
-function mb_strrchr(string $haystack, string $needle, bool $before_needle = false, ?string $encoding): string|false {}
+function mb_strrchr(string $haystack, string $needle, bool $before_needle = false, ?string $encoding = null): string|false {}
 
 /**
  * Finds first occurrence of a string within another, case insensitive
@@ -436,7 +436,7 @@ function mb_strrchr(string $haystack, string $needle, bool $before_needle = fals
  * or false if needle is not found.
  */
 #[Pure]
-function mb_stristr(string $haystack, string $needle, bool $before_needle = false, ?string $encoding): string|false {}
+function mb_stristr(string $haystack, string $needle, bool $before_needle = false, ?string $encoding = null): string|false {}
 
 /**
  * Finds the last occurrence of a character in a string within another, case insensitive
@@ -464,7 +464,7 @@ function mb_stristr(string $haystack, string $needle, bool $before_needle = fals
  * or false if needle is not found.
  */
 #[Pure]
-function mb_strrichr(string $haystack, string $needle, bool $before_needle = false, ?string $encoding): string|false {}
+function mb_strrichr(string $haystack, string $needle, bool $before_needle = false, ?string $encoding = null): string|false {}
 
 /**
  * Count the number of substring occurrences
@@ -481,7 +481,7 @@ function mb_strrichr(string $haystack, string $needle, bool $before_needle = fal
  * haystack string.
  */
 #[Pure]
-function mb_substr_count(string $haystack, string $needle, ?string $encoding): int {}
+function mb_substr_count(string $haystack, string $needle, ?string $encoding = null): int {}
 
 /**
  * Get part of string
@@ -502,7 +502,7 @@ function mb_substr_count(string $haystack, string $needle, ?string $encoding): i
  * length parameters.
  */
 #[Pure]
-function mb_substr(string $string, int $start, ?int $length, ?string $encoding): string {}
+function mb_substr(string $string, int $start, ?int $length = null, ?string $encoding = null): string {}
 
 /**
  * Get part of string
@@ -523,7 +523,7 @@ function mb_substr(string $string, int $start, ?int $length, ?string $encoding):
  * length parameters.
  */
 #[Pure]
-function mb_strcut(string $string, int $start, ?int $length, ?string $encoding): string {}
+function mb_strcut(string $string, int $start, ?int $length = null, ?string $encoding = null): string {}
 
 /**
  * Return width of string
@@ -535,7 +535,7 @@ function mb_strcut(string $string, int $start, ?int $length, ?string $encoding):
  * @return int The width of string str.
  */
 #[Pure]
-function mb_strwidth(string $string, ?string $encoding): int {}
+function mb_strwidth(string $string, ?string $encoding = null): int {}
 
 /**
  * Get truncated string with specified width
@@ -559,7 +559,7 @@ function mb_strwidth(string $string, ?string $encoding): int {}
  * trimmarker is appended to the return value.
  */
 #[Pure]
-function mb_strimwidth(string $string, int $start, int $width, string $trim_marker = '', ?string $encoding): string {}
+function mb_strimwidth(string $string, int $start, int $width, string $trim_marker = '', ?string $encoding = null): string {}
 
 /**
  * Convert character encoding
@@ -744,7 +744,7 @@ function mb_encoding_aliases(string $encoding) {}
  * @return string The converted string.
  */
 #[Pure]
-function mb_convert_kana(string $string, string $mode = 'KV', ?string $encoding): string {}
+function mb_convert_kana(string $string, string $mode = 'KV', ?string $encoding = null): string {}
 
 /**
  * Encode string for MIME header
@@ -779,7 +779,7 @@ function mb_convert_kana(string $string, string $mode = 'KV', ?string $encoding)
  * @return string A converted version of the string represented in ASCII.
  */
 #[Pure]
-function mb_encode_mimeheader(string $string, ?string $charset, ?string $transfer_encoding, string $newline = "\r\n", int $indent = 0): string {}
+function mb_encode_mimeheader(string $string, ?string $charset = null, ?string $transfer_encoding = null, string $newline = "\r\n", int $indent = 0): string {}
 
 /**
  * Decode string in MIME header field
@@ -817,7 +817,7 @@ function mb_decode_mimeheader(string $string): string {}
 function mb_convert_variables(
     string $to_encoding,
     array|string $from_encoding,
-    #[PhpStormStubsElementAvailable(from: '5.3', to: '7.4')] &$vars,
+    #[PhpStormStubsElementAvailable(from: '5.3', to: '7.4')] &$vars = null,
     #[PhpStormStubsElementAvailable(from: '8.0')] mixed &$var,
     mixed &...$vars
 ): string|false {}
@@ -888,7 +888,7 @@ function mb_decode_numericentity(string $string, array $map, ?string $encoding =
  * </p>
  * @return bool true on success or false on failure.
  */
-function mb_send_mail(string $to, string $subject, string $message, array|string $additional_headers = [], ?string $additional_params): bool {}
+function mb_send_mail(string $to, string $subject, string $message, array|string $additional_headers = [], ?string $additional_params = null): bool {}
 
 /**
  * Get internal settings of mbstring
@@ -940,7 +940,7 @@ function mb_get_info(string $type = 'all') {}
  * @since 5.1.3
  */
 #[Pure]
-function mb_check_encoding(array|string|null $value = null, ?string $encoding): bool {}
+function mb_check_encoding(array|string|null $value = null, ?string $encoding = null): bool {}
 
 /**
  * Returns current encoding for multibyte regex as string
@@ -951,7 +951,7 @@ function mb_check_encoding(array|string|null $value = null, ?string $encoding): 
  * is NOT changed. If encoding is omitted, then the current character
  * encoding name for a multibyte regex is returned.
  */
-function mb_regex_encoding(?string $encoding): string|bool {}
+function mb_regex_encoding(?string $encoding = null): string|bool {}
 
 /**
  * Set/Get the default options for mbregex functions
@@ -962,7 +962,7 @@ function mb_regex_encoding(?string $encoding): string|bool {}
  * @return string The previous options. If options is omitted,
  * it returns the string that describes the current options.
  */
-function mb_regex_set_options(?string $options): string {}
+function mb_regex_set_options(?string $options = null): string {}
 
 /**
  * Regular expression match with multibyte support
@@ -978,7 +978,7 @@ function mb_regex_set_options(?string $options): string {}
  * </p>
  * @return bool
  */
-function mb_ereg(string $pattern, string $string, &$matches): bool {}
+function mb_ereg(string $pattern, string $string, &$matches = null): bool {}
 
 /**
  * Regular expression match ignoring case with multibyte support
@@ -995,7 +995,7 @@ function mb_ereg(string $pattern, string $string, &$matches): bool {}
  * @return bool|int
  */
 #[LanguageLevelTypeAware(["8.0" => "bool"], default: "false|int")]
-function mb_eregi(string $pattern, string $string, &$matches): bool {}
+function mb_eregi(string $pattern, string $string, &$matches = null): bool {}
 
 /**
  * Replace regular expression with multibyte support
@@ -1129,7 +1129,7 @@ function mb_split(string $pattern, string $string, int $limit = -1): array|false
  * @return bool
  */
 #[Pure]
-function mb_ereg_match(string $pattern, string $string, ?string $options): bool {}
+function mb_ereg_match(string $pattern, string $string, ?string $options = null): bool {}
 
 /**
  * Multibyte regular expression match for predefined multibyte string
@@ -1143,7 +1143,7 @@ function mb_ereg_match(string $pattern, string $string, ?string $options): bool 
  * @return bool
  */
 #[Pure]
-function mb_ereg_search(?string $pattern, ?string $options): bool {}
+function mb_ereg_search(?string $pattern = null, ?string $options = null): bool {}
 
 /**
  * Returns position and length of a matched part of the multibyte regular expression for a predefined multibyte string
@@ -1160,7 +1160,7 @@ function mb_ereg_search(?string $pattern, ?string $options): bool {}
  * length in bytes of the match. If an error occurs, FALSE is returned.
  */
 #[Pure]
-function mb_ereg_search_pos(?string $pattern, ?string $options): array|false {}
+function mb_ereg_search_pos(?string $pattern = null, ?string $options = null): array|false {}
 
 /**
  * Returns the matched part of a multibyte regular expression
@@ -1178,7 +1178,7 @@ function mb_ereg_search_pos(?string $pattern, ?string $options): array|false {}
  * part as third element, and so on. It returns FALSE on error.
  */
 #[Pure]
-function mb_ereg_search_regs(?string $pattern, ?string $options): array|false {}
+function mb_ereg_search_regs(?string $pattern = null, ?string $options = null): array|false {}
 
 /**
  * Setup string and regular expression for a multibyte regular expression match
@@ -1194,7 +1194,7 @@ function mb_ereg_search_regs(?string $pattern, ?string $options): array|false {}
  * </p>
  * @return bool
  */
-function mb_ereg_search_init(string $string, ?string $pattern, ?string $options): bool {}
+function mb_ereg_search_init(string $string, ?string $pattern = null, ?string $options = null): bool {}
 
 /**
  * Retrieve the result from the last multibyte regular expression match
@@ -1364,7 +1364,7 @@ function mbereg_search_getpos() {}
  * @since 7.2
  */
 #[Pure]
-function mb_chr(int $codepoint, ?string $encoding): string|false {}
+function mb_chr(int $codepoint, ?string $encoding = null): string|false {}
 
 /**
  * Get code point of character
@@ -1375,7 +1375,7 @@ function mb_chr(int $codepoint, ?string $encoding): string|false {}
  * @since 7.2
  */
 #[Pure]
-function mb_ord(string $string, ?string $encoding): int|false {}
+function mb_ord(string $string, ?string $encoding = null): int|false {}
 
 /**
  * Scrub broken multibyte strings.
@@ -1387,7 +1387,7 @@ function mb_ord(string $string, ?string $encoding): int|false {}
  */
 #[Pure]
 #[LanguageLevelTypeAware(["8.0" => "string"], default: "string|false")]
-function mb_scrub(string $string, ?string $encoding): false|string {}
+function mb_scrub(string $string, ?string $encoding = null): false|string {}
 
 /**
  * @param $position
@@ -1414,7 +1414,7 @@ function mbereg_search_setpos($position) {}
  */
 #[Pure]
 #[LanguageLevelTypeAware(["8.0" => "array"], default: "array|false")]
-function mb_str_split(string $string, int $length = 1, ?string $encoding) {}
+function mb_str_split(string $string, int $length = 1, ?string $encoding = null) {}
 
 /**
  * Pad a multibyte string to a certain length with another multibyte string

--- a/memcache/memcache.php
+++ b/memcache/memcache.php
@@ -94,7 +94,7 @@ class MemcachePool
      * </p>
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
-    public function addServer($host, $port = 11211, $persistent = true, $weight = null, $timeout = 1, $retry_interval = 15, $status = true, callable $failure_callback = null, $timeoutms = null) {}
+    public function addServer($host, $port = 11211, $persistent = true, $weight = null, $timeout = 1, $retry_interval = 15, $status = true, ?callable $failure_callback = null, $timeoutms = null) {}
 
     /**
      * (PECL memcache &gt;= 2.1.0)<br/>
@@ -127,7 +127,7 @@ class MemcachePool
      * </p>
      * @return bool <p>Returns <b>TRUE</b> on success or <b>FALSE</b> on failure.</p>
      */
-    public function setServerParams($host, $port = 11211, $timeout = 1, $retry_interval = 15, $status = true, callable $failure_callback = null) {}
+    public function setServerParams($host, $port = 11211, $timeout = 1, $retry_interval = 15, $status = true, ?callable $failure_callback = null) {}
 
     /**
      * @param callable $callback
@@ -478,7 +478,7 @@ function memcache_pconnect($host, $port = null, $timeout = 1) {}
  * </p>
  * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
  */
-function memcache_add_server($memcache, $host, $port = 11211, $persistent = true, $weight = null, $timeout = 1, $retry_interval = 15, $status = true, callable $failure_callback = null, $timeoutms = null) {}
+function memcache_add_server($memcache, $host, $port = 11211, $persistent = true, $weight = null, $timeout = 1, $retry_interval = 15, $status = true, ?callable $failure_callback = null, $timeoutms = null) {}
 
 /**
  * (PECL memcache &gt;= 2.1.0)<br/>
@@ -515,7 +515,7 @@ function memcache_add_server($memcache, $host, $port = 11211, $persistent = true
  *
  * @return bool <p>Returns <b>TRUE</b> on success or <b>FALSE</b> on failure.</p>
  */
-function memcache_set_server_params($memcache, $host, $port = 11211, $timeout = 1, $retry_interval = 15, $status = true, callable $failure_callback = null) {}
+function memcache_set_server_params($memcache, $host, $port = 11211, $timeout = 1, $retry_interval = 15, $status = true, ?callable $failure_callback = null) {}
 
 /**
  * @param Memcache $memcache

--- a/memcached/memcached.php
+++ b/memcached/memcached.php
@@ -734,7 +734,7 @@ class Memcached
      * The <b>Memcached::getResultCode</b> will return
      * <b>Memcached::RES_NOTFOUND</b> if the key does not exist.
      */
-    public function get($key, callable $cache_cb = null, $flags = 0) {}
+    public function get($key, ?callable $cache_cb = null, $flags = 0) {}
 
     /**
      * (PECL memcached &gt;= 0.1.0)<br/>
@@ -756,7 +756,7 @@ class Memcached
      * The <b>Memcached::getResultCode</b> will return
      * <b>Memcached::RES_NOTFOUND</b> if the key does not exist.
      */
-    public function getByKey($server_key, $key, callable $cache_cb = null, $flags = 0) {}
+    public function getByKey($server_key, $key, ?callable $cache_cb = null, $flags = 0) {}
 
     /**
      * (PECL memcached &gt;= 0.1.0)<br/>
@@ -807,7 +807,7 @@ class Memcached
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      * Use <b>Memcached::getResultCode</b> if necessary.
      */
-    public function getDelayed(array $keys, $with_cas = null, callable $value_cb = null) {}
+    public function getDelayed(array $keys, $with_cas = null, ?callable $value_cb = null) {}
 
     /**
      * (PECL memcached &gt;= 0.1.0)<br/>
@@ -828,7 +828,7 @@ class Memcached
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      * Use <b>Memcached::getResultCode</b> if necessary.
      */
-    public function getDelayedByKey($server_key, array $keys, $with_cas = null, callable $value_cb = null) {}
+    public function getDelayedByKey($server_key, array $keys, $with_cas = null, ?callable $value_cb = null) {}
 
     /**
      * (PECL memcached &gt;= 0.1.0)<br/>
@@ -919,7 +919,7 @@ class Memcached
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      * Use <b>Memcached::getResultCode</b> if necessary.
      */
-    public function touchByKey($server_key, $key, $expiration) {}
+    public function touchByKey($server_key, $key, $expiration = 0) {}
 
     /**
      * (PECL memcached &gt;= 0.1.0)<br/>

--- a/mongo/mongo.php
+++ b/mongo/mongo.php
@@ -102,7 +102,7 @@ class MongoClient
      *         </ul>
      * @throws MongoConnectionException
      */
-    public function __construct($server = "mongodb://localhost:27017", array $options = ["connect" => true], $driver_options) {}
+    public function __construct($server = "mongodb://localhost:27017", array $options = ["connect" => true], $driver_options = []) {}
 
     /**
      * (PECL mongo &gt;= 1.3.0)<br/>
@@ -1149,7 +1149,7 @@ class MongoCollection
      * @param array $query An optional query parameters
      * @return array|false Returns an array of distinct values, or <b>FALSE</b> on failure
      */
-    public function distinct($key, array $query = null) {}
+    public function distinct($key, ?array $query = null) {}
 
     /**
      * Update a document and return it
@@ -1160,7 +1160,7 @@ class MongoCollection
      * @param array $options An array of options to apply, such as remove the match document from the DB and return it.
      * @return array Returns the original document, or the modified document when new is set.
      */
-    public function findAndModify(array $query, array $update = null, array $fields = null, array $options = null) {}
+    public function findAndModify(array $query, ?array $update = null, ?array $fields = null, ?array $options = null) {}
 
     /**
      * Querys this collection, returning a single element
@@ -1663,7 +1663,7 @@ class MongoCommandCursor implements MongoCursorInterface
 
     public function getReadPreference(): array {}
 
-    public function setReadPreference(string $read_preference, array $tags = null): MongoCursorInterface {}
+    public function setReadPreference(string $read_preference, ?array $tags = null): MongoCursorInterface {}
 
     public function timeout(int $ms): MongoCursorInterface {}
 }
@@ -1678,7 +1678,7 @@ interface MongoCursorInterface extends Iterator
 
     public function getReadPreference(): array;
 
-    public function setReadPreference(string $read_preference, array $tags = null): MongoCursorInterface;
+    public function setReadPreference(string $read_preference, ?array $tags = null): MongoCursorInterface;
 
     public function timeout(int $ms): MongoCursorInterface;
 }

--- a/mysql/mysql.php
+++ b/mysql/mysql.php
@@ -468,7 +468,7 @@ function mysql_fetch_assoc($result) {}
  * @removed 7.0
  */
 #[Deprecated(since: '5.5')]
-function mysql_fetch_object($result, $class_name = 'stdClass', array $params = null) {}
+function mysql_fetch_object($result, $class_name = 'stdClass', ?array $params = null) {}
 
 /**
  * Move internal result pointer

--- a/mysql_xdevapi/mysql_xdevapi.php
+++ b/mysql_xdevapi/mysql_xdevapi.php
@@ -1443,7 +1443,7 @@ class TableSelect implements \mysql_xdevapi\Executable
      * @param int|null $lock_waiting_option
      * @return \mysql_xdevapi\TableSelect
      */
-    public function lockExclusive(?int $lock_waiting_option): TableSelect {}
+    public function lockExclusive(?int $lock_waiting_option = null): TableSelect {}
 
     /**
      * Execute a read operation with SHARED LOCK. Only one lock can be active at a time.
@@ -1451,7 +1451,7 @@ class TableSelect implements \mysql_xdevapi\Executable
      * @param int|null $lock_waiting_option
      * @return \mysql_xdevapi\TableSelect
      */
-    public function lockShared(?int $lock_waiting_option): TableSelect {}
+    public function lockShared(?int $lock_waiting_option = null): TableSelect {}
 
     /**
      * Skip given number of rows in result.

--- a/mysqli/mysqli.php
+++ b/mysqli/mysqli.php
@@ -1472,7 +1472,7 @@ class mysqli_stmt
      * @param mysqli $mysql
      * @param string $query [optional]
      */
-    public function __construct($mysql, $query) {}
+    public function __construct($mysql, $query = null) {}
 
     /**
      * Used to get the current value of a statement attribute
@@ -1784,7 +1784,7 @@ function mysqli_autocommit(mysqli $mysql, bool $enable): bool {}
  * @return bool true on success or false on failure.
  * @since 5.5
  */
-function mysqli_begin_transaction(mysqli $mysql, int $flags = 0, ?string $name): bool {}
+function mysqli_begin_transaction(mysqli $mysql, int $flags = 0, ?string $name = null): bool {}
 
 /**
  * Changes the user of the specified database connection
@@ -2170,7 +2170,7 @@ function mysqli_get_charset(mysqli $mysql): ?object {}
  */
 #[LanguageLevelTypeAware(['8.0' => 'string'], default: 'string|null')]
 function mysqli_get_client_info(
-    #[PhpStormStubsElementAvailable(from: '5.3', to: '7.1')] mysqli $mysql,
+    #[PhpStormStubsElementAvailable(from: '5.3', to: '7.1')] mysqli $mysql = null,
     #[PhpStormStubsElementAvailable(from: '8.0')] ?mysqli $mysql = null
 ) {}
 
@@ -2476,7 +2476,7 @@ function mysqli_query(
  * @param int $flags
  * @return bool
  */
-function mysqli_real_connect(mysqli $mysql, ?string $hostname, ?string $username, ?string $password, ?string $database, ?int $port, ?string $socket, int $flags = 0): bool {}
+function mysqli_real_connect(mysqli $mysql, ?string $hostname = null, ?string $username = null, ?string $password = null, ?string $database = null, ?int $port = null, ?string $socket = null, int $flags = 0): bool {}
 
 /**
  * Escapes special characters in a string for use in an SQL statement, taking into account the current charset of the connection
@@ -2529,7 +2529,7 @@ function mysqli_release_savepoint(mysqli $mysql, string $name): bool {}
  * @param string|null $name [optional] If provided then ROLLBACKname is executed
  * @return bool
  */
-function mysqli_rollback(mysqli $mysql, int $flags = 0, ?string $name): bool {}
+function mysqli_rollback(mysqli $mysql, int $flags = 0, ?string $name = null): bool {}
 
 /**
  * Set a named transaction savepoint
@@ -2671,7 +2671,7 @@ function mysqli_stmt_send_long_data(mysqli_stmt $statement, int $param_num, stri
 function mysqli_stmt_bind_param(
     mysqli_stmt $statement,
     string $types,
-    #[PhpStormStubsElementAvailable(from: '5.3', to: '7.4')] mixed &$vars,
+    #[PhpStormStubsElementAvailable(from: '5.3', to: '7.4')] mixed &$vars = null,
     mixed &...$vars
 ): bool {}
 
@@ -2684,7 +2684,7 @@ function mysqli_stmt_bind_param(
  */
 function mysqli_stmt_bind_result(
     mysqli_stmt $statement,
-    #[PhpStormStubsElementAvailable(from: '5.3', to: '7.4')] mixed &$vars,
+    #[PhpStormStubsElementAvailable(from: '5.3', to: '7.4')] mixed &$vars = null,
     mixed &...$vars
 ): bool {}
 

--- a/newrelic/newrelic.php
+++ b/newrelic/newrelic.php
@@ -300,10 +300,10 @@ function newrelic_name_transaction(string $name): bool {}
  */
 function newrelic_notice_error(
     string|Throwable|Exception|int $messageOrExceptionOrCode,
-    string|Throwable|Exception $errstrOrException = null,
-    string $errfile = null,
-    int $errline = null,
-    string $errcontext = null
+    string|Throwable|Exception|null $errstrOrException = null,
+    ?string $errfile = null,
+    ?int $errline = null,
+    ?string $errcontext = null
 ) {}
 
 /**
@@ -373,7 +373,7 @@ function newrelic_record_custom_event(string $name, array $attributes): void {}
  *
  * @return bool Will return true if the application name was successfully changed.
  */
-function newrelic_set_appname(string $name, string $license, bool $xmit = false): bool {}
+function newrelic_set_appname(string $name, string $license = "", bool $xmit = false): bool {}
 
 /**
  * Create user-related custom attributes. newrelic_add_custom_parameter is more flexible.
@@ -439,7 +439,7 @@ function newrelic_set_user_id(string $user_id): bool {}
  *
  * @return bool
  */
-function newrelic_start_transaction(string $appname, string $license = null): bool {}
+function newrelic_start_transaction(string $appname, ?string $license = null): bool {}
 
 /**
  * Records a datastore segment.

--- a/odbc/odbc.php
+++ b/odbc/odbc.php
@@ -135,7 +135,14 @@ function odbc_commit($odbc): bool {}
  * </p>
  * @return Odbc\Connection|resource|false an ODBC connection or (<b>FALSE</b>) on error.
  */
-function odbc_connect(string $dsn, string $user, string $password, int $cursor_option = SQL_CUR_USE_DRIVER) {}
+function odbc_connect(
+    string $dsn,
+    #[PhpStormStubsElementAvailable(from: '5.3', to: '8.3')] string $user,
+    #[PhpStormStubsElementAvailable(from: '8.4')] ?string $user = null,
+    #[PhpStormStubsElementAvailable(from: '5.3', to: '8.3')] string $password,
+    #[PhpStormStubsElementAvailable(from: '8.4')] ?string $password = null,
+    int $cursor_option = SQL_CUR_USE_DRIVER
+) {}
 
 /**
  * Get cursorname
@@ -477,7 +484,14 @@ function odbc_num_rows($statement): int {}
  * @return Odbc\Connection|resource|false an ODBC connection id or 0 (<b>FALSE</b>) on
  * error.
  */
-function odbc_pconnect(string $dsn, string $user, string $password, int $cursor_option = SQL_CUR_USE_DRIVER) {}
+function odbc_pconnect(
+    string $dsn,
+    #[PhpStormStubsElementAvailable(from: '5.3', to: '8.3')] string $user,
+    #[PhpStormStubsElementAvailable(from: '8.4')] ?string $user = null,
+    #[PhpStormStubsElementAvailable(from: '5.3', to: '8.3')] string $password,
+    #[PhpStormStubsElementAvailable(from: '8.4')] ?string $password = null,
+    int $cursor_option = SQL_CUR_USE_DRIVER
+) {}
 
 /**
  * Prepares a statement for execution

--- a/openssl/openssl.php
+++ b/openssl/openssl.php
@@ -30,7 +30,7 @@ function openssl_pkey_free(#[LanguageLevelTypeAware(["8.0" => "OpenSSLAsymmetric
  * error.
  */
 #[LanguageLevelTypeAware(["8.0" => "OpenSSLAsymmetricKey|false"], default: "resource|false")]
-function openssl_pkey_new(?array $options) {}
+function openssl_pkey_new(?array $options = null) {}
 
 /**
  * Gets an exportable representation of a key into a string
@@ -51,8 +51,8 @@ function openssl_pkey_new(?array $options) {}
 function openssl_pkey_export(
     #[LanguageLevelTypeAware(['8.0' => 'OpenSSLAsymmetricKey|OpenSSLCertificate|array|string'], default: 'resource|array|string')] $key,
     &$output,
-    ?string $passphrase,
-    ?array $options
+    ?string $passphrase = null,
+    ?array $options = null
 ): bool {}
 
 /**
@@ -77,8 +77,8 @@ function openssl_pkey_export(
 function openssl_pkey_export_to_file(
     #[LanguageLevelTypeAware(['8.0' => 'OpenSSLAsymmetricKey|OpenSSLCertificate|array|string'], default: 'resource|array|string')] $key,
     string $output_filename,
-    ?string $passphrase,
-    ?array $options
+    ?string $passphrase = null,
+    ?array $options = null
 ): bool {}
 
 /**
@@ -176,7 +176,7 @@ function openssl_free_key(#[LanguageLevelTypeAware(["8.0" => "OpenSSLAsymmetricK
 #[LanguageLevelTypeAware(["8.0" => "OpenSSLAsymmetricKey|false"], default: "resource|false")]
 function openssl_get_privatekey(
     #[LanguageLevelTypeAware(['8.0' => 'OpenSSLAsymmetricKey|OpenSSLCertificate|array|string'], default: 'resource|array|string')] $private_key,
-    ?string $passphrase
+    ?string $passphrase = null
 ) {}
 
 /**
@@ -368,9 +368,9 @@ function openssl_x509_parse(
 function openssl_x509_checkpurpose(
     #[LanguageLevelTypeAware(["8.0" => "OpenSSLCertificate|string"], default: "resource|string")] $certificate,
     int $purpose,
-    #[PhpStormStubsElementAvailable(from: '5.3', to: '7.0')] array $ca_info,
+    #[PhpStormStubsElementAvailable(from: '5.3', to: '7.0')] array $ca_info = [],
     #[PhpStormStubsElementAvailable(from: '7.1')] array $ca_info = [],
-    ?string $untrusted_certificates_file
+    ?string $untrusted_certificates_file = null
 ): int|bool {}
 
 /**
@@ -449,7 +449,7 @@ function openssl_pkcs12_export(
     &$output,
     #[LanguageLevelTypeAware(['8.0' => 'OpenSSLAsymmetricKey|OpenSSLCertificate|array|string'], default: 'resource|array|string')] $private_key,
     string $passphrase,
-    #[PhpStormStubsElementAvailable(from: '5.3', to: '7.0')] $args,
+    #[PhpStormStubsElementAvailable(from: '5.3', to: '7.0')] $args = [],
     #[PhpStormStubsElementAvailable(from: '7.1')] array $options = []
 ): bool {}
 
@@ -587,8 +587,8 @@ function openssl_pkcs12_read(string $pkcs12, &$certificates, string $passphrase)
 function openssl_csr_new(
     array $distinguished_names,
     #[LanguageLevelTypeAware(['8.0' => 'OpenSSLAsymmetricKey'], default: 'resource')] &$private_key,
-    ?array $options,
-    ?array $extra_attributes
+    ?array $options = null,
+    ?array $extra_attributes = null
 ) {}
 
 /**
@@ -652,7 +652,7 @@ function openssl_csr_sign(
     #[LanguageLevelTypeAware(["8.0" => "OpenSSLCertificate|string|null"], default: "resource|string|null")] $ca_certificate,
     #[LanguageLevelTypeAware(["8.0" => "OpenSSLAsymmetricKey|OpenSSLCertificate|array|string"], default: "resource|array|string")] $private_key,
     int $days,
-    ?array $options,
+    ?array $options = null,
     int $serial = 0,
     #[PhpStormStubsElementAvailable(from: '8.4')] ?string $serial_hex = null
 ) {}
@@ -730,7 +730,7 @@ function openssl_encrypt(
     string $passphrase,
     int $options = 0,
     string $iv = "",
-    #[PhpStormStubsElementAvailable(from: '7.1')] &$tag,
+    #[PhpStormStubsElementAvailable(from: '7.1')] &$tag = null,
     #[PhpStormStubsElementAvailable(from: '7.1')] string $aad = "",
     #[PhpStormStubsElementAvailable(from: '7.1')] int $tag_length = 16
 ): string|false {}
@@ -878,7 +878,7 @@ function openssl_open(
     #[LanguageLevelTypeAware(['8.0' => 'OpenSSLAsymmetricKey|OpenSSLCertificate|array|string'], default: 'resource|array|string')] $private_key,
     #[PhpStormStubsElementAvailable(from: '7.0', to: '7.4')] string $cipher_algo = '',
     #[PhpStormStubsElementAvailable(from: '8.0')] string $cipher_algo,
-    #[PhpStormStubsElementAvailable(from: '7.0')] ?string $iv
+    #[PhpStormStubsElementAvailable(from: '7.0')] ?string $iv = null
 ): bool {}
 
 /**
@@ -933,11 +933,11 @@ function openssl_pbkdf2(string $password, string $salt, int $key_length, int $it
 function openssl_pkcs7_verify(
     string $input_filename,
     int $flags,
-    ?string $signers_certificates_filename,
+    ?string $signers_certificates_filename = null,
     array $ca_info = [],
-    ?string $untrusted_certificates_filename,
-    ?string $content,
-    #[PhpStormStubsElementAvailable("7.2")] ?string $output_filename
+    ?string $untrusted_certificates_filename = null,
+    ?string $content = null,
+    #[PhpStormStubsElementAvailable("7.2")] ?string $output_filename = null
 ): int|bool {}
 
 /**
@@ -956,7 +956,7 @@ function openssl_pkcs7_decrypt(
     string $input_filename,
     string $output_filename,
     $certificate,
-    #[LanguageLevelTypeAware(['8.0' => 'OpenSSLAsymmetricKey|OpenSSLCertificate|array|string|null'], default: 'resource|array|string|null')] $private_key
+    #[LanguageLevelTypeAware(['8.0' => 'OpenSSLAsymmetricKey|OpenSSLCertificate|array|string|null'], default: 'resource|array|string|null')] $private_key = null
 ): bool {}
 
 /**
@@ -989,7 +989,7 @@ function openssl_pkcs7_sign(
     #[LanguageLevelTypeAware(['8.0' => 'OpenSSLAsymmetricKey|OpenSSLCertificate|array|string'], default: 'resource|array|string')] $private_key,
     ?array $headers,
     int $flags = PKCS7_DETACHED,
-    ?string $untrusted_certificates_filename
+    ?string $untrusted_certificates_filename = null
 ): bool {}
 
 /**
@@ -1190,7 +1190,7 @@ function openssl_pkey_derive(
  * @return string|false the generated string of bytes on success, or false on failure.
  */
 #[LanguageLevelTypeAware(["7.4" => "string"], default: "string|false")]
-function openssl_random_pseudo_bytes(int $length, &$strong_result) {}
+function openssl_random_pseudo_bytes(int $length, &$strong_result = null) {}
 
 /**
  * Return openSSL error message
@@ -1242,7 +1242,7 @@ function openssl_pkcs7_read(string $data, &$certificates): bool {}
  * @return bool
  * @since 8.0
  */
-function openssl_cms_verify(string $input_filename, int $flags = 0, ?string $certificates, array $ca_info = [], ?string $untrusted_certificates_filename, ?string $content, ?string $pk7, ?string $sigfile, int $encoding = OPENSSL_ENCODING_SMIME): bool {}
+function openssl_cms_verify(string $input_filename, int $flags = 0, ?string $certificates = null, array $ca_info = [], ?string $untrusted_certificates_filename = null, ?string $content = null, ?string $pk7 = null, ?string $sigfile = null, int $encoding = OPENSSL_ENCODING_SMIME): bool {}
 
 /**
  * Encrypts the message in the file with the certificates and outputs the result to the supplied file.
@@ -1271,7 +1271,7 @@ function openssl_cms_encrypt(string $input_filename, string $output_filename, $c
  * @return bool
  * @since 8.0
  */
-function openssl_cms_sign(string $input_filename, string $output_filename, OpenSSLCertificate|string $certificate, $private_key, ?array $headers, int $flags = 0, int $encoding = OPENSSL_ENCODING_SMIME, ?string $untrusted_certificates_filename): bool {}
+function openssl_cms_sign(string $input_filename, string $output_filename, OpenSSLCertificate|string $certificate, $private_key, ?array $headers, int $flags = 0, int $encoding = OPENSSL_ENCODING_SMIME, ?string $untrusted_certificates_filename = null): bool {}
 
 /**
  * Decrypts the S/MIME message in the file and outputs the results to the supplied file.

--- a/parallel/parallel.php
+++ b/parallel/parallel.php
@@ -35,7 +35,7 @@ function bootstrap(string $file): void {}
  * @throws Runtime\Error\IllegalParameter if task accepts or argv contains illegal variables.
  * @throws Runtime\Error\IllegalReturn if task returns illegally.
  */
-function run(Closure $task, array $argv = null): ?Future {}
+function run(Closure $task, ?array $argv = null): ?Future {}
 
 #ifdef ZEND_DEBUG
 /**

--- a/parallel/parallel/Sync.php
+++ b/parallel/parallel/Sync.php
@@ -53,7 +53,7 @@ final class Sync
      *
      * @return bool
      */
-    public function notify(bool $all = null): bool {}
+    public function notify(?bool $all = null): bool {}
 
     /**
      * Shall exclusively enter into the critical code

--- a/pcntl/pcntl.php
+++ b/pcntl/pcntl.php
@@ -348,7 +348,7 @@ function pcntl_strerror(int $error_code): false|string {}
  * scheduling.
  */
 #[Pure]
-function pcntl_getpriority(?int $process_id, int $mode = PRIO_PROCESS): int|false {}
+function pcntl_getpriority(?int $process_id = null, int $mode = PRIO_PROCESS): int|false {}
 
 /**
  * Change the priority of any process
@@ -370,7 +370,7 @@ function pcntl_getpriority(?int $process_id, int $mode = PRIO_PROCESS): int|fals
  * </p>
  * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
  */
-function pcntl_setpriority(int $priority, ?int $process_id, int $mode = PRIO_PROCESS): bool {}
+function pcntl_setpriority(int $priority, ?int $process_id = null, int $mode = PRIO_PROCESS): bool {}
 
 /**
  * Sets and retrieves blocked signals
@@ -394,7 +394,7 @@ function pcntl_setpriority(int $priority, ?int $process_id, int $mode = PRIO_PRO
  * </p>
  * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
  */
-function pcntl_sigprocmask(int $mode, array $signals, &$old_signals): bool {}
+function pcntl_sigprocmask(int $mode, array $signals, &$old_signals = null): bool {}
 
 /**
  * Waits for signals
@@ -471,7 +471,7 @@ function pcntl_sigtimedwait(array $signals, &$info = [], int $seconds = 0, int $
  * @since 7.1
  */
 function pcntl_async_signals(
-    #[PhpStormStubsElementAvailable(from: '5.3', to: '7.4')] ?bool $enable,
+    #[PhpStormStubsElementAvailable(from: '5.3', to: '7.4')] ?bool $enable = null,
     #[PhpStormStubsElementAvailable(from: '8.0')] ?bool $enable = null
 ): bool {}
 

--- a/pcre/pcre.php
+++ b/pcre/pcre.php
@@ -157,7 +157,7 @@ use JetBrains\PhpStorm\Pure;
  * matches given <i>subject</i>, 0 if it does not, or <b>FALSE</b>
  * if an error occurred.
  */
-function preg_match(string $pattern, string $subject, &$matches, int $flags = 0, int $offset = 0): int|false {}
+function preg_match(string $pattern, string $subject, &$matches = null, int $flags = 0, int $offset = 0): int|false {}
 
 /**
  * Perform a global regular expression match
@@ -216,7 +216,7 @@ function preg_match(string $pattern, string $subject, &$matches, int $flags = 0,
  * or <b>FALSE</b> if an error occurred.
  */
 #[LanguageLevelTypeAware(['8.0' => 'int|false'], default: 'int|false|null')]
-function preg_match_all(string $pattern, string $subject, &$matches, int $flags = 0, int $offset = 0) {}
+function preg_match_all(string $pattern, string $subject, &$matches = null, int $flags = 0, int $offset = 0) {}
 
 /**
  * Perform a regular expression search and replace
@@ -304,7 +304,7 @@ function preg_match_all(string $pattern, string $subject, &$matches, int $flags 
  * be returned, otherwise <i>subject</i> will be
  * returned unchanged or <b>NULL</b> if an error occurred.
  */
-function preg_replace(array|string $pattern, array|string $replacement, array|string $subject, int $limit = -1, &$count): array|string|null {}
+function preg_replace(array|string $pattern, array|string $replacement, array|string $subject, int $limit = -1, &$count = null): array|string|null {}
 
 /**
  * Perform a regular expression search and replace using a callback
@@ -380,7 +380,7 @@ function preg_replace_callback(
     callable $callback,
     array|string $subject,
     int $limit = -1,
-    &$count,
+    &$count = null,
     #[PhpStormStubsElementAvailable(from: '7.4')] int $flags = 0
 ): array|string|null {}
 
@@ -399,7 +399,7 @@ function preg_replace_callback_array(
     array $pattern,
     array|string $subject,
     int $limit = -1,
-    &$count,
+    &$count = null,
     #[PhpStormStubsElementAvailable(from: '7.4')] int $flags = 0
 ): array|string|null {}
 
@@ -419,7 +419,7 @@ function preg_replace_callback_array(
  * is returned when <i>subject</i> is an array
  * or <b>NULL</b> otherwise.
  */
-function preg_filter(array|string $pattern, array|string $replacement, array|string $subject, int $limit = -1, &$count): array|string|null {}
+function preg_filter(array|string $pattern, array|string $replacement, array|string $subject, int $limit = -1, &$count = null): array|string|null {}
 
 /**
  * Split string by a regular expression

--- a/pgsql/pgsql.php
+++ b/pgsql/pgsql.php
@@ -277,7 +277,7 @@ function pg_ping(#[LanguageLevelTypeAware(['8.1' => 'PgSql\Connection|null'], de
  * @return string|false A string containing the value of the parameter, <b>FALSE</b> on failure or invalid
  * <i>param_name</i>.
  */
-function pg_parameter_status(#[LanguageLevelTypeAware(['8.1' => 'PgSql\Connection'], default: 'resource')] $connection, string $name): string|false {}
+function pg_parameter_status(#[LanguageLevelTypeAware(['8.1' => 'PgSql\Connection'], default: 'resource')] $connection = null, string $name): string|false {}
 
 /**
  * Returns the current in-transaction status of the server.
@@ -1137,7 +1137,7 @@ function pg_last_notice(#[LanguageLevelTypeAware(['8.1' => 'PgSql\Connection'], 
  */
 function pg_put_line(
     #[PhpStormStubsElementAvailable(from: '5.3', to: '7.4')] $connection = null,
-    #[PhpStormStubsElementAvailable(from: '8.0')] #[LanguageLevelTypeAware(['8.1' => 'PgSql\Connection'], default: 'resource')] $connection,
+    #[PhpStormStubsElementAvailable(from: '8.0')] #[LanguageLevelTypeAware(['8.1' => 'PgSql\Connection'], default: 'resource')] $connection = null,
     string $query
 ): bool {}
 
@@ -1486,7 +1486,7 @@ function pg_lo_truncate(
  */
 function pg_escape_string(
     #[PhpStormStubsElementAvailable(from: '5.3', to: '7.4')] $connection = null,
-    #[PhpStormStubsElementAvailable(from: '8.0')] #[LanguageLevelTypeAware(['8.1' => 'PgSql\Connection'], default: 'resource')] $connection,
+    #[PhpStormStubsElementAvailable(from: '8.0')] #[LanguageLevelTypeAware(['8.1' => 'PgSql\Connection'], default: 'resource')] $connection = null,
     string $string
 ): string {}
 
@@ -1507,7 +1507,7 @@ function pg_escape_string(
  */
 function pg_escape_bytea(
     #[PhpStormStubsElementAvailable(from: '5.3', to: '7.4')] $connection = null,
-    #[PhpStormStubsElementAvailable(from: '8.0')] #[LanguageLevelTypeAware(['8.1' => 'PgSql\Connection'], default: 'resource')] $connection,
+    #[PhpStormStubsElementAvailable(from: '8.0')] #[LanguageLevelTypeAware(['8.1' => 'PgSql\Connection'], default: 'resource')] $connection = null,
     string $string
 ): string {}
 
@@ -1528,7 +1528,7 @@ function pg_escape_bytea(
  */
 function pg_escape_identifier(
     #[PhpStormStubsElementAvailable(from: '5.4', to: '7.4')] $connection = null,
-    #[PhpStormStubsElementAvailable(from: '8.0')] #[LanguageLevelTypeAware(['8.1' => 'PgSql\Connection'], default: 'resource')] $connection,
+    #[PhpStormStubsElementAvailable(from: '8.0')] #[LanguageLevelTypeAware(['8.1' => 'PgSql\Connection'], default: 'resource')] $connection = null,
     string $string
 ): string|false {}
 
@@ -1549,7 +1549,7 @@ function pg_escape_identifier(
  */
 function pg_escape_literal(
     #[PhpStormStubsElementAvailable(from: '5.4', to: '7.4')] $connection = null,
-    #[PhpStormStubsElementAvailable(from: '8.0')] #[LanguageLevelTypeAware(['8.1' => 'PgSql\Connection'], default: 'resource')] $connection,
+    #[PhpStormStubsElementAvailable(from: '8.0')] #[LanguageLevelTypeAware(['8.1' => 'PgSql\Connection'], default: 'resource')] $connection = null,
     string $string
 ): string|false {}
 
@@ -1626,7 +1626,7 @@ function pg_client_encoding(#[LanguageLevelTypeAware(['8.1' => 'PgSql\Connection
  */
 function pg_set_client_encoding(
     #[PhpStormStubsElementAvailable(from: '5.3', to: '7.4')] $connection = null,
-    #[PhpStormStubsElementAvailable(from: '8.0')] #[LanguageLevelTypeAware(['8.1' => 'PgSql\Connection'], default: 'resource')] $connection,
+    #[PhpStormStubsElementAvailable(from: '8.0')] #[LanguageLevelTypeAware(['8.1' => 'PgSql\Connection'], default: 'resource')] $connection = null,
     string $encoding
 ): int {}
 

--- a/pq/pq.php
+++ b/pq/pq.php
@@ -76,7 +76,7 @@ class COPY
      * @throws \pq\Exception\BadMethodCallException
      * @throws \pq\Exception\RuntimeException
      */
-    public function __construct(Connection $conn, string $expression, int $direction, string $options = null) {}
+    public function __construct(Connection $conn, string $expression, int $direction, ?string $options = null) {}
 
     /**
      * End the COPY operation to the server during pq\Result::COPY_IN state.
@@ -86,7 +86,7 @@ class COPY
      * @throws \pq\Exception\BadMethodCallException
      * @throws \pq\Exception\RuntimeException
      */
-    public function end(string $error = null) {}
+    public function end(?string $error = null) {}
 
     /**
      * Receive data from the server during pq\Result::COPY_OUT state.
@@ -517,7 +517,7 @@ class Connection
      * @throws \pq\Exception\BadMethodCallException
      * @throws \pq\Exception\RuntimeException
      */
-    public function execAsync(string $query, callable $callback = null) {}
+    public function execAsync(string $query, ?callable $callback = null) {}
 
     /**
      * [Execute an SQL query](pq/Connection: Executing Queries) with properly escaped parameters substituted.
@@ -530,7 +530,7 @@ class Connection
      * @throws \pq\Exception\DomainException
      * @return \pq\Result
      */
-    public function execParams(string $query, array $params, array $types = null) {}
+    public function execParams(string $query, array $params, ?array $types = null) {}
 
     /**
      * [Asynchronously](pq/Connection/: Asynchronous Usage) [execute an SQL query](pq/Connection: Executing Queries) with properly escaped parameters substituted.
@@ -547,7 +547,7 @@ class Connection
      * @throws \pq\Exception\RuntimeException
      * @throws \pq\Exception\BadMethodCallException
      */
-    public function execParamsAsync(string $query, array $params, array $types = null, callable $cb = null) {}
+    public function execParamsAsync(string $query, array $params, ?array $types = null, ?callable $cb = null) {}
 
     /**
      * Flush pending writes on the connection.
@@ -671,7 +671,7 @@ class Connection
      * @throws \pq\Exception\RuntimeException
      * @return \pq\Statement a prepared statement instance.
      */
-    public function prepare(string $name, string $query, array $types = null) {}
+    public function prepare(string $name, string $query, ?array $types = null) {}
 
     /**
      * [Asynchronously](pq/Connection/: Asynchronous Usage) prepare a named statement for later execution with pq\Statement::exec().
@@ -687,7 +687,7 @@ class Connection
      * @throws \pq\Exception\RuntimeException
      * @return \pq\Statement a prepared statement instance.
      */
-    public function prepareAsync(string $name, string $query, array $types = null) {}
+    public function prepareAsync(string $name, string $query, ?array $types = null) {}
 
     /**
      * Quote a string for safe use in a query.
@@ -982,7 +982,7 @@ class Cursor
      * @throws \pq\Exception\BadMethodCallException
      * @throws \pq\Exception\RuntimeException
      */
-    public function fetchAsync(string $spec = "1", callable $callback = null) {}
+    public function fetchAsync(string $spec = "1", ?callable $callback = null) {}
 
     /**
      * Move the cursor.
@@ -1011,7 +1011,7 @@ class Cursor
      * @throws \pq\Exception\BadMethodCallException
      * @throws \pq\Exception\RuntimeException
      */
-    public function moveAsync(string $spec = "1", callable $callback = null) {}
+    public function moveAsync(string $spec = "1", ?callable $callback = null) {}
 
     /**
      * Reopen a cursor.
@@ -1456,7 +1456,7 @@ class Result implements \Traversable, \Countable
      * @throws \pq\Exception\BadMethodCallException
      * @return array all fetched rows.
      */
-    public function fetchAll(int $fetch_type = null) {}
+    public function fetchAll(?int $fetch_type = null) {}
 
     /**
      * Fetch all rows of a single column.
@@ -1506,7 +1506,7 @@ class Result implements \Traversable, \Countable
      * 		 or object stdClass instance for pq\Result::FETCH_OBJECT
      * 		 or NULL when iteration ends.
      */
-    public function fetchRow(int $fetch_type = null) {}
+    public function fetchRow(?int $fetch_type = null) {}
 
     /**
      * Fetch the complete result set as a simple map, a *multi dimensional array*, each dimension indexed by a column.
@@ -1519,7 +1519,7 @@ class Result implements \Traversable, \Countable
      * @throws \pq\Exception\RuntimeException
      * @return array|object the mapped columns.
      */
-    public function map($keys = 0, $vals = null, int $fetch_type = null) {}
+    public function map($keys = 0, $vals = null, ?int $fetch_type = null) {}
 }
 /**
  * A named prepared statement.
@@ -1577,7 +1577,7 @@ class Statement
      * @throws \pq\Exception\RuntimeException
      * @throws \pq\Exception\DomainException
      */
-    public function __construct(Connection $conn, string $name, string $query, array $types = null, bool $async = false) {}
+    public function __construct(Connection $conn, string $name, string $query, ?array $types = null, bool $async = false) {}
 
     /**
      * Bind a variable to an input parameter.
@@ -1641,7 +1641,7 @@ class Statement
      * @throws \pq\Exception\RuntimeException
      * @return \pq\Result the result of the execution of the prepared statement.
      */
-    public function exec(array $params = null) {}
+    public function exec(?array $params = null) {}
 
     /**
      * [Asynchronously](pq/Connection/: Asynchronous Usage) execute the prepared statement.
@@ -1654,7 +1654,7 @@ class Statement
      * @throws \pq\Exception\BadMethodCallException
      * @throws \pq\Exception\RuntimeException
      */
-    public function execAsync(array $params = null, callable $cb = null) {}
+    public function execAsync(?array $params = null, ?callable $cb = null) {}
 
     /**
      * Re-prepare a statement that has been deallocated. This is a no-op on already open statements.
@@ -2706,7 +2706,7 @@ class Types implements \ArrayAccess
      * @throws \pq\Exception\BadMethodCallException
      * @throws \pq\Exception\RuntimeException
      */
-    public function __construct(Connection $conn, array $namespaces = null) {}
+    public function __construct(Connection $conn, ?array $namespaces = null) {}
 
     /**
      * Refresh type information from `pg_type`.
@@ -2716,7 +2716,7 @@ class Types implements \ArrayAccess
      * @throws \pq\Exception\BadMethodCallException
      * @throws \pq\Exception\RuntimeException
      */
-    public function refresh(array $namespaces = null) {}
+    public function refresh(?array $namespaces = null) {}
 }
 
 namespace pq\Exception;

--- a/readline/readline.php
+++ b/readline/readline.php
@@ -13,7 +13,7 @@ use JetBrains\PhpStorm\Internal\LanguageLevelTypeAware;
  * @return string|false a single string from the user. The line returned has the ending newline removed.
  * If there is no more data to read, then FALSE is returned.
  */
-function readline(?string $prompt): string|false {}
+function readline(?string $prompt = null): string|false {}
 
 /**
  * Gets/sets various internal readline variables
@@ -49,7 +49,7 @@ function readline(?string $prompt): string|false {}
     'readline_name' => 'string',
     'attempted_completion_over' => 'int',
 ])]
-function readline_info(?string $var_name, $value): mixed {}
+function readline_info(?string $var_name = null, $value = null): mixed {}
 
 /**
  * Adds a line to the history
@@ -86,7 +86,7 @@ function readline_list_history(): array {}
  * </p>
  * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
  */
-function readline_read_history(?string $filename): bool {}
+function readline_read_history(?string $filename = null): bool {}
 
 /**
  * Writes the history
@@ -96,7 +96,7 @@ function readline_read_history(?string $filename): bool {}
  * </p>
  * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
  */
-function readline_write_history(?string $filename): bool {}
+function readline_write_history(?string $filename = null): bool {}
 
 /**
  * Registers a completion function

--- a/redis/RedisSentinel.php
+++ b/redis/RedisSentinel.php
@@ -77,7 +77,7 @@ class RedisSentinel
      *
      * @since >= 6.0.0
      */
-    public function __construct(array $options) {}
+    public function __construct(?array $options = null) {}
 
     /**
      * Check if the current Sentinel configuration is able to reach the quorum needed to failover a master, and the

--- a/relay/Cluster.php
+++ b/relay/Cluster.php
@@ -284,7 +284,7 @@ class Cluster
      * @return Cluster|int|false
      */
     #[Attributes\RedisCommand, Attributes\ValkeyCommand]
-    public function bitpos(mixed $key, int $bit, int $start = null, int $end = null, bool $by_bit = false): Cluster|int|false {}
+    public function bitpos(mixed $key, int $bit, ?int $start = null, ?int $end = null, bool $by_bit = false): Cluster|int|false {}
 
     /**
      * BLMOVE is the blocking variant of LMOVE. When source contains elements,
@@ -657,7 +657,7 @@ class Cluster
      * @return bool
      */
     #[Attributes\Local]
-    public static function flushMemory(?string $endpointId = null, int $db = null): bool {}
+    public static function flushMemory(?string $endpointId = null, ?int $db = null): bool {}
 
     /**
      * Deletes all the keys of all the existing databases, not just the currently selected one.
@@ -1286,7 +1286,7 @@ class Cluster
      * @return float|false
      */
     #[Attributes\Local]
-    public static function lastMemoryFlush(?string $endpointId = null, int $db = null): float|false {}
+    public static function lastMemoryFlush(?string $endpointId = null, ?int $db = null): float|false {}
 
     /**
      * Returns the UNIX time stamp of the last successful save to disk.
@@ -2482,7 +2482,7 @@ class Cluster
      * @return mixed
      */
     #[Attributes\RedisCommand, Attributes\ValkeyCommand]
-    public function xgroup(string $operation, mixed $key = null, string $group = null, string $id_or_consumer = null, bool $mkstream = false, int $entries_read = -2): mixed {}
+    public function xgroup(string $operation, mixed $key = null, ?string $group = null, ?string $id_or_consumer = null, bool $mkstream = false, int $entries_read = -2): mixed {}
 
     /**
      * Retrieve information about a stream key.

--- a/relay/Relay.php
+++ b/relay/Relay.php
@@ -1024,7 +1024,7 @@ class Relay
      * @return mixed
      */
     #[Attributes\RedisCommand, Attributes\ValkeyCommand]
-    public function fcall_ro(string $name, array $keys = [], array $argv = [], callable $handler = null): mixed {}
+    public function fcall_ro(string $name, array $keys = [], array $argv = [], ?callable $handler = null): mixed {}
 
     /**
      * Calls `FUNCTION` sub-command.
@@ -1047,7 +1047,7 @@ class Relay
      * @return bool
      */
     #[Attributes\Local]
-    public static function flushMemory(?string $endpointId = null, int $db = null): bool {}
+    public static function flushMemory(?string $endpointId = null, ?int $db = null): bool {}
 
     /**
      * Retrieve the timestamp of the last *user initiated* flush of the in-memory cache.
@@ -1062,7 +1062,7 @@ class Relay
      * @return float|false
      */
     #[Attributes\Local]
-    public static function lastMemoryFlush(?string $endpointId = null, int $db = null): float|false {}
+    public static function lastMemoryFlush(?string $endpointId = null, ?int $db = null): float|false {}
 
     /**
      * Run a search query on an index, and perform aggregate
@@ -1392,7 +1392,7 @@ class Relay
      * @return Relay|bool|string
      */
     #[Attributes\RedisCommand, Attributes\ValkeyCommand]
-    public function ping(string $arg = null): Relay|bool|string {}
+    public function ping(?string $arg = null): Relay|bool|string {}
 
     /**
      * Returns the number of milliseoconds since Relay has seen activity from the server.
@@ -1828,7 +1828,7 @@ class Relay
      * @return Relay|int|false
      */
     #[Attributes\RedisCommand, Attributes\ValkeyCommand]
-    public function bitpos(mixed $key, int $bit, int $start = null, int $end = null, bool $bybit = false): Relay|int|false {}
+    public function bitpos(mixed $key, int $bit, ?int $start = null, ?int $end = null, bool $bybit = false): Relay|int|false {}
 
     /**
      * Sets or clears the bit at offset in the string value stored at key.
@@ -3772,8 +3772,8 @@ class Relay
     public function xgroup(
         string $operation,
         mixed $key = null,
-        string $group = null,
-        string $id_or_consumer = null,
+        ?string $group = null,
+        ?string $id_or_consumer = null,
         bool $mkstream = false,
         int $entries_read = -2
     ): mixed {}

--- a/session/session.php
+++ b/session/session.php
@@ -27,7 +27,7 @@ use JetBrains\PhpStorm\Internal\PhpStormStubsElementAvailable;
  * @return string|false the name of the current session.
  */
 #[LanguageLevelTypeAware(['8.0' => 'string|false'], default: 'string')]
-function session_name(#[LanguageLevelTypeAware(['8.0' => 'null|string'], default: 'string')] $name) {}
+function session_name(#[LanguageLevelTypeAware(['8.0' => 'null|string'], default: 'string')] $name = null) {}
 
 /**
  * Get and/or set the current session module.<br/>
@@ -40,7 +40,7 @@ function session_name(#[LanguageLevelTypeAware(['8.0' => 'null|string'], default
  * @return string|false the name of the current session module.
  */
 #[LanguageLevelTypeAware(['8.0' => 'string|false'], default: 'string')]
-function session_module_name(#[LanguageLevelTypeAware(['8.0' => 'null|string'], default: 'string')] $module) {}
+function session_module_name(#[LanguageLevelTypeAware(['8.0' => 'null|string'], default: 'string')] $module = null) {}
 
 /**
  * Get and/or set the current session save path
@@ -60,7 +60,7 @@ function session_module_name(#[LanguageLevelTypeAware(['8.0' => 'null|string'], 
  * @return string|false the path of the current directory used for data storage.
  */
 #[LanguageLevelTypeAware(['8.0' => 'string|false'], default: 'string')]
-function session_save_path(#[LanguageLevelTypeAware(['8.0' => 'null|string'], default: 'string')] $path) {}
+function session_save_path(#[LanguageLevelTypeAware(['8.0' => 'null|string'], default: 'string')] $path = null) {}
 
 /**
  * Get and/or set the current session id
@@ -82,7 +82,7 @@ function session_save_path(#[LanguageLevelTypeAware(['8.0' => 'null|string'], de
  * session (no current session id exists).
  */
 #[LanguageLevelTypeAware(['8.0' => 'string|false'], default: 'string')]
-function session_id(#[LanguageLevelTypeAware(['8.0' => 'null|string'], default: 'string')] $id) {}
+function session_id(#[LanguageLevelTypeAware(['8.0' => 'null|string'], default: 'string')] $id = null) {}
 
 /**
  * Update the current session id with a newly generated one
@@ -324,7 +324,7 @@ function session_set_save_handler(SessionHandlerInterface $sessionhandler, bool 
  * @return string|false the name of the current cache limiter.
  */
 #[LanguageLevelTypeAware(["8.0" => "string|false"], default: "string")]
-function session_cache_limiter(#[LanguageLevelTypeAware(['8.0' => 'null|string'], default: 'string')] $value) {}
+function session_cache_limiter(#[LanguageLevelTypeAware(['8.0' => 'null|string'], default: 'string')] $value = null) {}
 
 /**
  * Return current cache expire
@@ -342,7 +342,7 @@ function session_cache_limiter(#[LanguageLevelTypeAware(['8.0' => 'null|string']
  * The value returned should be read in minutes, defaults to 180.
  */
 #[LanguageLevelTypeAware(["8.0" => "int|false"], default: "int")]
-function session_cache_expire(#[LanguageLevelTypeAware(['8.0' => 'null|int'], default: 'int')] $value) {}
+function session_cache_expire(#[LanguageLevelTypeAware(['8.0' => 'null|int'], default: 'int')] $value = null) {}
 
 /**
  * Set the session cookie parameters

--- a/snmp/snmp.php
+++ b/snmp/snmp.php
@@ -146,7 +146,7 @@ class SNMP
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      * @since 5.4
      */
-    public function setSecurity($sec_level, $auth_protocol, $auth_passphrase, $priv_protocol, $priv_passphrase, $contextName, $contextEngineID) {}
+    public function setSecurity($sec_level, $auth_protocol = "", $auth_passphrase = "", $priv_protocol = "", $priv_passphrase = "", $contextName = "", $contextEngineID = "") {}
 
     /**
      * Fetch an SNMP object

--- a/soap/soap.php
+++ b/soap/soap.php
@@ -450,7 +450,7 @@ class SoapClient
     #[TentativeType]
     public function __setCookie(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name,
-        #[LanguageLevelTypeAware(["8.0" => "string|null"], default: "string")] $value
+        #[LanguageLevelTypeAware(["8.0" => "string|null"], default: "string")] $value = null
     ): void {}
 
     /**
@@ -478,7 +478,7 @@ class SoapClient
      */
     #[TentativeType]
     public function __setSoapHeaders(
-        #[PhpStormStubsElementAvailable(from: '5.3', to: '5.6')] $headers,
+        #[PhpStormStubsElementAvailable(from: '5.3', to: '5.6')] $headers = null,
         #[PhpStormStubsElementAvailable(from: '7.0')] $headers = null
     ): bool {}
 }
@@ -551,7 +551,7 @@ class SoapVar
     public function __construct(
         #[LanguageLevelTypeAware(["8.0" => 'mixed'], default: '')] $data,
         #[LanguageLevelTypeAware(["7.1" => "int|null"], default: "int")] $encoding,
-        #[LanguageLevelTypeAware(["8.0" => "string|null"], default: "string")] $typeName,
+        #[LanguageLevelTypeAware(["8.0" => "string|null"], default: "string")] $typeName = null,
         #[LanguageLevelTypeAware(["8.0" => 'string|null'], default: '')] $typeNamespace = null,
         #[LanguageLevelTypeAware(["8.0" => 'string|null'], default: '')] $nodeName = null,
         #[LanguageLevelTypeAware(["8.0" => 'string|null'], default: '')] $nodeNamespace = null

--- a/sockets/sockets.php
+++ b/sockets/sockets.php
@@ -20,7 +20,7 @@ use JetBrains\PhpStorm\Internal\PhpStormStubsElementAvailable;
  * @return AddressInfo[]|false of AddrInfo resource handles that can be used with the other socket_addrinfo functions.
  * @since 7.2
  */
-function socket_addrinfo_lookup(string $host, ?string $service, array $hints = []): array|false {}
+function socket_addrinfo_lookup(string $host, ?string $service = null, array $hints = []): array|false {}
 
 /**
  * Create a Socket resource, and connect it to the provided AddrInfo resource.<br/>
@@ -719,7 +719,7 @@ function socket_send(Socket $socket, string $data, int $length, int $flags): int
 function socket_sendmsg(
     Socket $socket,
     array $message,
-    #[PhpStormStubsElementAvailable(from: '5.5', to: '7.4')] int $flags,
+    #[PhpStormStubsElementAvailable(from: '5.5', to: '7.4')] int $flags = 0,
     #[PhpStormStubsElementAvailable(from: '8.0')] int $flags = 0
 ): int|false {}
 
@@ -809,7 +809,7 @@ function socket_recvfrom(Socket $socket, &$data, int $length, int $flags, &$addr
 function socket_recvmsg(
     Socket $socket,
     array &$message,
-    #[PhpStormStubsElementAvailable(from: '5.5', to: '7.4')] int $flags,
+    #[PhpStormStubsElementAvailable(from: '5.5', to: '7.4')] int $flags = 0,
     #[PhpStormStubsElementAvailable(from: '8.0')] int $flags = 0
 ): int|false {}
 

--- a/sqlite3/sqlite3.php
+++ b/sqlite3/sqlite3.php
@@ -78,8 +78,8 @@ class SQLite3
     #[TentativeType]
     public function open(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $filename,
-        #[PhpStormStubsElementAvailable(from: '5.3', to: '5.6')] $flags,
-        #[PhpStormStubsElementAvailable(from: '5.3', to: '5.6')] $encryptionKey,
+        #[PhpStormStubsElementAvailable(from: '5.3', to: '5.6')] $flags = 6,
+        #[PhpStormStubsElementAvailable(from: '5.3', to: '5.6')] $encryptionKey = '',
         #[PhpStormStubsElementAvailable(from: '7.0')] #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $flags = SQLITE3_OPEN_READWRITE|SQLITE3_OPEN_CREATE,
         #[PhpStormStubsElementAvailable(from: '7.0')] #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $encryptionKey = ''
     ): void {}
@@ -343,7 +343,7 @@ class SQLite3
      */
     #[TentativeType]
     public function enableExceptions(
-        #[PhpStormStubsElementAvailable(from: '5.3', to: '5.6')] $enable,
+        #[PhpStormStubsElementAvailable(from: '5.3', to: '5.6')] $enable = false,
         #[PhpStormStubsElementAvailable(from: '7.0')] #[LanguageLevelTypeAware(['8.0' => 'bool'], default: '')] $enable = false
     ): bool {}
 
@@ -368,8 +368,8 @@ class SQLite3
      */
     public function __construct(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $filename,
-        #[PhpStormStubsElementAvailable(from: '5.3', to: '5.6')] $flags,
-        #[PhpStormStubsElementAvailable(from: '5.3', to: '5.6')] $encryptionKey,
+        #[PhpStormStubsElementAvailable(from: '5.3', to: '5.6')] $flags = 6,
+        #[PhpStormStubsElementAvailable(from: '5.3', to: '5.6')] $encryptionKey = '',
         #[PhpStormStubsElementAvailable(from: '7.0')] #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $flags = SQLITE3_OPEN_READWRITE|SQLITE3_OPEN_CREATE,
         #[PhpStormStubsElementAvailable(from: '7.0')] #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $encryptionKey = ''
     ) {}
@@ -387,7 +387,7 @@ class SQLite3
      */
     #[TentativeType]
     public function enableExtendedResultCodes(
-        #[PhpStormStubsElementAvailable(from: '7.4', to: '7.4')] bool $enable,
+        #[PhpStormStubsElementAvailable(from: '7.4', to: '7.4')] bool $enable = true,
         #[PhpStormStubsElementAvailable(from: '8.0')] bool $enable = true
     ): bool {}
 

--- a/standard/standard_0.php
+++ b/standard/standard_0.php
@@ -562,7 +562,7 @@ function htmlentities(string $string, int $flags = ENT_QUOTES|ENT_SUBSTITUTE, ?s
  * @return string the decoded string.
  */
 #[Pure]
-function html_entity_decode(string $string, int $flags = ENT_QUOTES|ENT_SUBSTITUTE, ?string $encoding): string {}
+function html_entity_decode(string $string, int $flags = ENT_QUOTES|ENT_SUBSTITUTE, ?string $encoding = null): string {}
 
 /**
  * Convert special HTML entities back to characters
@@ -947,7 +947,7 @@ function iptcembed(string $iptc_data, string $filename, int $spool = 0): string|
  * </p>
  */
 #[ArrayShape([0 => "int", 1 => "int", 2 => "int", 3 => "string", "bits" => "int", "channels" => "int", "mime" => "string"])]
-function getimagesize(string $filename, &$image_info): array|false {}
+function getimagesize(string $filename, &$image_info = null): array|false {}
 
 /**
  * Get Mime-Type for image-type returned by getimagesize, exif_read_data, exif_thumbnail, exif_imagetype
@@ -1151,7 +1151,7 @@ function phpinfo(#[ExpectedValues(flags: [INFO_GENERAL, INFO_CREDITS, INFO_CONFI
  * the extension isn't enabled.
  */
 #[Pure]
-function phpversion(?string $extension): string|false {}
+function phpversion(?string $extension = null): string|false {}
 
 /**
  * Prints out the credits for PHP
@@ -1359,7 +1359,7 @@ function strnatcasecmp(string $string1, string $string2): int {}
  * @return int<0,max> This functions returns an integer.
  */
 #[Pure]
-function substr_count(string $haystack, string $needle, int $offset = 0, ?int $length): int {}
+function substr_count(string $haystack, string $needle, int $offset = 0, ?int $length = null): int {}
 
 /**
  * Finds the length of the initial segment of a string consisting
@@ -1412,7 +1412,7 @@ function substr_count(string $haystack, string $needle, int $offset = 0, ?int $l
  * which consists entirely of characters in str2.
  */
 #[Pure]
-function strspn(string $string, string $characters, int $offset = 0, ?int $length): int {}
+function strspn(string $string, string $characters, int $offset = 0, ?int $length = null): int {}
 
 /**
  * Find length of initial segment not matching mask
@@ -1432,7 +1432,7 @@ function strspn(string $string, string $characters, int $offset = 0, ?int $lengt
  * @return int the length of the segment as an integer.
  */
 #[Pure]
-function strcspn(string $string, string $characters, int $offset = 0, ?int $length): int {}
+function strcspn(string $string, string $characters, int $offset = 0, ?int $length = null): int {}
 
 /**
  * Tokenize string
@@ -1452,6 +1452,6 @@ function strcspn(string $string, string $characters, int $offset = 0, ?int $leng
  */
 function strtok(
     string $string,
-    #[PhpStormStubsElementAvailable(from: '5.3', to: '7.0')] $token,
+    #[PhpStormStubsElementAvailable(from: '5.3', to: '7.0')] $token = null,
     #[PhpStormStubsElementAvailable(from: '7.1')] ?string $token = null
 ): string|false {}

--- a/standard/standard_1.php
+++ b/standard/standard_1.php
@@ -176,7 +176,7 @@ function hebrev(string $string, int $max_chars_per_line = 0): string {}
  * @removed 8.0
  */
 #[Deprecated(replacement: 'nl2br(hebrev(%parameter0%))', since: '7.4')]
-function hebrevc(string $hebrew_text, $max_chars_per_line): string {}
+function hebrevc(string $hebrew_text, $max_chars_per_line = 0): string {}
 
 /**
  * Inserts HTML line breaks before all newlines in a string
@@ -387,7 +387,7 @@ function str_shuffle(string $string): string {}
  * format chosen.
  */
 #[Pure]
-function str_word_count(string $string, int $format = 0, ?string $characters): array|int {}
+function str_word_count(string $string, int $format = 0, ?string $characters = null): array|int {}
 
 /**
  * Convert a string to an array
@@ -462,7 +462,7 @@ function strpbrk(
  * false.
  */
 #[Pure]
-function substr_compare(string $haystack, string $needle, int $offset, ?int $length, bool $case_insensitive = false): int {}
+function substr_compare(string $haystack, string $needle, int $offset, ?int $length = null, bool $case_insensitive = false): int {}
 
 /**
  * Locale based string comparison
@@ -573,7 +573,7 @@ function money_format(string $format, float $number): ?string {}
  */
 #[Pure]
 #[LanguageLevelTypeAware(["8.0" => "string"], default: "string|false")]
-function substr(string $string, int $offset, ?int $length) {}
+function substr(string $string, int $offset, ?int $length = null) {}
 
 /**
  * Replace text within a portion of a string
@@ -808,7 +808,7 @@ function rtrim(string $string, string $characters = " \n\r\t\v\0"): string {}
  * @param int &$count [optional] If passed, this will hold the number of matched and replaced needles.
  * @return string|string[] This function returns a string or an array with the replaced values.
  */
-function str_replace(array|string $search, array|string $replace, array|string $subject, &$count): array|string {}
+function str_replace(array|string $search, array|string $replace, array|string $subject, &$count = null): array|string {}
 
 /**
  * Case-insensitive version of <function>str_replace</function>.
@@ -832,7 +832,7 @@ function str_replace(array|string $search, array|string $replace, array|string $
  * </p>
  * @return string|string[] a string or an array of replacements.
  */
-function str_ireplace(array|string $search, array|string $replace, array|string $subject, &$count): array|string {}
+function str_ireplace(array|string $search, array|string $replace, array|string $subject, &$count = null): array|string {}
 
 /**
  * Repeat a string
@@ -978,7 +978,7 @@ function strip_tags(string $string, #[LanguageLevelTypeAware(["7.4" => "string[]
  * </p>
  * @return int the number of matching chars in both strings.
  */
-function similar_text(string $string1, string $string2, &$percent): int {}
+function similar_text(string $string1, string $string2, &$percent = null): int {}
 
 /**
  * Split a string by a string
@@ -1028,7 +1028,7 @@ function explode(string $separator, string $string, int $limit = PHP_INT_MAX) {}
  * elements in the same order, with the glue string between each element.
  */
 #[Pure]
-function implode(array|string $separator = "", ?array $array): string {}
+function implode(array|string $separator = "", ?array $array = null): string {}
 
 /**
  * Alias:
@@ -1046,7 +1046,7 @@ function implode(array|string $separator = "", ?array $array): string {}
  * elements in the same order, with the glue string between each element.
  */
 #[Pure]
-function join(array|string $separator = "", ?array $array): string {}
+function join(array|string $separator = "", ?array $array = null): string {}
 
 /**
  * Set locale information
@@ -1120,7 +1120,7 @@ function join(array|string $separator = "", ?array $array): string {}
 function setlocale(
     #[ExpectedValues([LC_ALL,  LC_COLLATE,  LC_CTYPE,  LC_MONETARY,  LC_NUMERIC,  LC_TIME,  LC_MESSAGES])] int $category,
     #[PhpStormStubsElementAvailable(from: '8.0')] $locales,
-    #[PhpStormStubsElementAvailable(from: '5.3', to: '7.4')] $rest,
+    #[PhpStormStubsElementAvailable(from: '5.3', to: '7.4')] $rest = null,
     ...$rest
 ): string|false {}
 

--- a/standard/standard_2.php
+++ b/standard/standard_2.php
@@ -340,7 +340,7 @@ function strchr(string $haystack, string $needle, bool $before_needle = false): 
 #[Pure]
 function sprintf(
     string $format,
-    #[PhpStormStubsElementAvailable(from: '5.3', to: '5.6')] $values,
+    #[PhpStormStubsElementAvailable(from: '5.3', to: '5.6')] $values = null,
     mixed ...$values
 ): string {}
 
@@ -641,7 +641,7 @@ function link(string $target, string $link): bool {}
  * @param resource $context [optional]
  * @return bool true on success or false on failure.
  */
-function unlink(string $filename, $context): bool {}
+function unlink(string $filename, $context = null): bool {}
 
 /**
  * Execute an external program
@@ -673,7 +673,7 @@ function unlink(string $filename, $context): bool {}
  * To get the output of the executed command, be sure to set and use the
  * output parameter.
  */
-function exec(string $command, &$output, &$result_code): string|false {}
+function exec(string $command, &$output = null, &$result_code = null): string|false {}
 
 /**
  * Execute an external program and display the output
@@ -689,7 +689,7 @@ function exec(string $command, &$output, &$result_code): string|false {}
  * @return string|false the last line of the command output on success, and false
  * on failure.
  */
-function system(string $command, &$result_code): string|false {}
+function system(string $command, &$result_code = null): string|false {}
 
 /**
  * Escape shell metacharacters
@@ -726,7 +726,7 @@ function escapeshellarg(string $arg): string {}
  * @return bool|null null on success or false on failure.
  */
 #[LanguageLevelTypeAware(['8.2' => 'null|false'], default: 'null|bool')]
-function passthru(string $command, &$result_code): ?bool {}
+function passthru(string $command, &$result_code = null): ?bool {}
 
 /**
  * Execute command via shell and return the complete output as a string
@@ -808,7 +808,7 @@ function shell_exec(string $command): string|false|null {}
  * proc_close when you are finished with it. On failure
  * returns false.
  */
-function proc_open(array|string $command, array $descriptor_spec, &$pipes, ?string $cwd, ?array $env_vars, ?array $options) {}
+function proc_open(array|string $command, array $descriptor_spec, &$pipes, ?string $cwd = null, ?array $env_vars = null, ?array $options = null) {}
 
 /**
  * Close a process opened by {@see proc_open} and return the exit code of that process

--- a/standard/standard_3.php
+++ b/standard/standard_3.php
@@ -805,7 +805,7 @@ function putenv(string $assignment): bool {}
 function getopt(
     string $short_options,
     array $long_options = [],
-    #[PhpStormStubsElementAvailable(from: '7.1')] &$rest_index
+    #[PhpStormStubsElementAvailable(from: '7.1')] &$rest_index = null
 ): array|false {}
 
 /**
@@ -1108,4 +1108,4 @@ function import_request_variables(string $types, $prefix = null): bool {}
  * </p>
  * @return bool true on success or false on failure.
  */
-function error_log(string $message, int $message_type = 0, ?string $destination, ?string $additional_headers): bool {}
+function error_log(string $message, int $message_type = 0, ?string $destination = null, ?string $additional_headers = null): bool {}

--- a/standard/standard_4.php
+++ b/standard/standard_4.php
@@ -228,7 +228,7 @@ function var_export(mixed $value, bool $return = false): ?string {}
  */
 function debug_zval_dump(
     #[PhpStormStubsElementAvailable(from: '8.0')] mixed $value,
-    #[PhpStormStubsElementAvailable(from: '5.3', to: '7.4')] $values,
+    #[PhpStormStubsElementAvailable(from: '5.3', to: '7.4')] $values = null,
     mixed ...$values
 ): void {}
 
@@ -453,7 +453,7 @@ function ini_get(string $option): string|false {}
  */
 #[Pure(true)]
 #[ArrayShape(["global_value" => "string", "local_value" => "string", "access" => "int"])]
-function ini_get_all(?string $extension, #[PhpStormStubsElementAvailable(from: '7.0')] bool $details = true): array|false {}
+function ini_get_all(?string $extension = null, #[PhpStormStubsElementAvailable(from: '7.0')] bool $details = true): array|false {}
 
 /**
  * Sets the value of a configuration option
@@ -822,7 +822,7 @@ function connection_status(): int {}
  * </p>
  * @return int the previous setting, as an integer.
  */
-function ignore_user_abort(?bool $enable): int {}
+function ignore_user_abort(?bool $enable = null): int {}
 
 /**
  * Parse a configuration file
@@ -1007,7 +1007,7 @@ function checkdnsrr(string $hostname, string $type = 'MX'): bool {}
  * @param array &$weights [optional]
  * @return bool
  */
-function dns_get_mx(string $hostname, &$hosts, &$weights): bool {}
+function dns_get_mx(string $hostname, &$hosts, &$weights = null): bool {}
 
 /**
  * Get MX records corresponding to a given Internet host name
@@ -1026,7 +1026,7 @@ function dns_get_mx(string $hostname, &$hosts, &$weights): bool {}
  * @return bool true if any records are found; returns false if no records
  * were found or if an error occurred.
  */
-function getmxrr(string $hostname, &$hosts, &$weights): bool {}
+function getmxrr(string $hostname, &$hosts, &$weights = null): bool {}
 
 /**
  * Fetch DNS Resource Records associated with a hostname
@@ -1235,4 +1235,4 @@ function getmxrr(string $hostname, &$hosts, &$weights): bool {}
  * </tr>
  * </table>
  */
-function dns_get_record(string $hostname, int $type = DNS_ANY, &$authoritative_name_servers, &$additional_records, bool $raw = false): array|false {}
+function dns_get_record(string $hostname, int $type = DNS_ANY, &$authoritative_name_servers = null, &$additional_records = null, bool $raw = false): array|false {}

--- a/standard/standard_5.php
+++ b/standard/standard_5.php
@@ -338,7 +338,7 @@ function is_scalar(mixed $value): bool {}
  * @return bool <b>TRUE</b> if $var is callable, <b>FALSE</b>
  * otherwise.
  */
-function is_callable(mixed $value, bool $syntax_only = false, &$callable_name): bool {}
+function is_callable(mixed $value, bool $syntax_only = false, &$callable_name = null): bool {}
 
 /**
  * Verify that the contents of a variable is a countable value
@@ -401,7 +401,7 @@ function popen(string $command, string $mode) {}
  * </p>
  * @return false|int the number of bytes read from the file, or FALSE on failure
  */
-function readfile(string $filename, bool $use_include_path = false, $context): int|false {}
+function readfile(string $filename, bool $use_include_path = false, $context = null): int|false {}
 
 /**
  * Rewind the position of a file pointer
@@ -423,7 +423,7 @@ function rewind($stream): bool {}
  * @param resource $context [optional]
  * @return bool true on success or false on failure.
  */
-function rmdir(string $directory, $context): bool {}
+function rmdir(string $directory, $context = null): bool {}
 
 /**
  * Changes the current umask
@@ -434,7 +434,7 @@ function rmdir(string $directory, $context): bool {}
  * @return int umask without arguments simply returns the
  * current umask otherwise the old umask is returned.
  */
-function umask(?int $mask): int {}
+function umask(?int $mask = null): int {}
 
 /**
  * Closes an open file pointer
@@ -488,7 +488,7 @@ function fgetc($stream): string|false {}
  * <p>
  * If an error occurs, returns false.
  */
-function fgets($stream, ?int $length): string|false {}
+function fgets($stream, ?int $length = null): string|false {}
 
 /**
  * Gets line from file pointer and strip HTML tags
@@ -704,7 +704,7 @@ function fread($stream, int $length): string|false {}
  * @param resource $context [optional]
  * @return resource|false a file pointer resource on success, or false on error.
  */
-function fopen(string $filename, string $mode, bool $use_include_path = false, $context) {}
+function fopen(string $filename, string $mode, bool $use_include_path = false, $context = null) {}
 
 /**
  * Output all remaining data on a file pointer
@@ -841,7 +841,7 @@ function fdatasync($stream): bool {}
  * </p>
  * @return int|false the number of bytes written, or <b>FALSE</b> on error.
  */
-function fwrite($stream, string $data, ?int $length): int|false {}
+function fwrite($stream, string $data, ?int $length = null): int|false {}
 
 /**
  * Alias:
@@ -867,7 +867,7 @@ function fwrite($stream, string $data, ?int $length): int|false {}
  * @link https://php.net/manual/en/function.fputs.php
  * Binary-safe file write
  */
-function fputs($stream, string $data, ?int $length): int|false {}
+function fputs($stream, string $data, ?int $length = null): int|false {}
 
 /**
  * Attempts to create the directory specified by pathname.
@@ -895,7 +895,7 @@ function fputs($stream, string $data, ?int $length): int|false {}
  * @param resource $context [optional]
  * @return bool true on success or false on failure.
  */
-function mkdir(string $directory, int $permissions = 0777, bool $recursive = false, $context): bool {}
+function mkdir(string $directory, int $permissions = 0777, bool $recursive = false, $context = null): bool {}
 
 /**
  * Renames a file or directory
@@ -913,7 +913,7 @@ function mkdir(string $directory, int $permissions = 0777, bool $recursive = fal
  * @param resource $context [optional]
  * @return bool true on success or false on failure.
  */
-function rename(string $from, string $to, $context): bool {}
+function rename(string $from, string $to, $context = null): bool {}
 
 /**
  * Copies file
@@ -935,7 +935,7 @@ function rename(string $from, string $to, $context): bool {}
  * </p>
  * @return bool true on success or false on failure.
  */
-function copy(string $from, string $to, $context): bool {}
+function copy(string $from, string $to, $context = null): bool {}
 
 /**
  * Create file with unique file name
@@ -990,7 +990,7 @@ function tmpfile() {}
  * </p>
  */
 #[Pure(true)]
-function file(string $filename, int $flags = 0, $context): array|false {}
+function file(string $filename, int $flags = 0, $context = null): array|false {}
 
 /**
  * Reads entire file into a string
@@ -1017,7 +1017,7 @@ function file(string $filename, int $flags = 0, $context): array|false {}
  * @return string|false The function returns the read data or false on failure.
  */
 #[Pure(true)]
-function file_get_contents(string $filename, bool $use_include_path = false, $context, int $offset = 0, ?int $length): string|false {}
+function file_get_contents(string $filename, bool $use_include_path = false, $context = null, int $offset = 0, ?int $length = null): string|false {}
 
 /**
  * Write a string to a file
@@ -1090,4 +1090,4 @@ function file_get_contents(string $filename, bool $use_include_path = false, $co
  * @return int|false The function returns the number of bytes that were written to the file, or
  * false on failure.
  */
-function file_put_contents(string $filename, mixed $data, int $flags = 0, $context): int|false {}
+function file_put_contents(string $filename, mixed $data, int $flags = 0, $context = null): int|false {}

--- a/standard/standard_6.php
+++ b/standard/standard_6.php
@@ -84,7 +84,7 @@ function stream_select(
     ?array &$write,
     ?array &$except,
     ?int $seconds,
-    #[LanguageLevelTypeAware(['8.1' => 'int|null'], default: 'int')] $microseconds
+    #[LanguageLevelTypeAware(['8.1' => 'int|null'], default: 'int')] $microseconds = null
 ): int|false {}
 
 /**
@@ -105,7 +105,7 @@ function stream_select(
  * </p>
  * @return resource A stream context resource.
  */
-function stream_context_create(?array $options, ?array $params) {}
+function stream_context_create(?array $options = null, ?array $params = null) {}
 
 /**
  * Set parameters for a stream/wrapper/context
@@ -189,7 +189,7 @@ function stream_context_get_options($stream_or_context): array {}
  * </p>
  * @return resource A stream context resource.
  */
-function stream_context_get_default(?array $options) {}
+function stream_context_get_default(?array $options = null) {}
 
 /**
  * Set the default stream context
@@ -325,7 +325,7 @@ function stream_filter_remove($stream_filter): bool {}
  * fwrite, fclose, and
  * feof), false on failure.
  */
-function stream_socket_client(string $address, &$error_code, &$error_message, ?float $timeout, int $flags = STREAM_CLIENT_CONNECT, $context) {}
+function stream_socket_client(string $address, &$error_code = null, &$error_message = null, ?float $timeout = null, int $flags = STREAM_CLIENT_CONNECT, $context = null) {}
 
 /**
  * Create an Internet or Unix domain server socket
@@ -375,7 +375,7 @@ function stream_socket_client(string $address, &$error_code, &$error_message, ?f
  * </p>
  * @return resource|false the created stream, or false on error.
  */
-function stream_socket_server(string $address, &$error_code, &$error_message, int $flags = STREAM_SERVER_BIND|STREAM_SERVER_LISTEN, $context) {}
+function stream_socket_server(string $address, &$error_code = null, &$error_message = null, int $flags = STREAM_SERVER_BIND|STREAM_SERVER_LISTEN, $context = null) {}
 
 /**
  * Accept a connection on a socket created by {@see stream_socket_server}
@@ -395,7 +395,7 @@ function stream_socket_server(string $address, &$error_code, &$error_message, in
  * </p>
  * @return resource|false Returns a stream to the accepted socket connection or FALSE on failure.
  */
-function stream_socket_accept($socket, ?float $timeout, &$peer_name) {}
+function stream_socket_accept($socket, ?float $timeout = null, &$peer_name = null) {}
 
 /**
  * Retrieve the name of the local or remote sockets
@@ -448,7 +448,7 @@ function stream_socket_get_name($socket, bool $remote): string|false {}
  * </p>
  * @return string|false the read data, as a string, or false on error
  */
-function stream_socket_recvfrom($socket, int $length, int $flags = 0, &$address): string|false {}
+function stream_socket_recvfrom($socket, int $length, int $flags = 0, &$address = null): string|false {}
 
 /**
  * Sends a message to a socket, whether it is connected or not
@@ -503,7 +503,7 @@ function stream_socket_sendto($socket, string $data, int $flags = 0, string $add
  * 0 if there isn't enough data and you should try again
  * (only for non-blocking sockets).
  */
-function stream_socket_enable_crypto($stream, bool $enable, ?int $crypto_method, $session_stream): int|bool {}
+function stream_socket_enable_crypto($stream, bool $enable, ?int $crypto_method = null, $session_stream = null): int|bool {}
 
 /**
  * Shutdown a full-duplex connection
@@ -569,7 +569,7 @@ function stream_socket_pair(int $domain, int $type, int $protocol): array|false 
  * </p>
  * @return int|false the total count of bytes copied, or false on failure.
  */
-function stream_copy_to_stream($from, $to, ?int $length, int $offset = 0): int|false {}
+function stream_copy_to_stream($from, $to, ?int $length = null, int $offset = 0): int|false {}
 
 /**
  * Reads remainder of a stream into a string
@@ -681,7 +681,7 @@ function fputcsv(
  * </p>
  * @return bool true on success or false on failure.
  */
-function flock($stream, int $operation, &$would_block): bool {}
+function flock($stream, int $operation, &$would_block = null): bool {}
 
 /**
  * Extracts all meta tag content attributes from a file and returns an array
@@ -1058,7 +1058,7 @@ function get_headers(
 function stream_set_timeout(
     $stream,
     int $seconds,
-    #[PhpStormStubsElementAvailable(from: '5.3', to: '5.6')] int $microseconds,
+    #[PhpStormStubsElementAvailable(from: '5.3', to: '5.6')] int $microseconds = 0,
     #[PhpStormStubsElementAvailable(from: '7.0')] int $microseconds = 0
 ): bool {}
 
@@ -1082,7 +1082,7 @@ function stream_set_timeout(
 function socket_set_timeout(
     $stream,
     int $seconds,
-    #[PhpStormStubsElementAvailable(from: '5.3', to: '5.6')] int $microseconds,
+    #[PhpStormStubsElementAvailable(from: '5.3', to: '5.6')] int $microseconds = 0,
     #[PhpStormStubsElementAvailable(from: '7.0')] int $microseconds = 0
 ): bool {}
 

--- a/standard/standard_7.php
+++ b/standard/standard_7.php
@@ -50,11 +50,11 @@ use JetBrains\PhpStorm\Pure;
  */
 function fsockopen(
     string $hostname,
-    #[PhpStormStubsElementAvailable(from: '5.3', to: '7.0')] int $port,
+    #[PhpStormStubsElementAvailable(from: '5.3', to: '7.0')] int $port = -1,
     #[PhpStormStubsElementAvailable(from: '7.1')] int $port = -1,
-    &$error_code,
-    &$error_message,
-    ?float $timeout
+    &$error_code = null,
+    &$error_message = null,
+    ?float $timeout = null
 ) {}
 
 /**
@@ -70,11 +70,11 @@ function fsockopen(
  */
 function pfsockopen(
     string $hostname,
-    #[PhpStormStubsElementAvailable(from: '5.3', to: '7.0')] int $port,
+    #[PhpStormStubsElementAvailable(from: '5.3', to: '7.0')] int $port = -1,
     #[PhpStormStubsElementAvailable(from: '7.1')] int $port = -1,
-    &$error_code,
-    &$error_message,
-    ?float $timeout
+    &$error_code = null,
+    &$error_message = null,
+    ?float $timeout = null
 ) {}
 
 /**
@@ -185,7 +185,7 @@ function pfsockopen(
 #[LanguageLevelTypeAware(["8.0" => "string"], default: "string|false")]
 function pack(
     string $format,
-    #[PhpStormStubsElementAvailable(from: '5.3', to: '7.3')] $values,
+    #[PhpStormStubsElementAvailable(from: '5.3', to: '7.3')] $values = null,
     mixed ...$values
 ) {}
 
@@ -237,7 +237,7 @@ function unpack(
  * reload, and check for the value.
  */
 #[Pure(true)]
-function get_browser(?string $user_agent, bool $return_array = false): object|array|false {}
+function get_browser(?string $user_agent = null, bool $return_array = false): object|array|false {}
 
 /**
  * One-way string encryption (hashing)
@@ -307,7 +307,7 @@ function crypt(string $string, string $salt): string {}
  * '@' to the
  * front of the function name.
  */
-function opendir(string $directory, $context) {}
+function opendir(string $directory, $context = null) {}
 
 /**
  * Close directory handle
@@ -320,7 +320,7 @@ function opendir(string $directory, $context) {}
  * </p>
  * @return void
  */
-function closedir($dir_handle): void {}
+function closedir($dir_handle = null): void {}
 
 /**
  * Change directory
@@ -370,7 +370,7 @@ function getcwd(): string|false {}
  * </p>
  * @see https://bugs.php.net/bug.php?id=75485
  */
-function rewinddir($dir_handle): void {}
+function rewinddir($dir_handle = null): void {}
 
 /**
  * Read entry from directory handle
@@ -383,7 +383,7 @@ function rewinddir($dir_handle): void {}
  * </p>
  * @return string|false the filename on success or false on failure.
  */
-function readdir($dir_handle): string|false {}
+function readdir($dir_handle = null): string|false {}
 
 /**
  * Return an instance of the Directory class
@@ -917,7 +917,7 @@ function chmod(string $filename, int $permissions): bool {}
  * </p>
  * @return bool true on success or false on failure.
  */
-function touch(string $filename, ?int $mtime, ?int $atime): bool {}
+function touch(string $filename, ?int $mtime = null, ?int $atime = null): bool {}
 
 /**
  * Clears file status cache

--- a/standard/standard_8.php
+++ b/standard/standard_8.php
@@ -101,7 +101,7 @@ function header_register_callback(callable $callback): bool {}
  * @since 5.4
  */
 #[ArrayShape([0 => 'int', 1 => 'int', 2 => 'int', 3 => 'string', 'bits' => 'int', 'channels' => 'int', 'mime' => 'string'])]
-function getimagesizefromstring(string $string, &$image_info): array|false {}
+function getimagesizefromstring(string $string, &$image_info = null): array|false {}
 
 /**
  * Set the stream chunk size.
@@ -744,7 +744,7 @@ function key(object|array $array): string|int|null {}
 #[Pure]
 function min(
     #[PhpStormStubsElementAvailable(from: '8.0')] mixed $value,
-    #[PhpStormStubsElementAvailable(from: '5.3', to: '7.4')] mixed $values,
+    #[PhpStormStubsElementAvailable(from: '5.3', to: '7.4')] mixed $values = null,
     mixed ...$values
 ): mixed {}
 
@@ -759,7 +759,7 @@ function min(
 #[Pure]
 function max(
     #[PhpStormStubsElementAvailable(from: '8.0')] mixed $value,
-    #[PhpStormStubsElementAvailable(from: '5.3', to: '7.4')] mixed $values,
+    #[PhpStormStubsElementAvailable(from: '5.3', to: '7.4')] mixed $values = null,
     mixed ...$values
 ): mixed {}
 
@@ -874,7 +874,7 @@ function extract(
  * @return array the output array with all the variables added to it.
  */
 #[Pure]
-function compact(#[PhpStormStubsElementAvailable(from: '8.0')] $var_name, #[PhpStormStubsElementAvailable(from: '5.3', to: '7.4')] $var_names, ...$var_names): array {}
+function compact(#[PhpStormStubsElementAvailable(from: '8.0')] $var_name, #[PhpStormStubsElementAvailable(from: '5.3', to: '7.4')] $var_names = null, ...$var_names): array {}
 
 /**
  * Fill an array with values

--- a/standard/standard_9.php
+++ b/standard/standard_9.php
@@ -1028,7 +1028,7 @@ function version_compare(
                "!=",
                "<>",
                "ne"
-           ])] ?string $operator
+           ])] ?string $operator = null
 ): int|bool {}
 
 /**
@@ -1087,7 +1087,7 @@ function version_compare(
         "!=",
         "<>",
         "ne"
-    ])] ?string $operator
+    ])] ?string $operator = null
 ): int|bool|null {}
 
 /**

--- a/svm/SVM.php
+++ b/svm/SVM.php
@@ -166,5 +166,5 @@ class SVM
      * @throws SMVException
      * @link https://www.php.net/manual/en/svm.train.php
      */
-    public function train(array $problem, array $weights = null): SVMModel {}
+    public function train(array $problem, ?array $weights = null): SVMModel {}
 }

--- a/swoole/Swoole/Coroutine.php
+++ b/swoole/Swoole/Coroutine.php
@@ -135,7 +135,7 @@ class Coroutine
      * @return int|false Memory usage of the coroutine; FALSE if the specified coroutine doesn't exist.
      * @since 4.8.0
      */
-    public static function getStackUsage(int $cid = null) {}
+    public static function getStackUsage(?int $cid = null) {}
 
     /**
      * @return mixed

--- a/swoole/Swoole/Coroutine/MySQL.php
+++ b/swoole/Swoole/Coroutine/MySQL.php
@@ -34,7 +34,7 @@ class MySQL
     /**
      * @return mixed
      */
-    public function connect(array $server_config = null) {}
+    public function connect(?array $server_config = null) {}
 
     /**
      * @param mixed $sql

--- a/swoole/Swoole/Coroutine/Redis.php
+++ b/swoole/Swoole/Coroutine/Redis.php
@@ -636,14 +636,14 @@ class Redis
      * @param mixed $count
      * @return mixed
      */
-    public function zPopMin($key, $count) {}
+    public function zPopMin($key, $count = null) {}
 
     /**
      * @param mixed $key
      * @param mixed $count
      * @return mixed
      */
-    public function zPopMax($key, $count) {}
+    public function zPopMax($key, $count = null) {}
 
     /**
      * @param mixed $key
@@ -935,7 +935,7 @@ class Redis
      * @param mixed $count
      * @return mixed
      */
-    public function lRem($key, $value, $count) {}
+    public function lRem($key, $value, $count = 0) {}
 
     /**
      * @param mixed $key

--- a/swoole/Swoole/Table.php
+++ b/swoole/Swoole/Table.php
@@ -51,7 +51,7 @@ class Table implements \Iterator, \ArrayAccess, \Countable
     /**
      * @return mixed
      */
-    public function get(string $key, string $field = null) {}
+    public function get(string $key, ?string $field = null) {}
 
     /**
      * This method has an alias of \Swoole\Table::delete().

--- a/sync/sync.php
+++ b/sync/sync.php
@@ -22,7 +22,7 @@ class SyncMutex
      * @throws Exception if the mutex cannot be created or opened
      * @link https://php.net/manual/en/syncmutex.construct.php
      */
-    public function __construct($name) {}
+    public function __construct($name = null) {}
 
     /**
      * Waits for an exclusive lock
@@ -70,7 +70,7 @@ class SyncSemaphore
      * @throws Exception if the semaphore cannot be created or opened
      * @link https://php.net/manual/en/syncsemaphore.construct.php
      */
-    public function __construct($name, $initialval = 1, $autounlock = true) {}
+    public function __construct($name = null, $initialval = 1, $autounlock = true) {}
 
     /**
      * Decreases the count of the semaphore or waits
@@ -118,7 +118,7 @@ class SyncEvent
      * @since 1.1.0 Added $prefire
      * @link https://php.net/manual/en/syncevent.construct.php
      */
-    public function __construct(string $name, bool $manual = false, bool $prefire = false) {}
+    public function __construct(?string $name = null, bool $manual = false, bool $prefire = false) {}
 
     /**
      * Fires/sets the event
@@ -174,7 +174,7 @@ class SyncReaderWriter
      * @throws Exception if the reader-writer cannot be created or opened.
      * @link https://php.net/manual/en/syncreaderwriter.construct.php
      */
-    public function __construct($name, $autounlock = true) {}
+    public function __construct($name = null, $autounlock = true) {}
 
     /**
      * Waits for a read lock

--- a/sysvmsg/sysvmsg.php
+++ b/sysvmsg/sysvmsg.php
@@ -55,7 +55,7 @@ function msg_get_queue(int $key, int $permissions = 0666) {}
  * <i>msg_stime</i> is set to the current time.
  * </p>
  */
-function msg_send(#[LanguageLevelTypeAware(["8.0" => "SysvMessageQueue"], default: "resource")] $queue, int $message_type, $message, bool $serialize = true, bool $blocking = true, &$error_code): bool {}
+function msg_send(#[LanguageLevelTypeAware(["8.0" => "SysvMessageQueue"], default: "resource")] $queue, int $message_type, $message, bool $serialize = true, bool $blocking = true, &$error_code = null): bool {}
 
 /**
  * Receive a message from a message queue
@@ -142,7 +142,7 @@ function msg_send(#[LanguageLevelTypeAware(["8.0" => "SysvMessageQueue"], defaul
  * msg_rtime is set to the current time.
  * </p>
  */
-function msg_receive(#[LanguageLevelTypeAware(["8.0" => "SysvMessageQueue"], default: "resource")] $queue, int $desired_message_type, &$received_message_type, int $max_message_size, mixed & $message, bool $unserialize = true, int $flags = 0, &$error_code): bool {}
+function msg_receive(#[LanguageLevelTypeAware(["8.0" => "SysvMessageQueue"], default: "resource")] $queue, int $desired_message_type, &$received_message_type, int $max_message_size, mixed & $message, bool $unserialize = true, int $flags = 0, &$error_code = null): bool {}
 
 /**
  * Destroy a message queue

--- a/sysvshm/sysvshm.php
+++ b/sysvshm/sysvshm.php
@@ -20,7 +20,7 @@ use JetBrains\PhpStorm\Internal\LanguageLevelTypeAware;
  * @return resource|SysvSharedMemory|false a shared memory segment identifier.
  */
 #[LanguageLevelTypeAware(["8.0" => "SysvSharedMemory|false"], default: "resource|false")]
-function shm_attach(int $key, ?int $size, int $permissions = 0666) {}
+function shm_attach(int $key, ?int $size = null, int $permissions = 0666) {}
 
 /**
  * Removes shared memory from Unix systems

--- a/tests/TestData/mutedProblems.json
+++ b/tests/TestData/mutedProblems.json
@@ -1785,6 +1785,22 @@
               ]
             }
           ]
+        },
+        {
+          "name": "running",
+          "parameters": [
+            {
+              "name": "retphar",
+              "problems": [
+                {
+                  "description": "wrong optionallity",
+                  "versions": [
+                    5.6
+                  ]
+                }
+              ]
+            }
+          ]
         }
       ]
     },
@@ -2642,6 +2658,25 @@
       ]
     },
     {
+      "name": "MultipleIterator",
+      "methods": [
+        {
+          "name": "__construct",
+          "parameters": [
+            {
+              "name": "flags",
+              "problems": [
+                {
+                  "description": "wrong optionallity",
+                  "versions": [5.6, 7.0, 7.1, 7.2, 7.3, 7.4]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
       "name": "DateTimeZone",
       "methods": [
         {
@@ -2658,6 +2693,28 @@
         {
           "name": "getTransitions",
           "parameters": [
+            {
+              "name": "timestamp_begin",
+              "problems": [
+                {
+                  "description": "wrong optionallity",
+                  "versions": [
+                    5.6
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "timestamp_end",
+              "problems": [
+                {
+                  "description": "wrong optionallity",
+                  "versions": [
+                    5.6
+                  ]
+                }
+              ]
+            },
             {
               "name": "timestampEnd",
               "problems": [
@@ -2865,6 +2922,92 @@
       "name": "SQLite3",
       "methods": [
         {
+          "name": "__construct",
+          "parameters": [
+            {
+              "name": "flags",
+              "problems": [
+                {
+                  "description": "wrong optionallity",
+                  "versions": [
+                    5.6
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "encryption_key",
+              "problems": [
+                {
+                  "description": "wrong optionallity",
+                  "versions": [
+                    5.6
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "open",
+          "parameters": [
+            {
+              "name": "flags",
+              "problems": [
+                {
+                  "description": "wrong optionallity",
+                  "versions": [
+                    5.6
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "encryption_key",
+              "problems": [
+                {
+                  "description": "wrong optionallity",
+                  "versions": [
+                    5.6
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "enableExceptions",
+          "parameters": [
+            {
+              "name": "enableExceptions",
+              "problems": [
+                {
+                  "description": "wrong optionallity",
+                  "versions": [
+                    5.6
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "enableExtendedResultCodes",
+          "parameters": [
+            {
+              "name": "enable",
+              "problems": [
+                {
+                  "description": "wrong optionallity",
+                  "versions": [
+                    7.4
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
           "name": "createFunction",
           "parameters": [
             {
@@ -2890,6 +3033,27 @@
                   "description": "has scalar typehint",
                   "versions": [
                     "ALL"
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "SoapClient",
+      "methods": [
+        {
+          "name": "__setSoapHeaders",
+          "parameters": [
+            {
+              "name": "soapheaders",
+              "problems": [
+                {
+                  "description": "wrong optionallity",
+                  "versions": [
+                    5.6
                   ]
                 }
               ]

--- a/uv/uv_functions.php
+++ b/uv/uv_functions.php
@@ -159,7 +159,7 @@ function uv_shutdown($handle, callable $callback) {}
  *
  * @return void
  */
-function uv_close($handle, callable $callback = null) {}
+function uv_close($handle, ?callable $callback = null) {}
 
 /**
  * Starts read callback for uv streams.
@@ -505,7 +505,7 @@ function uv_is_writable($handle): bool {}
  *
  * @return bool
  */
-function uv_walk($loop, callable $closure, array $opaque = null): bool {}
+function uv_walk($loop, callable $closure, ?array $opaque = null): bool {}
 
 /**
  * @param resource $uv

--- a/v8js/v8js.php
+++ b/v8js/v8js.php
@@ -114,7 +114,7 @@ class V8Js
      * @param bool $auto_enable
      * @return bool
      */
-    public static function registerExtension($extension_name, $code, array $dependencies, $auto_enable = false) {}
+    public static function registerExtension($extension_name, $code, array $dependencies = [], $auto_enable = false) {}
 
     /**
      * Returns extensions successfully registered with V8Js::registerExtension().

--- a/wincache/wincache.php
+++ b/wincache/wincache.php
@@ -130,7 +130,7 @@ function wincache_ocache_meminfo() {}
  * or relative file paths can be used.</p>
  * @return bool Returns TRUE on success or FALSE on failure.
  */
-function wincache_refresh_if_changed(array $files) {}
+function wincache_refresh_if_changed(?array $files = null) {}
 
 /**
  * (PHP 5.2+; PECL wincache &gt;= 1.0.0)<br/>
@@ -281,7 +281,7 @@ function wincache_ucache_clear() {}
  * <p>Will be set to TRUE on success and FALSE on failure.</p>
  * @return int|false Returns the decremented value on success and FALSE on failure.
  */
-function wincache_ucache_dec($key, $dec_by = 1, &$success) {}
+function wincache_ucache_dec($key, $dec_by = 1, &$success = null) {}
 
 /**
  * (PHP 5.2+; PECL wincache &gt;= 1.1.0)<br/>
@@ -321,7 +321,7 @@ function wincache_ucache_exists($key) {}
  * operation in user cache was successful. If none of the keys in the key array finds a
  * match in the user cache an empty array will be returned.</p>
  */
-function wincache_ucache_get($key, &$success) {}
+function wincache_ucache_get($key, &$success = null) {}
 
 /**
  * (PHP 5.2+; PECL wincache &gt;= 1.1.0)<br/>
@@ -337,7 +337,7 @@ function wincache_ucache_get($key, &$success) {}
  * <p>Will be set to TRUE on success and FALSE on failure.</p>
  * @return int|false Returns the incremented value on success and FALSE on failure.
  */
-function wincache_ucache_inc($key, $inc_by = 1, &$success) {}
+function wincache_ucache_inc($key, $inc_by = 1, &$success = null) {}
 
 /**
  * (PHP 5.2+; PECL wincache &gt;= 1.1.0)<br/>

--- a/xdiff/xdiff.php
+++ b/xdiff/xdiff.php
@@ -164,7 +164,7 @@ function xdiff_string_diff(string $old_data, string $new_data, int $context = 3,
  * @param ?string $error If provided then rejected parts are stored inside this variable.
  * @return bool|string the merged string, false if an internal error happened, or true if merged string is empty.
  */
-function xdiff_string_merge3(string $old_data, string $new_data1, string $new_data2, ?string &$error) {}
+function xdiff_string_merge3(string $old_data, string $new_data1, string $new_data2, ?string &$error = null) {}
 
 /**
  * Alias of xdiff_string_bpatch
@@ -186,7 +186,7 @@ function xdiff_string_patch_binary(string $str, string $patch) {}
  * @param ?string $error If provided then rejected parts are stored inside this variable.
  * @return string|false the patched string, or false on error.
  */
-function xdiff_string_patch(string $str, string $patch, #[ExpectedValues([XDIFF_PATCH_NORMAL|XDIFF_PATCH_REVERSE|XDIFF_PATCH_IGNORESPACE])] ?int $flags, ?string &$error) {}
+function xdiff_string_patch(string $str, string $patch, #[ExpectedValues([XDIFF_PATCH_NORMAL|XDIFF_PATCH_REVERSE|XDIFF_PATCH_IGNORESPACE])] ?int $flags = null, ?string &$error = null) {}
 
 /**
  * Make binary diff of two strings using the Rabin's polynomial fingerprinting algorithm

--- a/xlswriter/xlswriter.php
+++ b/xlswriter/xlswriter.php
@@ -156,7 +156,7 @@ namespace Vtiful\Kernel;
          *
          * @return Excel
          */
-        public function insertText(int $row, int $column, $data, string $format = null, $formatHandle = null): self
+        public function insertText(int $row, int $column, $data, ?string $format = null, $formatHandle = null): self
         {
             return $this;
         }
@@ -172,7 +172,7 @@ namespace Vtiful\Kernel;
          *
          * @return Excel
          */
-        public function insertDate(int $row, int $column, int $timestamp, string $format = null, $formatHandle = null): self
+        public function insertDate(int $row, int $column, int $timestamp, ?string $format = null, $formatHandle = null): self
         {
             return $this;
         }
@@ -299,7 +299,7 @@ namespace Vtiful\Kernel;
          *
          * @return Excel
          */
-        public function openSheet(string $sheetName = null, int $skipFlag = 0x00): self
+        public function openSheet(?string $sheetName = null, int $skipFlag = 0x00): self
         {
             return $this;
         }
@@ -342,7 +342,7 @@ namespace Vtiful\Kernel;
          * @param callable $callback function(int $row, int $cell, string $data)
          * @param string|null $sheetName sheet name
          */
-        public function nextCellCallback(callable $callback, string $sheetName = null): void {}
+        public function nextCellCallback(callable $callback, ?string $sheetName = null): void {}
 
         /**
          * Freeze panes

--- a/xml/xml.php
+++ b/xml/xml.php
@@ -25,7 +25,7 @@ use JetBrains\PhpStorm\Pure;
  */
 #[Pure]
 #[LanguageLevelTypeAware(["8.0" => "XMLParser"], default: "resource")]
-function xml_parser_create(?string $encoding) {}
+function xml_parser_create(?string $encoding = null) {}
 
 /**
  * Create an XML parser with namespace support
@@ -50,7 +50,7 @@ function xml_parser_create(?string $encoding) {}
  */
 #[Pure]
 #[LanguageLevelTypeAware(["8.0" => "XMLParser"], default: "resource")]
-function xml_parser_create_ns(?string $encoding, string $separator = ':') {}
+function xml_parser_create_ns(?string $encoding = null, string $separator = ':') {}
 
 /**
  * Use XML Parser within an object
@@ -402,7 +402,7 @@ function xml_parse(#[LanguageLevelTypeAware(["8.0" => "XMLParser"], default: "re
  * operators such as ===.
  */
 #[LanguageLevelTypeAware(['8.1' => 'int|false'], default: 'int')]
-function xml_parse_into_struct(#[LanguageLevelTypeAware(["8.0" => "XMLParser"], default: "resource")] $parser, string $data, &$values, &$index) {}
+function xml_parse_into_struct(#[LanguageLevelTypeAware(["8.0" => "XMLParser"], default: "resource")] $parser, string $data, &$values, &$index = null) {}
 
 /**
  * Get XML parser error code

--- a/xmlwriter/xmlwriter.php
+++ b/xmlwriter/xmlwriter.php
@@ -885,7 +885,7 @@ function xmlwriter_start_element_ns(#[LanguageLevelTypeAware(["8.0" => "XMLWrite
  * </p>
  * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
  */
-function xmlwriter_write_element(#[LanguageLevelTypeAware(["8.0" => "XMLWriter"], default: "resource")] $writer, string $name, ?string $content): bool {}
+function xmlwriter_write_element(#[LanguageLevelTypeAware(["8.0" => "XMLWriter"], default: "resource")] $writer, string $name, ?string $content = null): bool {}
 
 /**
  * (PHP 5 &gt;= 5.1.2, PECL xmlwriter &gt;= 0.1.0)<br/>
@@ -910,7 +910,7 @@ function xmlwriter_write_element(#[LanguageLevelTypeAware(["8.0" => "XMLWriter"]
  * </p>
  * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
  */
-function xmlwriter_write_element_ns(#[LanguageLevelTypeAware(["8.0" => "XMLWriter"], default: "resource")] $writer, ?string $prefix, string $name, ?string $namespace, ?string $content): bool {}
+function xmlwriter_write_element_ns(#[LanguageLevelTypeAware(["8.0" => "XMLWriter"], default: "resource")] $writer, ?string $prefix, string $name, ?string $namespace, ?string $content = null): bool {}
 
 /**
  * (PHP 5 &gt;= 5.1.2, PECL xmlwriter &gt;= 0.1.0)<br/>
@@ -1054,7 +1054,7 @@ function xmlwriter_write_raw(#[LanguageLevelTypeAware(["8.0" => "XMLWriter"], de
  * </p>
  * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
  */
-function xmlwriter_start_document(#[LanguageLevelTypeAware(["8.0" => "XMLWriter"], default: "resource")] $writer, ?string $version = '1.0', ?string $encoding, ?string $standalone): bool {}
+function xmlwriter_start_document(#[LanguageLevelTypeAware(["8.0" => "XMLWriter"], default: "resource")] $writer, ?string $version = '1.0', ?string $encoding = null, ?string $standalone = null): bool {}
 
 /**
  * (PHP 5 &gt;= 5.1.2, PECL xmlwriter &gt;= 0.1.0)<br/>
@@ -1105,7 +1105,7 @@ function xmlwriter_write_comment(#[LanguageLevelTypeAware(["8.0" => "XMLWriter"]
  * </p>
  * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
  */
-function xmlwriter_start_dtd(#[LanguageLevelTypeAware(["8.0" => "XMLWriter"], default: "resource")] $writer, string $qualifiedName, ?string $publicId, ?string $systemId): bool {}
+function xmlwriter_start_dtd(#[LanguageLevelTypeAware(["8.0" => "XMLWriter"], default: "resource")] $writer, string $qualifiedName, ?string $publicId = null, ?string $systemId = null): bool {}
 
 /**
  * (PHP 5 &gt;= 5.1.2, PECL xmlwriter &gt;= 0.1.0)<br/>
@@ -1142,7 +1142,7 @@ function xmlwriter_end_dtd(#[LanguageLevelTypeAware(["8.0" => "XMLWriter"], defa
  * </p>
  * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
  */
-function xmlwriter_write_dtd(#[LanguageLevelTypeAware(["8.0" => "XMLWriter"], default: "resource")] $writer, string $name, ?string $publicId, ?string $systemId, ?string $content): bool {}
+function xmlwriter_write_dtd(#[LanguageLevelTypeAware(["8.0" => "XMLWriter"], default: "resource")] $writer, string $name, ?string $publicId = null, ?string $systemId = null, ?string $content = null): bool {}
 
 /**
  * (PHP 5 &gt;= 5.1.2, PECL xmlwriter &gt;= 0.1.0)<br/>

--- a/yaf/yaf.php
+++ b/yaf/yaf.php
@@ -2890,7 +2890,7 @@ final class Yaf_Route_Rewrite extends Yaf_Router implements Yaf_Route_Interface
      *
      * @throws Yaf_Exception_TypeError
      */
-    public function __construct($match, array $route, array $verify = null, $reverse = null) {}
+    public function __construct($match, array $route, ?array $verify = null, $reverse = null) {}
 
     /**
      * @link https://secure.php.net/manual/en/yaf-route-rewrite.route.php
@@ -2986,7 +2986,7 @@ final class Yaf_Route_Regex extends Yaf_Router implements Yaf_Route_Interface
      * @param array|null $query
      * @return bool
      */
-    public function assemble(array $info, array $query = null) {}
+    public function assemble(array $info, ?array $query = null) {}
 
     /**
      * @param string $uri

--- a/yaf/yaf_namespace.php
+++ b/yaf/yaf_namespace.php
@@ -364,7 +364,7 @@ final class Dispatcher
      * @param array $options
      * @return \Yaf\View_Interface
      */
-    public function initView($templates_dir, array $options = null) {}
+    public function initView($templates_dir, ?array $options = null) {}
 
     /**
      * This method provides a solution for that if you want use a custom view engine instead of \Yaf\View\Simple
@@ -1071,7 +1071,7 @@ abstract class Controller_Abstract
      *
      * @return string
      */
-    protected function render($tpl, array $parameters = null) {}
+    protected function render($tpl, ?array $parameters = null) {}
 
     /**
      * @link https://secure.php.net/manual/en/yaf-controller-abstract.display.php
@@ -1081,7 +1081,7 @@ abstract class Controller_Abstract
      *
      * @return bool
      */
-    protected function display($tpl, array $parameters = null) {}
+    protected function display($tpl, ?array $parameters = null) {}
 
     /**
      * retrieve current request object
@@ -1127,7 +1127,7 @@ abstract class Controller_Abstract
      *
      * @return \Yaf\Response_Abstract
      */
-    public function initView(array $options = null) {}
+    public function initView(?array $options = null) {}
 
     /**
      * @link https://secure.php.net/manual/en/yaf-controller-abstract.setviewpath.php
@@ -1165,7 +1165,7 @@ abstract class Controller_Abstract
      *
      * @return bool return FALSE on failure
      */
-    public function forward($module, $controller = null, $action = null, array $parameters = null) {}
+    public function forward($module, $controller = null, $action = null, ?array $parameters = null) {}
 
     /**
      * redirect to a URL by sending a 302 header
@@ -1211,7 +1211,7 @@ abstract class Controller_Abstract
      * @param \Yaf\View_Interface $view
      * @param array $invokeArgs
      */
-    final public function __construct(Request_Abstract $request, Response_Abstract $response, View_Interface $view, array $invokeArgs = null) {}
+    final public function __construct(Request_Abstract $request, Response_Abstract $response, View_Interface $view, ?array $invokeArgs = null) {}
 
     /**
      * @link https://secure.php.net/manual/en/yaf-controller-abstract.clone.php
@@ -1821,7 +1821,7 @@ interface View_Interface
      * @param array $tpl_vars
      * @return bool
      */
-    public function display($tpl, array $tpl_vars = null);
+    public function display($tpl, ?array $tpl_vars = null);
 
     /**
      * @link https://secure.php.net/manual/en/yaf-view-interface.getscriptpath.php
@@ -1839,7 +1839,7 @@ interface View_Interface
      * @param array $tpl_vars
      * @return string
      */
-    public function render($tpl, array $tpl_vars = null);
+    public function render($tpl, ?array $tpl_vars = null);
 
     /**
      * Set the templates base directory, this is usually called by \Yaf\Dispatcher
@@ -1880,7 +1880,7 @@ interface Route_Interface
      * @param array $query
      * @return bool
      */
-    public function assemble(array $info, array $query = null);
+    public function assemble(array $info, ?array $query = null);
 }/**
  * @link https://secure.php.net/manual/en/class.yaf-exception.php
  */
@@ -1924,7 +1924,7 @@ class Route_Static implements \Yaf\Route_Interface
      * @param array $query
      * @return bool
      */
-    public function assemble(array $info, array $query = null) {}
+    public function assemble(array $info, ?array $query = null) {}
 }}
 
 namespace Yaf\Response {
@@ -2429,7 +2429,7 @@ namespace Yaf\View {
  * <b>\Yaf\View\Simple</b> is the built-in template engine in Yaf, it is a simple but fast template engine, and only support PHP script template.
  * @link https://secure.php.net/manual/en/class.yaf-view-simple.php
  *
- * @method void|bool eval(string $tpl_str, array $vars = null) <p>Render a string template and return the result.</p>
+ * @method void|bool eval(string $tpl_str, ?array $vars = null) <p>Render a string template and return the result.</p>
  *
  * @link https://secure.php.net/manual/en/yaf-view-simple.eval.php
  *
@@ -2466,7 +2466,7 @@ class Simple implements \Yaf\View_Interface
      * </p>
      * @throws \Yaf\Exception\TypeError
      */
-    final public function __construct($template_dir, array $options = null) {}
+    final public function __construct($template_dir, ?array $options = null) {}
 
     /**
      * @link https://secure.php.net/manual/en/yaf-view-simple.isset.php
@@ -2496,7 +2496,7 @@ class Simple implements \Yaf\View_Interface
      *
      * @return string|void
      */
-    public function render($tpl, array $tpl_vars = null) {}
+    public function render($tpl, ?array $tpl_vars = null) {}
 
     /**
      * <p>Render a template and display the result instantly.</p>
@@ -2510,7 +2510,7 @@ class Simple implements \Yaf\View_Interface
      *
      * @return bool
      */
-    public function display($tpl, array $tpl_vars = null) {}
+    public function display($tpl, ?array $tpl_vars = null) {}
 
     /**
      * <p>unlike \Yaf\View\Simple::assign(), this method assign a ref value to engine.</p>
@@ -2635,7 +2635,7 @@ final class Simple implements \Yaf\Route_Interface
      * @param array $query
      * @return bool
      */
-    public function assemble(array $info, array $query = null) {}
+    public function assemble(array $info, ?array $query = null) {}
 }/**
  * @link https://secure.php.net/manual/en/class.yaf-route-supervar.php
  */
@@ -2675,7 +2675,7 @@ final class Supervar implements \Yaf\Route_Interface
      * @param array $query
      * @return bool
      */
-    public function assemble(array $info, array $query = null) {}
+    public function assemble(array $info, ?array $query = null) {}
 }/**
  * <p>For usage, please see the example section of \Yaf\Route\Rewrite::__construct()</p>
  *
@@ -2710,7 +2710,7 @@ final class Rewrite extends \Yaf\Router implements \Yaf\Route_Interface
      *
      * @throws \Yaf\Exception\TypeError
      */
-    public function __construct($match, array $route, array $verify = null, $reverse = null) {}
+    public function __construct($match, array $route, ?array $verify = null, $reverse = null) {}
 
     /**
      * @link https://secure.php.net/manual/en/yaf-route-rewrite.route.php
@@ -2730,7 +2730,7 @@ final class Rewrite extends \Yaf\Router implements \Yaf\Route_Interface
      * @param array $query
      * @return bool
      */
-    public function assemble(array $info, array $query = null) {}
+    public function assemble(array $info, ?array $query = null) {}
 }/**
  * <p><b>\Yaf\Route\Regex</b> is the most flexible route among the Yaf built-in routes.</p>
  *
@@ -2776,7 +2776,7 @@ final class Regex extends \Yaf\Router implements \Yaf\Route_Interface
      *
      * @throws \Yaf\Exception\TypeError
      */
-    public function __construct($match, array $route, array $map = null, array $verify = null, $reverse = null) {}
+    public function __construct($match, array $route, ?array $map = null, ?array $verify = null, $reverse = null) {}
 
     /**
      * Route a incoming request.
@@ -2798,7 +2798,7 @@ final class Regex extends \Yaf\Router implements \Yaf\Route_Interface
      * @param array $query
      * @return bool
      */
-    public function assemble(array $info, array $query = null) {}
+    public function assemble(array $info, ?array $query = null) {}
 }/**
  * <p><b>\Yaf\Route\Map</b> is a built-in route, it simply convert a URI endpoint (that part of the URI which comes after the base URI: see \Yaf\Request_Abstract::setBaseUri()) to a controller name or action name(depends on the parameter passed to \Yaf\Route\Map::__construct()) in following rule: A => controller A. A/B/C => controller A_B_C. A/B/C/D/E => controller A_B_C_D_E.</p>
  * <br/>
@@ -2844,7 +2844,7 @@ final class Map implements \Yaf\Route_Interface
      * @param array $query
      * @return bool
      */
-    public function assemble(array $info, array $query = null) {}
+    public function assemble(array $info, ?array $query = null) {}
 }}
 
 namespace Yaf\Exception {

--- a/yar/yar.php
+++ b/yar/yar.php
@@ -125,7 +125,7 @@ class Yar_Concurrent_Client
      * @return int An unique id, can be used to identified which call it is.
      * @link https://secure.php.net/manual/en/yar-concurrent-client.call.php
      */
-    public static function call($uri, $method, $parameters, callable $callback = null, callable $error_callback, array $options) {}
+    public static function call($uri, $method, $parameters, ?callable $callback = null, ?callable $error_callback = null, array $options) {}
 
     /**
      * Send all calls

--- a/zip/zip.php
+++ b/zip/zip.php
@@ -747,7 +747,7 @@ class ZipArchive implements Countable
     #[TentativeType]
     public function addEmptyDir(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $dirname,
-        #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $flags
+        #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $flags = 0
     ): bool {}
 
     /**

--- a/zlib/zlib.php
+++ b/zlib/zlib.php
@@ -214,7 +214,7 @@ function gztell($stream): int|false {}
  * @return int|false the number of (uncompressed) bytes written to the given gz-file
  * stream.
  */
-function gzwrite($stream, string $data, ?int $length): int|false {}
+function gzwrite($stream, string $data, ?int $length = null): int|false {}
 
 /**
  * Alias of <b>gzwrite</b>
@@ -224,7 +224,7 @@ function gzwrite($stream, string $data, ?int $length): int|false {}
  * @param int|null $length [optional]
  * @return int|false
  */
-function gzputs($stream, string $data, ?int $length): int|false {}
+function gzputs($stream, string $data, ?int $length = null): int|false {}
 
 /**
  * Read entire gz-file into an array


### PR DESCRIPTION
These missing defaults are causing a bunch of false positives in PHPStorm and other diagnostic tools (like [PHPantom LSP](https://github.com/AJenbo/phpantom_lsp)).

<img width="806" height="113" alt="image" src="https://github.com/user-attachments/assets/951860e3-2201-4af9-8042-7056161fab2a" />

The fixes here are done using a script that cross-references three sources to find parameters that should be optional but lack default values:

1. **PHP reflection** to provides the actual default values
2. **PHPStan's `functionMap.php`** which marks optional params with a trailing `=`
3. **`[optional]` annotations** in the stub PHPDoc comments

And finally checked against the official php-doc by parsing the XML version and applying the additional details found there. And  `http/http3.php` for some of the extensions.

Overwrites and other things that cannot be properly expressed in the stubs (like defaults with no value) are left out in the hope of making this easy to review / accept.