### PR TITLE
revert: incorrect deprecation for ReflectionParameter::allowsNull()

### DIFF
--- a/Reflection/ReflectionParameter.php
+++ b/Reflection/ReflectionParameter.php
@@ -186,7 +186,6 @@ class ReflectionParameter implements Reflector
      * otherwise {@see false}
      */
     #[TentativeType]
-    #[Deprecated("use ReflectionParameter::getType() instead", '%class%->getType(%parametersList%)', since: '8.5')]
     public function allowsNull(): bool {}
 
     /**


### PR DESCRIPTION
A [recent change](https://github.com/JetBrains/phpstorm-stubs/commit/593901e6056867575ad7a591596d9805898b0e7b#diff-604dc970f5b07ba8e8e0abbd5acf885ccc77e88fc7f4d412a8ac5ad9631c4ef1) marked `ReflectionParameter::allowsNull()` as deprecated since 8.5. However, this is not the case.

An [RFC for this](https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionparameterallowsnull) was submitted for PHP 8.5, but the vote didn't pass.

Neither the [current PHP documentation](https://www.php.net/manual/en/reflectionparameter.allowsnull.php) nor the official [PHP 8.5 deprecations page](https://www.php.net/manual/en/migration85.deprecated.php) mention it either.

A simple check using `php -r "print_r(new ReflectionClass(ReflectionParameter::class)->getMethod('allowsNull')->getAttributes());"` also returns an empty array, so no `Deprecated` attribute.

So this MR reverts that line.