### PR TITLE
WI-84254 Add `Pdo\Firebird` class and missing `#[Deprecated]` annotations

### DIFF
--- a/PDO/PDO.php
+++ b/PDO/PDO.php
@@ -951,11 +951,13 @@ namespace {
         /**
          * Sets the time format.
          */
+        #[Deprecated('use Pdo\Firebird::ATTR_TIME_FORMAT instead', since: '8.5')]
         public const FB_ATTR_TIME_FORMAT = 1001;
 
         /**
          * Sets the timestamp format.
          */
+        #[Deprecated('use Pdo\Firebird::ATTR_TIMESTAMP_FORMAT instead', since: '8.5')]
         public const FB_ATTR_TIMESTAMP_FORMAT = 1002;
 
         /**
@@ -2235,5 +2237,22 @@ namespace Pdo {
         public function lobUnlink(string $oid): bool {}
 
         public function setNoticeCallback(?callable $callback): void {}
+    }
+
+    /**
+     * @since 8.4
+     */
+    class Firebird extends PDO
+    {
+        public const int ATTR_DATE_FORMAT = 1000;
+        public const int ATTR_TIME_FORMAT = 1001;
+        public const int ATTR_TIMESTAMP_FORMAT = 1002;
+        public const int TRANSACTION_ISOLATION_LEVEL = 1003;
+        public const int READ_COMMITTED = 1004;
+        public const int REPEATABLE_READ = 1005;
+        public const int SERIALIZABLE = 1006;
+        public const int WRITABLE_TRANSACTION = 1007;
+
+        public static function getApiVersion(): int {}
     }
 }

--- a/PhpStormStubsMap.php
+++ b/PhpStormStubsMap.php
@@ -843,6 +843,7 @@ const CLASSES = array (
   'Parle\\Token' => 'Parle/Token.php',
   'ParseError' => 'Core/Core_c.php',
   'Pcntl\\QosClass' => 'pcntl/pcntl_c.php',
+  'Pdo\\Firebird' => 'PDO/PDO.php',
   'Pdo\\Mysql' => 'PDO/PDO.php',
   'Pdo\\Pgsql' => 'PDO/PDO.php',
   'Pdo\\Sqlite' => 'PDO/PDO.php',


### PR DESCRIPTION
## Summary

- Add `Pdo\Firebird` class stub with 8 constants and `getApiVersion()` method (exists in PHP since 8.4, see [php.net docs](https://www.php.net/manual/en/class.pdo-firebird.php))
- Add missing `#[Deprecated]` annotations to `PDO::FB_ATTR_TIME_FORMAT` and `PDO::FB_ATTR_TIMESTAMP_FORMAT` (deprecated since PHP 8.5, confirmed via [php-src](https://github.com/php/php-src/blob/master/ext/pdo_firebird/pdo_firebird.c))
- Register `Pdo\Firebird` in `PhpStormStubsMap`

## Context

`Pdo\Mysql`, `Pdo\Pgsql`, and `Pdo\Sqlite` already have stubs — `Pdo\Firebird` was the only missing PDO driver subclass that has deprecated constant aliases in PHP 8.5.

This is needed for:
- **[WI-84254](https://youtrack.jetbrains.com/issue/WI-84254/Add-quick-fixes-for-PHP-8.5-deprecation-inspection)** (quick fixes for PHP 8.5 deprecation inspection) — the `PdoDriverConstantFix` replaces `PDO::FB_ATTR_*` with `Pdo\Firebird::ATTR_*`, which requires the class to exist in stubs to avoid Undefined class warnings.
- **[WI-84305](https://youtrack.jetbrains.com/issue/WI-84305/Deprecates-in-8.5-inspection-Dont-highlight-entities-that-are-marked-as-deprecated-in-phpstorm-stubs)** (skip stubs-deprecated entities) — once `FB_ATTR_TIME_FORMAT` and `FB_ATTR_TIMESTAMP_FORMAT` have `#[Deprecated]`, the inspection will correctly skip them when already handled by stubs.

## Constants

All values verified against the [enum in php-src](https://github.com/php/php-src/blob/master/ext/pdo_firebird/php_pdo_firebird_int.h) (`PDO_ATTR_DRIVER_SPECIFIC = 1000`, sequential):

| Constant | Value | Since |
|---|---|---|
| `ATTR_DATE_FORMAT` | 1000 | 8.4 |
| `ATTR_TIME_FORMAT` | 1001 | 8.4 |
| `ATTR_TIMESTAMP_FORMAT` | 1002 | 8.4 |
| `TRANSACTION_ISOLATION_LEVEL` | 1003 | 8.4 |
| `READ_COMMITTED` | 1004 | 8.4 |
| `REPEATABLE_READ` | 1005 | 8.4 |
| `SERIALIZABLE` | 1006 | 8.4 |
| `WRITABLE_TRANSACTION` | 1007 | 8.4 |
```