### PR TITLE
Revert getConstant return type narrow

### DIFF
--- a/Reflection/ReflectionClass.php
+++ b/Reflection/ReflectionClass.php
@@ -305,7 +305,7 @@ class ReflectionClass implements Reflector
      *
      * @link https://php.net/manual/en/reflectionclass.getconstants.php
      * @param int|null $filter [optional] allows the filtering of constants defined in a class by their visibility. Since 8.0.
-     * @return array<string, scalar|array<scalar>> An array of constants, where the keys hold the name and
+     * @return array<string, scalar|null|array<scalar|null>> An array of constants, where the keys hold the name and
      * the values the value of the constants.
      */
     #[Pure]
@@ -317,7 +317,7 @@ class ReflectionClass implements Reflector
      *
      * @link https://php.net/manual/en/reflectionclass.getconstant.php
      * @param string $name Name of the constant.
-     * @return scalar|array<scalar> Value of the constant with the name name.
+     * @return scalar|null|array<scalar|null> Value of the constant with the name name.
      * Returns {@see false} if the constant was not found in the class.
      */
     #[Pure]

--- a/Reflection/ReflectionClass.php
+++ b/Reflection/ReflectionClass.php
@@ -305,7 +305,7 @@ class ReflectionClass implements Reflector
      *
      * @link https://php.net/manual/en/reflectionclass.getconstants.php
      * @param int|null $filter [optional] allows the filtering of constants defined in a class by their visibility. Since 8.0.
-     * @return array<string, scalar|null|array<scalar|null>> An array of constants, where the keys hold the name and
+     * @return array<string, mixed> An array of constants, where the keys hold the name and
      * the values the value of the constants.
      */
     #[Pure]
@@ -317,7 +317,7 @@ class ReflectionClass implements Reflector
      *
      * @link https://php.net/manual/en/reflectionclass.getconstant.php
      * @param string $name Name of the constant.
-     * @return scalar|null|array<scalar|null> Value of the constant with the name name.
+     * @return mixed Value of the constant with the name name.
      * Returns {@see false} if the constant was not found in the class.
      */
     #[Pure]


### PR DESCRIPTION
It can be a scalar OR NULL
Reflection/ReflectionClass.php

Edit: `object` is also possible see https://3v4l.org/aD9Bc#v8.5.3
And nested arrays are allowed too `array<array<scalar>>` for instance...

I propose to revert the change which didn't had lot of values.

cc @isfedorov @LolGleb