### PR TITLE
Add missing @template-implements ArrayAccess to WeakMap

### DIFF
--- a/Core/Core_c.php
+++ b/Core/Core_c.php
@@ -778,6 +778,7 @@ final class WeakReference
  * @template TKey of object
  * @template TValue
  * @template-implements IteratorAggregate<TKey, TValue>
+ * @template-implements ArrayAccess<TKey, TValue>
  */
 final class WeakMap implements ArrayAccess, Countable, IteratorAggregate
 {


### PR DESCRIPTION
There is an annotation for `IteratorAggregate` but it is missing one for `ArrayAccess`.