### PR TITLE
Update throws annotation on createFromDateString

### DIFF
--- a/date/date_c.php
+++ b/date/date_c.php
@@ -1127,7 +1127,21 @@ class DateInterval
      * @link https://php.net/manual/en/dateinterval.createfromdatestring.php
      */
     #[TentativeType]
-    #[LanguageLevelTypeAware(['8.4' => 'DateInterval'], default: 'DateInterval|false')]
+    #[PhpStormStubsElementAvailable(from: '5.3', to: '8.2')]
+    #[LanguageLevelTypeAware(['8.3' => 'DateInterval'], default: 'DateInterval|false')]
+    public static function createFromDateString(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $datetime) {}
+
+    /**
+     * Sets up a DateInterval from the relative parts of the string
+     * @param string $datetime
+     * @return DateInterval|false Returns a new {@link https://www.php.net/manual/en/class.dateinterval.php DateInterval}
+     * instance on success, or <b>FALSE</b> on failure.
+     * @throws DateMalformedStringException
+     * @link https://php.net/manual/en/dateinterval.createfromdatestring.php
+     */
+    #[TentativeType]
+    #[PhpStormStubsElementAvailable(from: '8.3')]
+    #[LanguageLevelTypeAware(['8.3' => 'DateInterval'], default: 'DateInterval|false')]
     public static function createFromDateString(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $datetime) {}
 
     #[TentativeType]

--- a/date/date_c.php
+++ b/date/date_c.php
@@ -1128,7 +1128,7 @@ class DateInterval
      */
     #[TentativeType]
     #[PhpStormStubsElementAvailable(from: '5.3', to: '8.2')]
-    #[LanguageLevelTypeAware(['8.3' => 'DateInterval'], default: 'DateInterval|false')]
+    #[LanguageLevelTypeAware(['8.4' => 'DateInterval'], default: 'DateInterval|false')]
     public static function createFromDateString(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $datetime) {}
 
     /**
@@ -1141,7 +1141,7 @@ class DateInterval
      */
     #[TentativeType]
     #[PhpStormStubsElementAvailable(from: '8.3')]
-    #[LanguageLevelTypeAware(['8.3' => 'DateInterval'], default: 'DateInterval|false')]
+    #[LanguageLevelTypeAware(['8.4' => 'DateInterval'], default: 'DateInterval|false')]
     public static function createFromDateString(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $datetime) {}
 
     #[TentativeType]


### PR DESCRIPTION
Hi @isfedorov 

See https://www.php.net/manual/en/dateinterval.createfromdatestring.php
Since PHP 8.3 the method can now throws `DateMalformedStringException`

Since there is no LanguageLevelTypeAware about throw type, I think I have to duplicate the stub with a PhpStormStubsElementAvailable element.

NB: The LanguageLevelAware should be about 8.3 and not 8.4, but if I try to fix it, tests are failing ; is there something we can do ?