### PR TITLE
Remove `Serializable` interface from GMP class

### DIFF
--- a/gmp/gmp.php
+++ b/gmp/gmp.php
@@ -798,7 +798,7 @@ define('GMP_VERSION', "6.3.0");
 
 define('GMP_MPIR_VERSION', '3.0.0');
 
-final class GMP implements Serializable
+final class GMP
 {
     /**
      * @since 8.2
@@ -806,24 +806,24 @@ final class GMP implements Serializable
     public function __construct(int|string $num = 0, int $base = 0) {}
 
     /**
-     * String representation of object
-     * @link https://php.net/manual/en/serializable.serialize.php
-     * @return string the string representation of the object or null
+     * Get array representation of object
+     * @link https://www.php.net/manual/en/language.oop5.magic.php#object.serialize
+     * @return string[] <p>
+     * The array representation of the GMP object. For GMP this is expected to be a 
+     * single-element list (zero-indexed) containing the string representation of the 
+     * GMP number
+     * </p>
      */
-    public function serialize() {}
-
     public function __serialize(): array {}
 
     /**
-     * Constructs the object
-     * @link https://php.net/manual/en/serializable.unserialize.php
-     * @param string $data <p>
-     * The string representation of the object.
+     * Reconstructs the GMP object from array representation
+     * @link https://www.php.net/manual/en/language.oop5.magic.php#object.serialize
+     * @param string[] $data <p>
+     * The array representation of the GMP object.
      * </p>
      * @return void
      */
-    public function unserialize($data) {}
-
     public function __unserialize(array $data): void {}
 }
 // End of gmp v.


### PR DESCRIPTION
Trying to use `$gmp->serialize()` or `$gmp->unserialize()` as defined in the stubs will result in `Error: Call to undefined method GMP::serialize()`

This is because GMP class does not actually implement the `Serializable` interface (although it does implement `__serialize()` and `__unserialize`). Note that with those functions present, PHP could have implement the serializable class for GMP, but probably omitted that deliberately as PHP does not provide an object-oriented interface to manipulate GMP objects, only a procedural GMP API. 

See: https://www.php.net/manual/en/class.gmp.php

> _"No object-oriented interface is provided to manipulate GMP objects. Please use the procedural GMP API."_

This can be confirmed in the PHP source code, the GMP class does not implement the `Serializable` interface, see: https://github.com/php/php-src/blob/master/ext/gmp/gmp.c#L584

```c
gmp_ce = register_class_GMP();
```

If `Serializable` interface was implemented in the GMP class in the PHP source code, then we would have expected to see:

```c
gmp_ce = register_class_GMP(zend_ce_serializable);
```