### PR TITLE
fix getopt return type

### DIFF
--- a/standard/standard_3.php
+++ b/standard/standard_3.php
@@ -798,7 +798,7 @@ function putenv(string $assignment): bool {}
  * option --opt.
  * Prior to PHP5.3.0 this parameter was only available on few systems
  * @param int &$rest_index [optional] If the optind parameter is present, then the index where argument parsing stopped will be written to this variable.
- * @return string[]|false[]|false This function will return an array of option / argument pairs or false on
+ * @return (string|false|string[]|false[])[]|false This function will return an array of option / argument pairs or false on
  * failure.
  */
 #[Pure(true)]


### PR DESCRIPTION
As shown in the PHP documentation for `getopt`, if the CLI option is repeated, then the return type can be a 2 dimensional array. 
https://www.php.net/manual/en/function.getopt.php