### PR TITLE
Update MongoDB extension stubs for 2.3.0

### DIFF
--- a/mongodb/Exception/BulkWriteException.php
+++ b/mongodb/Exception/BulkWriteException.php
@@ -13,8 +13,9 @@ class BulkWriteException extends ServerException implements Exception
 {
     /**
      * @var WriteResult associated with the failed write operation.
+     * @since 2.3.0
      */
-    protected $writeResult;
+    public readonly WriteResult $writeResult;
 
     /**
      * @return WriteResult for the failed write operation

--- a/mongodb/Exception/CommandException.php
+++ b/mongodb/Exception/CommandException.php
@@ -10,7 +10,11 @@ namespace MongoDB\Driver\Exception;
  */
 class CommandException extends ServerException
 {
-    protected $resultDocument;
+    /**
+     * @var object The result document for the failed command
+     * @since 2.3.0
+     */
+    public readonly object $resultDocument;
 
     /**
      * Returns the result document for the failed command

--- a/mongodb/Monitoring/CommandFailedEvent.php
+++ b/mongodb/Monitoring/CommandFailedEvent.php
@@ -12,6 +12,61 @@ use MongoDB\Driver\Server;
  */
 class CommandFailedEvent
 {
+    /**
+     * @since 2.3.0
+     */
+    public readonly string $host;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly int $port;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly string $commandName;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly string $databaseName;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly int $duration;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly \Exception $error;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly object $reply;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly string $operationId;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly string $requestId;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly ?ObjectId $serviceId;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly ?int $serverConnectionId;
+
     final private function __construct() {}
 
     final public function __wakeup() {}

--- a/mongodb/Monitoring/CommandStartedEvent.php
+++ b/mongodb/Monitoring/CommandStartedEvent.php
@@ -12,6 +12,51 @@ use MongoDB\Driver\Server;
  */
 class CommandStartedEvent
 {
+    /**
+     * @since 2.3.0
+     */
+    public readonly string $host;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly int $port;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly string $commandName;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly string $databaseName;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly object $command;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly string $operationId;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly string $requestId;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly ?ObjectId $serviceId;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly ?int $serverConnectionId;
+
     final private function __construct() {}
 
     final public function __wakeup() {}

--- a/mongodb/Monitoring/CommandSucceededEvent.php
+++ b/mongodb/Monitoring/CommandSucceededEvent.php
@@ -12,6 +12,56 @@ use MongoDB\Driver\Server;
  */
 class CommandSucceededEvent
 {
+    /**
+     * @since 2.3.0
+     */
+    public readonly string $host;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly int $port;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly string $commandName;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly string $databaseName;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly int $duration;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly object $reply;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly string $operationId;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly string $requestId;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly ?ObjectId $serviceId;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly ?int $serverConnectionId;
+
     final private function __construct() {}
 
     final public function __wakeup() {}

--- a/mongodb/Monitoring/ServerChangedEvent.php
+++ b/mongodb/Monitoring/ServerChangedEvent.php
@@ -10,6 +10,31 @@ use MongoDB\Driver\ServerDescription;
  */
 final class ServerChangedEvent
 {
+    /**
+     * @since 2.3.0
+     */
+    public readonly string $host;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly int $port;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly ObjectId $topologyId;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly ServerDescription $newDescription;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly ServerDescription $previousDescription;
+
     final private function __construct() {}
 
     /**

--- a/mongodb/Monitoring/ServerClosedEvent.php
+++ b/mongodb/Monitoring/ServerClosedEvent.php
@@ -9,6 +9,21 @@ use MongoDB\BSON\ObjectId;
  */
 final class ServerClosedEvent
 {
+    /**
+     * @since 2.3.0
+     */
+    public readonly string $host;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly int $port;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly ObjectId $topologyId;
+
     final private function __construct() {}
 
     /**

--- a/mongodb/Monitoring/ServerHeartbeatFailedEvent.php
+++ b/mongodb/Monitoring/ServerHeartbeatFailedEvent.php
@@ -7,6 +7,31 @@ namespace MongoDB\Driver\Monitoring;
  */
 final class ServerHeartbeatFailedEvent
 {
+    /**
+     * @since 2.3.0
+     */
+    public readonly string $host;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly int $port;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly bool $awaited;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly int $duration;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly \Exception $error;
+
     final private function __construct() {}
 
     /**

--- a/mongodb/Monitoring/ServerHeartbeatStartedEvent.php
+++ b/mongodb/Monitoring/ServerHeartbeatStartedEvent.php
@@ -7,6 +7,21 @@ namespace MongoDB\Driver\Monitoring;
  */
 final class ServerHeartbeatStartedEvent
 {
+    /**
+     * @since 2.3.0
+     */
+    public readonly string $host;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly int $port;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly bool $awaited;
+
     final private function __construct() {}
 
     /**

--- a/mongodb/Monitoring/ServerHeartbeatSucceededEvent.php
+++ b/mongodb/Monitoring/ServerHeartbeatSucceededEvent.php
@@ -7,6 +7,31 @@ namespace MongoDB\Driver\Monitoring;
  */
 final class ServerHeartbeatSucceededEvent
 {
+    /**
+     * @since 2.3.0
+     */
+    public readonly string $host;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly int $port;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly bool $awaited;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly int $duration;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly object $reply;
+
     final private function __construct() {}
 
     /**

--- a/mongodb/Monitoring/ServerOpeningEvent.php
+++ b/mongodb/Monitoring/ServerOpeningEvent.php
@@ -9,6 +9,21 @@ use MongoDB\BSON\ObjectId;
  */
 final class ServerOpeningEvent
 {
+    /**
+     * @since 2.3.0
+     */
+    public readonly string $host;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly int $port;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly ObjectId $topologyId;
+
     final private function __construct() {}
 
     /**

--- a/mongodb/Monitoring/TopologyChangedEvent.php
+++ b/mongodb/Monitoring/TopologyChangedEvent.php
@@ -10,6 +10,21 @@ use MongoDB\Driver\TopologyDescription;
  */
 final class TopologyChangedEvent
 {
+    /**
+     * @since 2.3.0
+     */
+    public readonly ObjectId $topologyId;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly TopologyDescription $newDescription;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly TopologyDescription $previousDescription;
+
     final private function __construct() {}
 
     /**

--- a/mongodb/Monitoring/TopologyClosedEvent.php
+++ b/mongodb/Monitoring/TopologyClosedEvent.php
@@ -9,6 +9,11 @@ use MongoDB\BSON\ObjectId;
  */
 final class TopologyClosedEvent
 {
+    /**
+     * @since 2.3.0
+     */
+    public readonly ObjectId $topologyId;
+
     final private function __construct() {}
 
     /**

--- a/mongodb/Monitoring/TopologyOpeningEvent.php
+++ b/mongodb/Monitoring/TopologyOpeningEvent.php
@@ -9,6 +9,11 @@ use MongoDB\BSON\ObjectId;
  */
 final class TopologyOpeningEvent
 {
+    /**
+     * @since 2.3.0
+     */
+    public readonly ObjectId $topologyId;
+
     final private function __construct() {}
 
     /**

--- a/mongodb/ReadConcern.php
+++ b/mongodb/ReadConcern.php
@@ -30,6 +30,11 @@ final class ReadConcern implements Serializable
     public const SNAPSHOT = 'snapshot';
 
     /**
+     * @since 2.3.0
+     */
+    public readonly string|null $level;
+
+    /**
      * Construct immutable ReadConcern
      * @link https://php.net/manual/en/mongodb-driver-readconcern.construct.php
      */

--- a/mongodb/ReadPreference.php
+++ b/mongodb/ReadPreference.php
@@ -48,6 +48,27 @@ final class ReadPreference implements Serializable
     public const SMALLEST_MAX_STALENESS_SECONDS = 90;
 
     /**
+     * @since 2.3.0
+     */
+    public readonly string $mode;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly array|null $tags;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly int $maxStalenessSeconds;
+
+    /**
+     * @since 2.3.0
+     * @deprecated
+     */
+    public readonly object|null $hedge;
+
+    /**
      * Construct immutable ReadPreference
      * @link https://php.net/manual/en/mongodb-driver-readpreference.construct.php
      * @param string $mode
@@ -63,6 +84,7 @@ final class ReadPreference implements Serializable
      * Returns the ReadPreference's "hedge" option
      * @since 1.8.0
      * @link https://www.php.net/manual/en/mongodb-driver-readpreference.gethedge.php
+     * @deprecated
      */
     final public function getHedge(): ?object {}
 

--- a/mongodb/WriteConcern.php
+++ b/mongodb/WriteConcern.php
@@ -17,6 +17,21 @@ final class WriteConcern implements Serializable
     public const MAJORITY = 'majority';
 
     /**
+     * @since 2.3.0
+     */
+    public readonly string|int|null $w;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly bool|null $j;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly int $wtimeout;
+
+    /**
      * Construct immutable WriteConcern
      * @link https://php.net/manual/en/mongodb-driver-writeconcern.construct.php
      * @param string|int $w

--- a/mongodb/WriteConcernError.php
+++ b/mongodb/WriteConcernError.php
@@ -8,6 +8,21 @@ namespace MongoDB\Driver;
  */
 final class WriteConcernError
 {
+    /**
+     * @since 2.3.0
+     */
+    public readonly string $message;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly int $code;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly ?object $info;
+
     final private function __construct() {}
 
     final public function __wakeup() {}

--- a/mongodb/WriteError.php
+++ b/mongodb/WriteError.php
@@ -7,6 +7,26 @@ namespace MongoDB\Driver;
  */
 final class WriteError
 {
+    /**
+     * @since 2.3.0
+     */
+    public readonly string $message;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly int $code;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly int $index;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly ?object $info;
+
     final private function __construct() {}
 
     final public function __wakeup() {}

--- a/mongodb/WriteResult.php
+++ b/mongodb/WriteResult.php
@@ -8,6 +8,61 @@ namespace MongoDB\Driver;
  */
 final class WriteResult
 {
+    /**
+     * @since 2.3.0
+     */
+    public readonly ?int $insertedCount;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly ?int $matchedCount;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly ?int $modifiedCount;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly ?int $deletedCount;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly ?int $upsertedCount;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly Server $server;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly array $upsertedIds;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly array $writeErrors;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly ?WriteConcernError $writeConcernError;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly ?WriteConcern $writeConcern;
+
+    /**
+     * @since 2.3.0
+     */
+    public readonly array $errorReplies;
+
     final private function __construct() {}
 
     final public function __wakeup() {}


### PR DESCRIPTION
Updates the MongoDB stubs for version 2.3.0, adding new public properties and deprecating hedged reads.