### PR TITLE
[phpstorm-stubs] replace Tentative return types to signature with LanguageLevelTypeAware

### DIFF
--- a/Core/Core_c.php
+++ b/Core/Core_c.php
@@ -48,7 +48,8 @@ interface IteratorAggregate extends Traversable
      * @throws Exception on failure.
      */
     #[TentativeType]
-    public function getIterator(): Traversable;
+    #[LanguageLevelTypeAware(['8.1' => 'Traversable'], default: '')]
+    public function getIterator();
 }
 
 /**
@@ -67,7 +68,8 @@ interface Iterator extends Traversable
      * @return TValue Can return any type.
      */
     #[TentativeType]
-    public function current(): mixed;
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function current();
 
     /**
      * Move forward to next element
@@ -75,7 +77,8 @@ interface Iterator extends Traversable
      * @return void Any returned value is ignored.
      */
     #[TentativeType]
-    public function next(): void;
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function next();
 
     /**
      * Return the key of the current element
@@ -83,7 +86,8 @@ interface Iterator extends Traversable
      * @return TKey|null TKey on success, or null on failure.
      */
     #[TentativeType]
-    public function key(): mixed;
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function key();
 
     /**
      * Checks if current position is valid
@@ -92,7 +96,8 @@ interface Iterator extends Traversable
      * Returns true on success or false on failure.
      */
     #[TentativeType]
-    public function valid(): bool;
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function valid();
 
     /**
      * Rewind the Iterator to the first element
@@ -100,7 +105,8 @@ interface Iterator extends Traversable
      * @return void Any returned value is ignored.
      */
     #[TentativeType]
-    public function rewind(): void;
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function rewind();
 }
 
 /**
@@ -123,7 +129,8 @@ interface ArrayAccess
      * The return value will be casted to boolean if non-boolean was returned.
      */
     #[TentativeType]
-    public function offsetExists(#[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $offset): bool;
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function offsetExists(#[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $offset);
 
     /**
      * Offset to retrieve
@@ -134,7 +141,8 @@ interface ArrayAccess
      * @return TValue Can return all value types.
      */
     #[TentativeType]
-    public function offsetGet(#[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $offset): mixed;
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function offsetGet(#[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $offset);
 
     /**
      * Offset to set
@@ -148,10 +156,11 @@ interface ArrayAccess
      * @return void
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
     public function offsetSet(
         #[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $offset,
         #[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $value
-    ): void;
+    );
 
     /**
      * Offset to unset
@@ -162,7 +171,8 @@ interface ArrayAccess
      * @return void
      */
     #[TentativeType]
-    public function offsetUnset(#[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $offset): void;
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function offsetUnset(#[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $offset);
 }
 
 /**
@@ -407,7 +417,8 @@ class Exception implements Throwable
     public function __toString() {}
 
     #[TentativeType]
-    public function __wakeup(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function __wakeup() {}
 }
 
 /**
@@ -545,7 +556,8 @@ class Error implements Throwable
     private function __clone(): void {}
 
     #[TentativeType]
-    public function __wakeup(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function __wakeup() {}
 }
 
 /**
@@ -744,7 +756,8 @@ interface Countable
      * </p>
      */
     #[TentativeType]
-    public function count(): int;
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function count();
 }
 
 /**

--- a/PDO/PDO.php
+++ b/PDO/PDO.php
@@ -1087,10 +1087,11 @@ namespace {
          * so <b>PDO::prepare</b> does not check the statement.
          */
         #[TentativeType]
+        #[LanguageLevelTypeAware(['8.1' => 'PDOStatement|false'], default: '')]
         public function prepare(
             #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $query,
             #[LanguageLevelTypeAware(['8.0' => 'array'], default: '')] $options = []
-        ): PDOStatement|false {}
+        ) {}
 
         /**
          * (PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.1.0)<br/>
@@ -1117,7 +1118,8 @@ namespace {
          * attribute is not <b>PDO::ERRMODE_EXCEPTION</b>.
          */
         #[TentativeType]
-        public function beginTransaction(): bool {}
+        #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+        public function beginTransaction() {}
 
         /**
          * (PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.1.0)<br/>
@@ -1127,7 +1129,8 @@ namespace {
          * @throws PDOException if there is no active transaction.
          */
         #[TentativeType]
-        public function commit(): bool {}
+        #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+        public function commit() {}
 
         /**
          * (PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.1.0)<br/>
@@ -1137,7 +1140,8 @@ namespace {
          * @throws PDOException if there is no active transaction.
          */
         #[TentativeType]
-        public function rollBack(): bool {}
+        #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+        public function rollBack() {}
 
         /**
          * (PHP 5 &gt;= 5.3.3, Bundled pdo_pgsql, PHP 7)<br/>
@@ -1146,7 +1150,8 @@ namespace {
          * @return bool <b>TRUE</b> if a transaction is currently active, and <b>FALSE</b> if not.
          */
         #[TentativeType]
-        public function inTransaction(): bool {}
+        #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+        public function inTransaction() {}
 
         /**
          * (PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.1.0)<br/>
@@ -1158,10 +1163,11 @@ namespace {
          * @throws PDOException On error if PDO::ERRMODE_EXCEPTION option is true.
          */
         #[TentativeType]
+        #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
         public function setAttribute(
             #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $attribute,
             #[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $value
-        ): bool {}
+        ) {}
 
         /**
          * (PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.1.0)<br/>
@@ -1193,7 +1199,8 @@ namespace {
          * @throws PDOException On error if PDO::ERRMODE_EXCEPTION option is true.
          */
         #[TentativeType]
-        public function exec(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $statement): int|false {}
+        #[LanguageLevelTypeAware(['8.1' => 'int|false'], default: '')]
+        public function exec(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $statement) {}
 
         /**
          * (PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.2.0)<br/>
@@ -1222,7 +1229,8 @@ namespace {
          */
         #[PhpStormStubsElementAvailable(to: '7.4')]
         #[TentativeType]
-        public function query($query, $fetchMode = PDO::ATTR_DEFAULT_FETCH_MODE, $arg3 = null, $ctorargs = []): PDOStatement|false {}
+        #[LanguageLevelTypeAware(['8.1' => 'PDOStatement|false'], default: '')]
+        public function query($query, $fetchMode = PDO::ATTR_DEFAULT_FETCH_MODE, $arg3 = null, $ctorargs = []) {}
 
         /**
          * (PHP 5 >= 5.1.0, PHP 7, PHP 8, PECL pdo &gt;= 0.2.0)<br/>
@@ -1248,11 +1256,12 @@ namespace {
          */
         #[PhpStormStubsElementAvailable('8.0')]
         #[TentativeType]
+        #[LanguageLevelTypeAware(['8.1' => 'PDOStatement|false'], default: '')]
         public function query(
             #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $query,
             #[LanguageLevelTypeAware(['8.0' => 'int|null'], default: '')] $fetchMode = null,
             #[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] ...$fetchModeArgs
-        ): PDOStatement|false {}
+        ) {}
 
         /**
          * (PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.1.0)<br/>
@@ -1279,7 +1288,8 @@ namespace {
          * @throws PDOException On error if PDO::ERRMODE_EXCEPTION option is true.
          */
         #[TentativeType]
-        public function lastInsertId(#[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $name = null): string|false {}
+        #[LanguageLevelTypeAware(['8.1' => 'string|false'], default: '')]
+        public function lastInsertId(#[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $name = null) {}
 
         /**
          * (PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.1.0)<br/>
@@ -1308,7 +1318,8 @@ namespace {
          * Returns <b>NULL</b> if no operation has been run on the database handle.
          */
         #[TentativeType]
-        public function errorCode(): ?string {}
+        #[LanguageLevelTypeAware(['8.1' => 'string|null'], default: '')]
+        public function errorCode() {}
 
         /**
          * (PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.1.0)<br/>
@@ -1351,7 +1362,8 @@ namespace {
          */
         #[ArrayShape([0 => "string", 1 => "int", 2 => "string"])]
         #[TentativeType]
-        public function errorInfo(): array {}
+        #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+        public function errorInfo() {}
 
         /**
          * (PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.2.0)<br/>
@@ -1378,7 +1390,8 @@ namespace {
          * @throws PDOException when the underlying driver does not support the requested attribute.
          */
         #[TentativeType]
-        public function getAttribute(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $attribute): mixed {}
+        #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+        public function getAttribute(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $attribute) {}
 
         /**
          * (PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.2.1)<br/>
@@ -1395,10 +1408,11 @@ namespace {
          * this way.
          */
         #[TentativeType]
+        #[LanguageLevelTypeAware(['8.1' => 'string|false'], default: '')]
         public function quote(
             #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $string,
             #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $type = PDO::PARAM_STR
-        ): string|false {}
+        ) {}
 
         final public function __wakeup() {}
 
@@ -1412,7 +1426,8 @@ namespace {
          * no drivers are available, it returns an empty array.
          */
         #[TentativeType]
-        public static function getAvailableDrivers(): array {}
+        #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+        public static function getAvailableDrivers() {}
 
         /**
          * (PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo_sqlite &gt;= 1.0.0)<br/>
@@ -1674,7 +1689,8 @@ namespace {
          * @throws PDOException On error if PDO::ERRMODE_EXCEPTION option is true.
          */
         #[TentativeType]
-        public function execute(#[LanguageLevelTypeAware(['8.0' => 'array|null'], default: '')] $params = null): bool {}
+        #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+        public function execute(#[LanguageLevelTypeAware(['8.0' => 'array|null'], default: '')] $params = null) {}
 
         /**
          * (PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.1.0)<br/>
@@ -1706,11 +1722,12 @@ namespace {
          * @throws PDOException On error if PDO::ERRMODE_EXCEPTION option is true.
          */
         #[TentativeType]
+        #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
         public function fetch(
             #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $mode = PDO::FETCH_DEFAULT,
             #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $cursorOrientation = PDO::FETCH_ORI_NEXT,
             #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $cursorOffset = 0
-        ): mixed {}
+        ) {}
 
         /**
          * (PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.1.0)<br/>
@@ -1744,13 +1761,14 @@ namespace {
          * @throws PDOException On error if PDO::ERRMODE_EXCEPTION option is true.
          */
         #[TentativeType]
+        #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
         public function bindParam(
             #[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $param,
             #[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] &$var,
             #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $type = PDO::PARAM_STR,
             #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $maxLength = 0,
             #[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $driverOptions = null
-        ): bool {}
+        ) {}
 
         /**
          * (PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.1.0)<br/>
@@ -1777,13 +1795,14 @@ namespace {
          * @throws PDOException On error if PDO::ERRMODE_EXCEPTION option is true.
          */
         #[TentativeType]
+        #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
         public function bindColumn(
             #[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $column,
             #[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] &$var,
             #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $type = PDO::PARAM_STR,
             #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $maxLength = 0,
             #[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $driverOptions = null
-        ): bool {}
+        ) {}
 
         /**
          * (PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 1.0.0)<br/>
@@ -1807,11 +1826,12 @@ namespace {
          * @throws PDOException On error if PDO::ERRMODE_EXCEPTION option is true.
          */
         #[TentativeType]
+        #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
         public function bindValue(
             #[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $param,
             #[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $value,
             #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $type = PDO::PARAM_STR
-        ): bool {}
+        ) {}
 
         /**
          * (PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.1.0)<br/>
@@ -1821,7 +1841,8 @@ namespace {
          * @throws PDOException On error if PDO::ERRMODE_EXCEPTION option is true.
          */
         #[TentativeType]
-        public function rowCount(): int {}
+        #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+        public function rowCount() {}
 
         /**
          * (PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.9.0)<br/>
@@ -1841,7 +1862,8 @@ namespace {
          * @throws PDOException On error if PDO::ERRMODE_EXCEPTION option is true.
          */
         #[TentativeType]
-        public function fetchColumn(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $column = 0): mixed {}
+        #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+        public function fetchColumn(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $column = 0) {}
 
         /**
          * (PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.1.0)<br/>
@@ -1891,11 +1913,12 @@ namespace {
          * processing them with PHP.
          */
         #[TentativeType]
+        #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
         public function fetchAll(
             #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $mode = PDO::FETCH_DEFAULT,
             #[PhpStormStubsElementAvailable(from: '5.3', to: '7.4')] $fetch_argument = null,
             #[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] ...$args
-        ): array {}
+        ) {}
 
         /**
          * @template T
@@ -1914,10 +1937,11 @@ namespace {
          * @throws PDOException On error if PDO::ERRMODE_EXCEPTION option is true.
          */
         #[TentativeType]
+        #[LanguageLevelTypeAware(['8.1' => 'object|false'], default: '')]
         public function fetchObject(
             #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $class = "stdClass",
             #[LanguageLevelTypeAware(['8.0' => 'array'], default: '')] $constructorArgs = []
-        ): object|false {}
+        ) {}
 
         /**
          * (PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.1.0)<br/>
@@ -1928,7 +1952,8 @@ namespace {
          * for operations performed with PDOStatement objects.
          */
         #[TentativeType]
-        public function errorCode(): ?string {}
+        #[LanguageLevelTypeAware(['8.1' => 'string|null'], default: '')]
+        public function errorCode() {}
 
         /**
          * (PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.1.0)<br/>
@@ -1957,7 +1982,8 @@ namespace {
          */
         #[ArrayShape([0 => "string", 1 => "int", 2 => "string"])]
         #[TentativeType]
-        public function errorInfo(): array {}
+        #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+        public function errorInfo() {}
 
         /**
          * (PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.2.0)<br/>
@@ -1969,10 +1995,11 @@ namespace {
          * @throws PDOException On error if PDO::ERRMODE_EXCEPTION option is true.
          */
         #[TentativeType]
+        #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
         public function setAttribute(
             #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $attribute,
             #[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $value
-        ): bool {}
+        ) {}
 
         /**
          * (PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.2.0)<br/>
@@ -1982,7 +2009,8 @@ namespace {
          * @return mixed the attribute value.
          */
         #[TentativeType]
-        public function getAttribute(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $name): mixed {}
+        #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+        public function getAttribute(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $name) {}
 
         /**
          * (PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.2.0)<br/>
@@ -1994,7 +2022,8 @@ namespace {
          * @throws PDOException On error if PDO::ERRMODE_EXCEPTION option is true.
          */
         #[TentativeType]
-        public function columnCount(): int {}
+        #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+        public function columnCount() {}
 
         /**
          * (PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.2.0)<br/>
@@ -2057,6 +2086,7 @@ namespace {
          * or if no result set exists.
          */
         #[TentativeType]
+        #[LanguageLevelTypeAware(['8.1' => 'array|false'], default: '')]
         #[ArrayShape([
             "name" => "string",
             "len" => "int",
@@ -2067,7 +2097,7 @@ namespace {
             "flags" => "array",
             "pdo_type" => "int"
         ])]
-        public function getColumnMeta(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $column): array|false {}
+        public function getColumnMeta(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $column) {}
 
         /**
          * (PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.2.0)<br/>
@@ -2092,7 +2122,8 @@ namespace {
          * @throws PDOException On error if PDO::ERRMODE_EXCEPTION option is true.
          */
         #[TentativeType]
-        public function nextRowset(): bool {}
+        #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+        public function nextRowset() {}
 
         /**
          * (PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.9.0)<br/>
@@ -2102,7 +2133,8 @@ namespace {
          * @throws PDOException On error if PDO::ERRMODE_EXCEPTION option is true.
          */
         #[TentativeType]
-        public function closeCursor(): bool {}
+        #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+        public function closeCursor() {}
 
         /**
          * (PHP 5 &gt;= 5.1.0, PHP 7, PECL pdo &gt;= 0.9.0)<br/>
@@ -2111,7 +2143,8 @@ namespace {
          * @return bool|null No value is returned.
          */
         #[TentativeType]
-        public function debugDumpParams(): ?bool {}
+        #[LanguageLevelTypeAware(['8.1' => 'bool|null'], default: '')]
+        public function debugDumpParams() {}
 
         final public function __wakeup() {}
 

--- a/Phar/Phar.php
+++ b/Phar/Phar.php
@@ -78,10 +78,11 @@ class Phar extends RecursiveDirectoryIterator implements RecursiveIterator, Seek
      * @return void no return value, exception is thrown on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
     public function addEmptyDir(
         #[PhpStormStubsElementAvailable(from: '5.3', to: '7.4')] $directory = '',
         #[PhpStormStubsElementAvailable(from: '8.0')] string $directory
-    ): void {}
+    ) {}
 
     /**
      * (Unknown)<br/>
@@ -97,10 +98,11 @@ class Phar extends RecursiveDirectoryIterator implements RecursiveIterator, Seek
      * @return void no return value, exception is thrown on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
     public function addFile(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $filename,
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $localName = null
-    ): void {}
+    ) {}
 
     /**
      * (Unknown)<br/>
@@ -115,11 +117,12 @@ class Phar extends RecursiveDirectoryIterator implements RecursiveIterator, Seek
      * @return void no return value, exception is thrown on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
     public function addFromString(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $localName,
         #[PhpStormStubsElementAvailable(from: '5.3', to: '7.4')] $contents = '',
         #[PhpStormStubsElementAvailable(from: '8.0')] string $contents
-    ): void {}
+    ) {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 2.0.0)<br/>
@@ -139,10 +142,11 @@ class Phar extends RecursiveDirectoryIterator implements RecursiveIterator, Seek
      * filesystem.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
     public function buildFromDirectory(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $directory,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $pattern = ''
-    ): array {}
+    ) {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 2.0.0)<br/>
@@ -161,10 +165,11 @@ class Phar extends RecursiveDirectoryIterator implements RecursiveIterator, Seek
      * filesystem.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
     public function buildFromIterator(
         Traversable $iterator,
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $baseDirectory = null
-    ): array {}
+    ) {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 2.0.0)<br/>
@@ -178,7 +183,8 @@ class Phar extends RecursiveDirectoryIterator implements RecursiveIterator, Seek
      * @return void No value is returned.
      */
     #[TentativeType]
-    public function compressFiles(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $compression): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function compressFiles(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $compression) {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 2.0.0)<br/>
@@ -264,11 +270,12 @@ class Phar extends RecursiveDirectoryIterator implements RecursiveIterator, Seek
      * exception on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'Phar|null'], default: '')]
     public function convertToExecutable(
         #[LanguageLevelTypeAware(['8.0' => 'int|null'], default: '')] $format = null,
         #[LanguageLevelTypeAware(['8.0' => 'int|null'], default: '')] $compression = null,
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $extension = null
-    ): ?Phar {}
+    ) {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 2.0.0)<br/>
@@ -300,11 +307,12 @@ class Phar extends RecursiveDirectoryIterator implements RecursiveIterator, Seek
      * exception on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'PharData|null'], default: '')]
     public function convertToData(
         #[LanguageLevelTypeAware(['8.0' => 'int|null'], default: '')] $format = null,
         #[LanguageLevelTypeAware(['8.0' => 'int|null'], default: '')] $compression = null,
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $extension = null
-    ): ?PharData {}
+    ) {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 2.0.0)<br/>
@@ -331,7 +339,8 @@ class Phar extends RecursiveDirectoryIterator implements RecursiveIterator, Seek
      * if none.
      */
     #[TentativeType]
-    public function count(#[PhpStormStubsElementAvailable(from: '8.0')] int $mode = COUNT_NORMAL): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function count(#[PhpStormStubsElementAvailable(from: '8.0')] int $mode = COUNT_NORMAL) {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 2.0.0)<br/>
@@ -375,18 +384,20 @@ class Phar extends RecursiveDirectoryIterator implements RecursiveIterator, Seek
      * and assume success if none is thrown.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function extractTo(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $directory,
         #[LanguageLevelTypeAware(['8.0' => 'array|string|null'], default: '')] $files = null,
         #[LanguageLevelTypeAware(['8.0' => 'bool'], default: '')] $overwrite = false
-    ): bool {}
+    ) {}
 
     /**
      * @return string|null
      * @see setAlias
      */
     #[TentativeType]
-    public function getAlias(): ?string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string|null'], default: '')]
+    public function getAlias() {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 1.0.0)<br/>
@@ -398,7 +409,8 @@ class Phar extends RecursiveDirectoryIterator implements RecursiveIterator, Seek
      * or <b>NULL</b> if no meta-data is stored.
      */
     #[TentativeType]
-    public function getMetadata(#[PhpStormStubsElementAvailable(from: '8.0')] array $unserializeOptions = []): mixed {}
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function getMetadata(#[PhpStormStubsElementAvailable(from: '8.0')] array $unserializeOptions = []) {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 1.0.0)<br/>
@@ -407,7 +419,8 @@ class Phar extends RecursiveDirectoryIterator implements RecursiveIterator, Seek
      * @return bool <b>TRUE</b> if the phar has been modified since opened, <b>FALSE</b> if not.
      */
     #[TentativeType]
-    public function getModified(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function getModified() {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 1.0.0)<br/>
@@ -424,7 +437,8 @@ class Phar extends RecursiveDirectoryIterator implements RecursiveIterator, Seek
      */
     #[ArrayShape(["hash" => "string", "hash_type" => "string"])]
     #[TentativeType]
-    public function getSignature(): array|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'array|false'], default: '')]
+    public function getSignature() {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 1.0.0)<br/>
@@ -434,7 +448,8 @@ class Phar extends RecursiveDirectoryIterator implements RecursiveIterator, Seek
      * the current Phar archive.
      */
     #[TentativeType]
-    public function getStub(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function getStub() {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 1.0.0)<br/>
@@ -447,7 +462,8 @@ class Phar extends RecursiveDirectoryIterator implements RecursiveIterator, Seek
      * documentation for more information.
      */
     #[TentativeType]
-    public function getVersion(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function getVersion() {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 1.2.0)<br/>
@@ -456,7 +472,8 @@ class Phar extends RecursiveDirectoryIterator implements RecursiveIterator, Seek
      * @return bool <b>TRUE</b> if meta-data has been set, and <b>FALSE</b> if not.
      */
     #[TentativeType]
-    public function hasMetadata(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function hasMetadata() {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 1.0.0)<br/>
@@ -465,7 +482,8 @@ class Phar extends RecursiveDirectoryIterator implements RecursiveIterator, Seek
      * @return bool <b>TRUE</b> if the write operations are being buffer, <b>FALSE</b> otherwise.
      */
     #[TentativeType]
-    public function isBuffering(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isBuffering() {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 2.0.0)<br/>
@@ -474,7 +492,8 @@ class Phar extends RecursiveDirectoryIterator implements RecursiveIterator, Seek
      * @return mixed Phar::GZ, Phar::BZ2 or <b>FALSE</b>
      */
     #[TentativeType]
-    public function isCompressed(): int|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'int|false'], default: '')]
+    public function isCompressed() {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 2.0.0)<br/>
@@ -487,7 +506,8 @@ class Phar extends RecursiveDirectoryIterator implements RecursiveIterator, Seek
      * @return bool <b>TRUE</b> if the phar archive matches the file format requested by the parameter
      */
     #[TentativeType]
-    public function isFileFormat(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $format): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isFileFormat(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $format) {}
 
     /**
      * (Unknown)<br/>
@@ -496,7 +516,8 @@ class Phar extends RecursiveDirectoryIterator implements RecursiveIterator, Seek
      * @return bool <b>TRUE</b> if the phar archive can be modified
      */
     #[TentativeType]
-    public function isWritable(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isWritable() {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 1.0.0)<br/>
@@ -508,7 +529,8 @@ class Phar extends RecursiveDirectoryIterator implements RecursiveIterator, Seek
      * @return bool <b>TRUE</b> if the file exists within the phar, or <b>FALSE</b> if not.
      */
     #[TentativeType]
-    public function offsetExists($localName): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function offsetExists($localName) {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 1.0.0)<br/>
@@ -521,7 +543,8 @@ class Phar extends RecursiveDirectoryIterator implements RecursiveIterator, Seek
      * iterate over a file's contents or to retrieve information about the current file.
      */
     #[TentativeType]
-    public function offsetGet($localName): SplFileInfo {}
+    #[LanguageLevelTypeAware(['8.1' => 'SplFileInfo'], default: '')]
+    public function offsetGet($localName) {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 1.0.0)<br/>
@@ -536,7 +559,8 @@ class Phar extends RecursiveDirectoryIterator implements RecursiveIterator, Seek
      * @return void No return values.
      */
     #[TentativeType]
-    public function offsetSet($localName, $value): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function offsetSet($localName, $value) {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 1.0.0)<br/>
@@ -548,7 +572,8 @@ class Phar extends RecursiveDirectoryIterator implements RecursiveIterator, Seek
      * @return void
      */
     #[TentativeType]
-    public function offsetUnset($localName): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function offsetUnset($localName) {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 1.2.1)<br/>
@@ -593,7 +618,8 @@ class Phar extends RecursiveDirectoryIterator implements RecursiveIterator, Seek
      * @return void No value is returned.
      */
     #[TentativeType]
-    public function setMetadata(#[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $metadata): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function setMetadata(#[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $metadata) {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 1.1.0)<br/>
@@ -619,10 +645,11 @@ class Phar extends RecursiveDirectoryIterator implements RecursiveIterator, Seek
      * @return void No value is returned.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
     public function setSignatureAlgorithm(
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $algo,
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $privateKey = null
-    ): void {}
+    ) {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 1.0.0)<br/>
@@ -650,7 +677,8 @@ class Phar extends RecursiveDirectoryIterator implements RecursiveIterator, Seek
      * @return void No value is returned.
      */
     #[TentativeType]
-    public function startBuffering(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function startBuffering() {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 1.0.0)<br/>
@@ -659,7 +687,8 @@ class Phar extends RecursiveDirectoryIterator implements RecursiveIterator, Seek
      * @return void No value is returned.
      */
     #[TentativeType]
-    public function stopBuffering(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function stopBuffering() {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 1.0.0)<br/>
@@ -929,7 +958,8 @@ class Phar extends RecursiveDirectoryIterator implements RecursiveIterator, Seek
      * @return bool whether the current entry is a directory, but not '.' or '..'
      */
     #[TentativeType]
-    public function hasChildren(#[LanguageLevelTypeAware(['8.0' => 'bool'], default: '')] $allowLinks = false): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function hasChildren(#[LanguageLevelTypeAware(['8.0' => 'bool'], default: '')] $allowLinks = false) {}
 
     /**
      * Returns an iterator for the current entry if it is a directory
@@ -937,7 +967,8 @@ class Phar extends RecursiveDirectoryIterator implements RecursiveIterator, Seek
      * @return RecursiveDirectoryIterator An iterator for the current entry, if it is a directory.
      */
     #[TentativeType]
-    public function getChildren(): RecursiveDirectoryIterator {}
+    #[LanguageLevelTypeAware(['8.1' => 'RecursiveDirectoryIterator'], default: '')]
+    public function getChildren() {}
 
     /**
      * Rewinds back to the beginning
@@ -945,7 +976,8 @@ class Phar extends RecursiveDirectoryIterator implements RecursiveIterator, Seek
      * @return void No value is returned.
      */
     #[TentativeType]
-    public function rewind(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function rewind() {}
 
     /**
      * Move to the next file
@@ -953,7 +985,8 @@ class Phar extends RecursiveDirectoryIterator implements RecursiveIterator, Seek
      * @return void No value is returned.
      */
     #[TentativeType]
-    public function next(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function next() {}
 
     /**
      * Retrieve the key for the current file
@@ -962,7 +995,8 @@ class Phar extends RecursiveDirectoryIterator implements RecursiveIterator, Seek
      * See the FilesystemIterator constants.
      */
     #[TentativeType]
-    public function key(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function key() {}
 
     /**
      * The current file
@@ -971,7 +1005,8 @@ class Phar extends RecursiveDirectoryIterator implements RecursiveIterator, Seek
      * See the FilesystemIterator constants.
      */
     #[TentativeType]
-    public function current(): SplFileInfo|FilesystemIterator|string {}
+    #[LanguageLevelTypeAware(['8.1' => 'SplFileInfo|FilesystemIterator|string'], default: '')]
+    public function current() {}
 
     /**
      * Check whether current DirectoryIterator position is a valid file
@@ -979,7 +1014,8 @@ class Phar extends RecursiveDirectoryIterator implements RecursiveIterator, Seek
      * @return bool <b>TRUE</b> if the position is valid, otherwise <b>FALSE</b>
      */
     #[TentativeType]
-    public function valid(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function valid() {}
 
     /**
      * Seek to a DirectoryIterator item
@@ -990,7 +1026,8 @@ class Phar extends RecursiveDirectoryIterator implements RecursiveIterator, Seek
      * @return void No value is returned.
      */
     #[TentativeType]
-    public function seek(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $offset): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function seek(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $offset) {}
 }
 
 /**
@@ -1036,14 +1073,16 @@ class PharData extends RecursiveDirectoryIterator implements Countable, ArrayAcc
      * @return bool
      */
     #[TentativeType]
-    public function offsetExists($localName): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function offsetExists($localName) {}
 
     /**
      * @param string $localName
      * @return SplFileInfo
      */
     #[TentativeType]
-    public function offsetGet($localName): SplFileInfo {}
+    #[LanguageLevelTypeAware(['8.1' => 'SplFileInfo'], default: '')]
+    public function offsetGet($localName) {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 2.0.0)<br/>
@@ -1058,7 +1097,8 @@ class PharData extends RecursiveDirectoryIterator implements Countable, ArrayAcc
      * @return void No return values.
      */
     #[TentativeType]
-    public function offsetSet($localName, $value): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function offsetSet($localName, $value) {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 2.0.0)<br/>
@@ -1070,7 +1110,8 @@ class PharData extends RecursiveDirectoryIterator implements Countable, ArrayAcc
      * @return void
      */
     #[TentativeType]
-    public function offsetUnset($localName): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function offsetUnset($localName) {}
 
     /**
      * Returns whether current entry is a directory and not '.' or '..'
@@ -1080,7 +1121,8 @@ class PharData extends RecursiveDirectoryIterator implements Countable, ArrayAcc
      * @return bool whether the current entry is a directory, but not '.' or '..'
      */
     #[TentativeType]
-    public function hasChildren(#[LanguageLevelTypeAware(['8.0' => 'bool'], default: '')] $allowLinks = false): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function hasChildren(#[LanguageLevelTypeAware(['8.0' => 'bool'], default: '')] $allowLinks = false) {}
 
     /**
      * Returns an iterator for the current entry if it is a directory
@@ -1088,7 +1130,8 @@ class PharData extends RecursiveDirectoryIterator implements Countable, ArrayAcc
      * @return RecursiveDirectoryIterator An iterator for the current entry, if it is a directory.
      */
     #[TentativeType]
-    public function getChildren(): RecursiveDirectoryIterator {}
+    #[LanguageLevelTypeAware(['8.1' => 'RecursiveDirectoryIterator'], default: '')]
+    public function getChildren() {}
 
     /**
      * Rewinds back to the beginning
@@ -1096,7 +1139,8 @@ class PharData extends RecursiveDirectoryIterator implements Countable, ArrayAcc
      * @return void No value is returned.
      */
     #[TentativeType]
-    public function rewind(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function rewind() {}
 
     /**
      * Move to the next file
@@ -1104,7 +1148,8 @@ class PharData extends RecursiveDirectoryIterator implements Countable, ArrayAcc
      * @return void No value is returned.
      */
     #[TentativeType]
-    public function next(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function next() {}
 
     /**
      * Retrieve the key for the current file
@@ -1113,7 +1158,8 @@ class PharData extends RecursiveDirectoryIterator implements Countable, ArrayAcc
      * See the FilesystemIterator constants.
      */
     #[TentativeType]
-    public function key(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function key() {}
 
     /**
      * The current file
@@ -1122,7 +1168,8 @@ class PharData extends RecursiveDirectoryIterator implements Countable, ArrayAcc
      * See the FilesystemIterator constants.
      */
     #[TentativeType]
-    public function current(): SplFileInfo|FilesystemIterator|string {}
+    #[LanguageLevelTypeAware(['8.1' => 'SplFileInfo|FilesystemIterator|string'], default: '')]
+    public function current() {}
 
     /**
      * Check whether current DirectoryIterator position is a valid file
@@ -1130,7 +1177,8 @@ class PharData extends RecursiveDirectoryIterator implements Countable, ArrayAcc
      * @return bool <b>TRUE</b> if the position is valid, otherwise <b>FALSE</b>
      */
     #[TentativeType]
-    public function valid(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function valid() {}
 
     /**
      * (Unknown)<br/>
@@ -1142,10 +1190,11 @@ class PharData extends RecursiveDirectoryIterator implements Countable, ArrayAcc
      * @return void no return value, exception is thrown on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
     public function addEmptyDir(
         #[PhpStormStubsElementAvailable(from: '5.3', to: '7.4')] $directory = '',
         #[PhpStormStubsElementAvailable(from: '8.0')] string $directory
-    ): void {}
+    ) {}
 
     /**
      * (Unknown)<br/>
@@ -1161,10 +1210,11 @@ class PharData extends RecursiveDirectoryIterator implements Countable, ArrayAcc
      * @return void no return value, exception is thrown on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
     public function addFile(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $filename,
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $localName = null
-    ): void {}
+    ) {}
 
     /**
      * (Unknown)<br/>
@@ -1179,11 +1229,12 @@ class PharData extends RecursiveDirectoryIterator implements Countable, ArrayAcc
      * @return void no return value, exception is thrown on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
     public function addFromString(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $localName,
         #[PhpStormStubsElementAvailable(from: '5.3', to: '7.4')] $contents = '',
         #[PhpStormStubsElementAvailable(from: '8.0')] string $contents
-    ): void {}
+    ) {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 2.0.0)<br/>
@@ -1203,10 +1254,11 @@ class PharData extends RecursiveDirectoryIterator implements Countable, ArrayAcc
      * filesystem.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
     public function buildFromDirectory(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $directory,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $pattern = ''
-    ): array {}
+    ) {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 2.0.0)<br/>
@@ -1225,10 +1277,11 @@ class PharData extends RecursiveDirectoryIterator implements Countable, ArrayAcc
      * filesystem.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
     public function buildFromIterator(
         Traversable $iterator,
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $baseDirectory = null
-    ): array {}
+    ) {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 2.0.0)<br/>
@@ -1242,7 +1295,8 @@ class PharData extends RecursiveDirectoryIterator implements Countable, ArrayAcc
      * @return void No value is returned.
      */
     #[TentativeType]
-    public function compressFiles(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $compression): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function compressFiles(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $compression) {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 2.0.0)<br/>
@@ -1328,11 +1382,12 @@ class PharData extends RecursiveDirectoryIterator implements Countable, ArrayAcc
      * exception on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'Phar|null'], default: '')]
     public function convertToExecutable(
         #[LanguageLevelTypeAware(['8.0' => 'int|null'], default: '')] $format = null,
         #[LanguageLevelTypeAware(['8.0' => 'int|null'], default: '')] $compression = null,
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $extension = null
-    ): ?Phar {}
+    ) {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 2.0.0)<br/>
@@ -1364,11 +1419,12 @@ class PharData extends RecursiveDirectoryIterator implements Countable, ArrayAcc
      * exception on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'PharData|null'], default: '')]
     public function convertToData(
         #[LanguageLevelTypeAware(['8.0' => 'int|null'], default: '')] $format = null,
         #[LanguageLevelTypeAware(['8.0' => 'int|null'], default: '')] $compression = null,
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $extension = null
-    ): ?PharData {}
+    ) {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 2.0.0)<br/>
@@ -1395,7 +1451,8 @@ class PharData extends RecursiveDirectoryIterator implements Countable, ArrayAcc
      * if none.
      */
     #[TentativeType]
-    public function count(#[PhpStormStubsElementAvailable(from: '8.0')] int $mode = COUNT_NORMAL): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function count(#[PhpStormStubsElementAvailable(from: '8.0')] int $mode = COUNT_NORMAL) {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 2.0.0)<br/>
@@ -1439,11 +1496,12 @@ class PharData extends RecursiveDirectoryIterator implements Countable, ArrayAcc
      * and assume success if none is thrown.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function extractTo(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $directory,
         #[LanguageLevelTypeAware(['8.0' => 'array|string|null'], default: '')] $files = null,
         #[LanguageLevelTypeAware(['8.0' => 'bool'], default: '')] $overwrite = false
-    ): bool {}
+    ) {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 1.2.1)<br/>
@@ -1464,7 +1522,8 @@ class PharData extends RecursiveDirectoryIterator implements Countable, ArrayAcc
      * @see setAlias
      */
     #[TentativeType]
-    public function getAlias(): ?string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string|null'], default: '')]
+    public function getAlias() {}
 
     /**
      * Gets the path without filename
@@ -1472,7 +1531,8 @@ class PharData extends RecursiveDirectoryIterator implements Countable, ArrayAcc
      * @since 5.3
      */
     #[TentativeType]
-    public function getPath(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function getPath() {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 1.0.0)<br/>
@@ -1484,7 +1544,8 @@ class PharData extends RecursiveDirectoryIterator implements Countable, ArrayAcc
      * or <b>NULL</b> if no meta-data is stored.
      */
     #[TentativeType]
-    public function getMetadata(#[PhpStormStubsElementAvailable(from: '8.0')] array $unserializeOptions = []): mixed {}
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function getMetadata(#[PhpStormStubsElementAvailable(from: '8.0')] array $unserializeOptions = []) {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 1.0.0)<br/>
@@ -1493,7 +1554,8 @@ class PharData extends RecursiveDirectoryIterator implements Countable, ArrayAcc
      * @return bool <b>TRUE</b> if the phar has been modified since opened, <b>FALSE</b> if not.
      */
     #[TentativeType]
-    public function getModified(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function getModified() {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 1.0.0)<br/>
@@ -1510,7 +1572,8 @@ class PharData extends RecursiveDirectoryIterator implements Countable, ArrayAcc
      */
     #[ArrayShape(["hash" => "string", "hash_type" => "string"])]
     #[TentativeType]
-    public function getSignature(): array|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'array|false'], default: '')]
+    public function getSignature() {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 1.0.0)<br/>
@@ -1520,7 +1583,8 @@ class PharData extends RecursiveDirectoryIterator implements Countable, ArrayAcc
      * the current Phar archive.
      */
     #[TentativeType]
-    public function getStub(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function getStub() {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 1.0.0)<br/>
@@ -1533,7 +1597,8 @@ class PharData extends RecursiveDirectoryIterator implements Countable, ArrayAcc
      * documentation for more information.
      */
     #[TentativeType]
-    public function getVersion(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function getVersion() {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 1.2.0)<br/>
@@ -1542,7 +1607,8 @@ class PharData extends RecursiveDirectoryIterator implements Countable, ArrayAcc
      * @return bool <b>TRUE</b> if meta-data has been set, and <b>FALSE</b> if not.
      */
     #[TentativeType]
-    public function hasMetadata(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function hasMetadata() {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 1.0.0)<br/>
@@ -1551,7 +1617,8 @@ class PharData extends RecursiveDirectoryIterator implements Countable, ArrayAcc
      * @return bool <b>TRUE</b> if the write operations are being buffer, <b>FALSE</b> otherwise.
      */
     #[TentativeType]
-    public function isBuffering(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isBuffering() {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 2.0.0)<br/>
@@ -1560,7 +1627,8 @@ class PharData extends RecursiveDirectoryIterator implements Countable, ArrayAcc
      * @return mixed Phar::GZ, Phar::BZ2 or <b>FALSE</b>
      */
     #[TentativeType]
-    public function isCompressed(): int|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'int|false'], default: '')]
+    public function isCompressed() {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 2.0.0)<br/>
@@ -1573,7 +1641,8 @@ class PharData extends RecursiveDirectoryIterator implements Countable, ArrayAcc
      * @return bool <b>TRUE</b> if the phar archive matches the file format requested by the parameter
      */
     #[TentativeType]
-    public function isFileFormat(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $format): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isFileFormat(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $format) {}
 
     /**
      * (Unknown)<br/>
@@ -1582,7 +1651,8 @@ class PharData extends RecursiveDirectoryIterator implements Countable, ArrayAcc
      * @return bool <b>TRUE</b> if the phar archive can be modified
      */
     #[TentativeType]
-    public function isWritable(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isWritable() {}
 
     /**
      * (Unknown)<br/>
@@ -1613,7 +1683,8 @@ class PharData extends RecursiveDirectoryIterator implements Countable, ArrayAcc
      * @return void No value is returned.
      */
     #[TentativeType]
-    public function setMetadata(#[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $metadata): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function setMetadata(#[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $metadata) {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 1.1.0)<br/>
@@ -1639,10 +1710,11 @@ class PharData extends RecursiveDirectoryIterator implements Countable, ArrayAcc
      * @return void No value is returned.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
     public function setSignatureAlgorithm(
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $algo,
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $privateKey = null
-    ): void {}
+    ) {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 1.0.0)<br/>
@@ -1669,7 +1741,8 @@ class PharData extends RecursiveDirectoryIterator implements Countable, ArrayAcc
      * @return void No value is returned.
      */
     #[TentativeType]
-    public function startBuffering(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function startBuffering() {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 1.0.0)<br/>
@@ -1678,7 +1751,8 @@ class PharData extends RecursiveDirectoryIterator implements Countable, ArrayAcc
      * @return void No value is returned.
      */
     #[TentativeType]
-    public function stopBuffering(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function stopBuffering() {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 1.0.0)<br/>
@@ -1949,7 +2023,8 @@ class PharData extends RecursiveDirectoryIterator implements Countable, ArrayAcc
      * @return void No value is returned.
      */
     #[TentativeType]
-    public function seek(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $offset): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function seek(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $offset) {}
 
     public function __destruct() {}
 }
@@ -1985,7 +2060,8 @@ class PharFileInfo extends SplFileInfo
      * @return void No value is returned.
      */
     #[TentativeType]
-    public function chmod(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $perms): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function chmod(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $perms) {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 2.0.0)<br/>
@@ -2030,7 +2106,8 @@ class PharFileInfo extends SplFileInfo
      * @return int<0, max> The size in bytes of the file within the Phar archive on disk.
      */
     #[TentativeType]
-    public function getCompressedSize(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function getCompressedSize() {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 1.0.0)<br/>
@@ -2039,10 +2116,12 @@ class PharFileInfo extends SplFileInfo
      * @return int The <b>crc32</b> checksum of the file within the Phar archive.
      */
     #[TentativeType]
-    public function getCRC32(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function getCRC32() {}
 
     #[TentativeType]
-    public function getContent(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function getContent() {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 1.0.0)<br/>
@@ -2054,7 +2133,8 @@ class PharFileInfo extends SplFileInfo
      * or <b>NULL</b> if no meta-data is stored.
      */
     #[TentativeType]
-    public function getMetadata(#[PhpStormStubsElementAvailable(from: '8.0')] array $unserializeOptions = []): mixed {}
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function getMetadata(#[PhpStormStubsElementAvailable(from: '8.0')] array $unserializeOptions = []) {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 1.0.0)<br/>
@@ -2063,7 +2143,8 @@ class PharFileInfo extends SplFileInfo
      * @return int The Phar flags (always 0 in the current implementation)
      */
     #[TentativeType]
-    public function getPharFlags(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function getPharFlags() {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 1.2.0)<br/>
@@ -2072,7 +2153,8 @@ class PharFileInfo extends SplFileInfo
      * @return bool <b>FALSE</b> if no metadata is set or is <b>NULL</b>, <b>TRUE</b> if metadata is not <b>NULL</b>
      */
     #[TentativeType]
-    public function hasMetadata(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function hasMetadata() {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 1.0.0)<br/>
@@ -2085,7 +2167,8 @@ class PharFileInfo extends SplFileInfo
      * @return bool <b>TRUE</b> if the file is compressed within the Phar archive, <b>FALSE</b> if not.
      */
     #[TentativeType]
-    public function isCompressed(#[LanguageLevelTypeAware(['8.0' => 'int|null'], default: '')] $compression = null): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isCompressed(#[LanguageLevelTypeAware(['8.0' => 'int|null'], default: '')] $compression = null) {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 1.0.0)<br/>
@@ -2094,7 +2177,8 @@ class PharFileInfo extends SplFileInfo
      * @return bool <b>TRUE</b> if the file has had its CRC verified, <b>FALSE</b> if not.
      */
     #[TentativeType]
-    public function isCRCChecked(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isCRCChecked() {}
 
     /**
      * (PHP &gt;= 5.3.0, PECL phar &gt;= 1.0.0)<br/>

--- a/Reflection/Reflection.php
+++ b/Reflection/Reflection.php
@@ -19,7 +19,8 @@ class Reflection
      * @return string[] An array of modifier names.
      */
     #[TentativeType]
-    public static function getModifierNames(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $modifiers): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public static function getModifierNames(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $modifiers) {}
 
     /**
      * Exports

--- a/Reflection/ReflectionClass.php
+++ b/Reflection/ReflectionClass.php
@@ -99,7 +99,8 @@ class ReflectionClass implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getName(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function getName() {}
 
     /**
      * Checks if class is defined internally by an extension, or the core
@@ -109,7 +110,8 @@ class ReflectionClass implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function isInternal(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isInternal() {}
 
     /**
      * Checks if user defined
@@ -119,7 +121,8 @@ class ReflectionClass implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function isUserDefined(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isUserDefined() {}
 
     /**
      * Checks if the class is instantiable
@@ -129,7 +132,8 @@ class ReflectionClass implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function isInstantiable(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isInstantiable() {}
 
     /**
      * Returns whether this class is cloneable
@@ -140,7 +144,8 @@ class ReflectionClass implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function isCloneable(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isCloneable() {}
 
     /**
      * Gets the filename of the file in which the class has been defined
@@ -152,7 +157,8 @@ class ReflectionClass implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getFileName(): string|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'string|false'], default: '')]
+    public function getFileName() {}
 
     /**
      * Gets starting line number
@@ -162,7 +168,8 @@ class ReflectionClass implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getStartLine(): int|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'int|false'], default: '')]
+    public function getStartLine() {}
 
     /**
      * Gets end line
@@ -173,7 +180,8 @@ class ReflectionClass implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getEndLine(): int|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'int|false'], default: '')]
+    public function getEndLine() {}
 
     /**
      * Gets doc comments
@@ -183,7 +191,8 @@ class ReflectionClass implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getDocComment(): string|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'string|false'], default: '')]
+    public function getDocComment() {}
 
     /**
      * Gets the constructor of the class
@@ -194,7 +203,8 @@ class ReflectionClass implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getConstructor(): ?ReflectionMethod {}
+    #[LanguageLevelTypeAware(['8.1' => 'ReflectionMethod|null'], default: '')]
+    public function getConstructor() {}
 
     /**
      * Checks if method is defined
@@ -204,7 +214,8 @@ class ReflectionClass implements Reflector
      * @return bool Returns {@see true} if it has the method, otherwise {@see false}
      */
     #[TentativeType]
-    public function hasMethod(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function hasMethod(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name) {}
 
     /**
      * Gets a <b>ReflectionMethod</b> for a class method.
@@ -216,7 +227,8 @@ class ReflectionClass implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getMethod(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name): ReflectionMethod {}
+    #[LanguageLevelTypeAware(['8.1' => 'ReflectionMethod'], default: '')]
+    public function getMethod(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name) {}
 
     /**
      * Gets an array of methods for the class.
@@ -229,7 +241,8 @@ class ReflectionClass implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getMethods(#[LanguageLevelTypeAware(['8.0' => 'int|null'], default: '')] $filter = null): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public function getMethods(#[LanguageLevelTypeAware(['8.0' => 'int|null'], default: '')] $filter = null) {}
 
     /**
      * Checks if property is defined
@@ -239,7 +252,8 @@ class ReflectionClass implements Reflector
      * @return bool Returns {@see true} if it has the property, otherwise {@see false}
      */
     #[TentativeType]
-    public function hasProperty(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function hasProperty(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name) {}
 
     /**
      * Gets a <b>ReflectionProperty</b> for a class's property
@@ -251,7 +265,8 @@ class ReflectionClass implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getProperty(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name): ReflectionProperty {}
+    #[LanguageLevelTypeAware(['8.1' => 'ReflectionProperty'], default: '')]
+    public function getProperty(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name) {}
 
     /**
      * Gets properties
@@ -264,7 +279,8 @@ class ReflectionClass implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getProperties(#[LanguageLevelTypeAware(['8.0' => 'int|null'], default: '')] $filter = null): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public function getProperties(#[LanguageLevelTypeAware(['8.0' => 'int|null'], default: '')] $filter = null) {}
 
     /**
      * Gets a ReflectionClassConstant for a class's property
@@ -276,7 +292,8 @@ class ReflectionClass implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getReflectionConstant(string $name): ReflectionClassConstant|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'ReflectionClassConstant|false'], default: '')]
+    public function getReflectionConstant(string $name) {}
 
     /**
      * Gets class constants
@@ -288,7 +305,8 @@ class ReflectionClass implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getReflectionConstants(#[PhpStormStubsElementAvailable(from: '8.0')] ?int $filter = null): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public function getReflectionConstants(#[PhpStormStubsElementAvailable(from: '8.0')] ?int $filter = null) {}
 
     /**
      * Checks if constant is defined
@@ -298,7 +316,8 @@ class ReflectionClass implements Reflector
      * @return bool Returns {@see true} if the constant is defined, otherwise {@see false}
      */
     #[TentativeType]
-    public function hasConstant(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function hasConstant(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name) {}
 
     /**
      * Gets constants
@@ -310,7 +329,8 @@ class ReflectionClass implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getConstants(#[PhpStormStubsElementAvailable(from: '8.0')] ?int $filter = null): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public function getConstants(#[PhpStormStubsElementAvailable(from: '8.0')] ?int $filter = null) {}
 
     /**
      * Gets defined constant
@@ -322,7 +342,8 @@ class ReflectionClass implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getConstant(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name): mixed {}
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function getConstant(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name) {}
 
     /**
      * Gets the interfaces
@@ -333,7 +354,8 @@ class ReflectionClass implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getInterfaces(): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public function getInterfaces() {}
 
     /**
      * Gets the interface names
@@ -343,7 +365,8 @@ class ReflectionClass implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getInterfaceNames(): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public function getInterfaceNames() {}
 
     /**
      * Checks if the class is anonymous
@@ -354,7 +377,8 @@ class ReflectionClass implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function isAnonymous(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isAnonymous() {}
 
     /**
      * Checks if the class is an interface
@@ -364,7 +388,8 @@ class ReflectionClass implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function isInterface(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isInterface() {}
 
     /**
      * Returns an array of traits used by this class
@@ -376,7 +401,8 @@ class ReflectionClass implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getTraits(): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public function getTraits() {}
 
     /**
      * Returns an array of names of traits used by this class
@@ -388,7 +414,8 @@ class ReflectionClass implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getTraitNames(): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public function getTraitNames() {}
 
     /**
      * Returns an array of trait aliases
@@ -401,7 +428,8 @@ class ReflectionClass implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getTraitAliases(): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public function getTraitAliases() {}
 
     /**
      * Returns whether this is a trait
@@ -413,7 +441,8 @@ class ReflectionClass implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function isTrait(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isTrait() {}
 
     /**
      * Checks if class is abstract
@@ -423,7 +452,8 @@ class ReflectionClass implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function isAbstract(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isAbstract() {}
 
     /**
      * Checks if class is final
@@ -433,7 +463,8 @@ class ReflectionClass implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function isFinal(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isFinal() {}
 
     /**
      * @return bool
@@ -450,7 +481,8 @@ class ReflectionClass implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getModifiers(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function getModifiers() {}
 
     /**
      * Checks class for instance
@@ -461,7 +493,8 @@ class ReflectionClass implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function isInstance(#[LanguageLevelTypeAware(['8.0' => 'object'], default: '')] $object): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isInstance(#[LanguageLevelTypeAware(['8.0' => 'object'], default: '')] $object) {}
 
     /**
      * Creates a new class instance from given arguments.
@@ -475,7 +508,8 @@ class ReflectionClass implements Reflector
      * one or more parameters.
      */
     #[TentativeType]
-    public function newInstance(mixed ...$args): object {}
+    #[LanguageLevelTypeAware(['8.1' => 'object'], default: '')]
+    public function newInstance(mixed ...$args) {}
 
     /**
      * Creates a new class instance without invoking the constructor.
@@ -488,7 +522,8 @@ class ReflectionClass implements Reflector
      * @since 5.4
      */
     #[TentativeType]
-    public function newInstanceWithoutConstructor(): object {}
+    #[LanguageLevelTypeAware(['8.1' => 'object'], default: '')]
+    public function newInstanceWithoutConstructor() {}
 
     /**
      * Creates a new class instance from given arguments.
@@ -502,7 +537,8 @@ class ReflectionClass implements Reflector
      * @since 5.1
      */
     #[TentativeType]
-    public function newInstanceArgs(array $args = []): ?object {}
+    #[LanguageLevelTypeAware(['8.1' => 'object|null'], default: '')]
+    public function newInstanceArgs(array $args = []) {}
 
     /**
      * Gets parent class
@@ -513,7 +549,8 @@ class ReflectionClass implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getParentClass(): ReflectionClass|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'ReflectionClass|false'], default: '')]
+    public function getParentClass() {}
 
     /**
      * Checks if a subclass
@@ -525,7 +562,8 @@ class ReflectionClass implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function isSubclassOf(#[LanguageLevelTypeAware(['8.0' => 'ReflectionClass|string'], default: '')] $class): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isSubclassOf(#[LanguageLevelTypeAware(['8.0' => 'ReflectionClass|string'], default: '')] $class) {}
 
     /**
      * Gets static properties
@@ -551,10 +589,11 @@ class ReflectionClass implements Reflector
      */
     #[Pure]
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
     public function getStaticPropertyValue(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name,
         #[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $default
-    ): mixed {}
+    ) {}
 
     /**
      * Sets static property value
@@ -565,10 +604,11 @@ class ReflectionClass implements Reflector
      * @return void No value is returned.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
     public function setStaticPropertyValue(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name,
         #[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $value
-    ): void {}
+    ) {}
 
     /**
      * Gets default properties
@@ -582,7 +622,8 @@ class ReflectionClass implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getDefaultProperties(): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public function getDefaultProperties() {}
 
     /**
      * An alias of {@see ReflectionClass::isIterable} method.
@@ -592,7 +633,8 @@ class ReflectionClass implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function isIterateable(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isIterateable() {}
 
     /**
      * Check whether this class is iterable
@@ -603,7 +645,8 @@ class ReflectionClass implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function isIterable(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isIterable() {}
 
     /**
      * Checks whether it implements an interface.
@@ -613,7 +656,8 @@ class ReflectionClass implements Reflector
      * @return bool Returns {@see true} on success or {@see false} on failure.
      */
     #[TentativeType]
-    public function implementsInterface(#[LanguageLevelTypeAware(['8.0' => 'ReflectionClass|string'], default: '')] $interface): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function implementsInterface(#[LanguageLevelTypeAware(['8.0' => 'ReflectionClass|string'], default: '')] $interface) {}
 
     /**
      * Gets a <b>ReflectionExtension</b> object for the extension which defined the class
@@ -624,7 +668,8 @@ class ReflectionClass implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getExtension(): ?ReflectionExtension {}
+    #[LanguageLevelTypeAware(['8.1' => 'ReflectionExtension|null'], default: '')]
+    public function getExtension() {}
 
     /**
      * Gets the name of the extension which defined the class
@@ -635,7 +680,8 @@ class ReflectionClass implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getExtensionName(): string|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'string|false'], default: '')]
+    public function getExtensionName() {}
 
     /**
      * Checks if in namespace
@@ -644,7 +690,8 @@ class ReflectionClass implements Reflector
      * @return bool {@see true} on success or {@see false} on failure.
      */
     #[TentativeType]
-    public function inNamespace(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function inNamespace() {}
 
     /**
      * Gets namespace name
@@ -654,7 +701,8 @@ class ReflectionClass implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getNamespaceName(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function getNamespaceName() {}
 
     /**
      * Gets short name
@@ -664,7 +712,8 @@ class ReflectionClass implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getShortName(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function getShortName() {}
 
     /**
      * @template T

--- a/Reflection/ReflectionClassConstant.php
+++ b/Reflection/ReflectionClassConstant.php
@@ -94,7 +94,8 @@ class ReflectionClassConstant implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getDeclaringClass(): ReflectionClass {}
+    #[LanguageLevelTypeAware(['8.1' => 'ReflectionClass'], default: '')]
+    public function getDeclaringClass() {}
 
     /**
      * Gets doc comments
@@ -105,7 +106,8 @@ class ReflectionClassConstant implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getDocComment(): string|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'string|false'], default: '')]
+    public function getDocComment() {}
 
     /**
      * Gets the class constant modifiers
@@ -117,7 +119,8 @@ class ReflectionClassConstant implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getModifiers(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function getModifiers() {}
 
     /**
      * Get name of the constant
@@ -128,7 +131,8 @@ class ReflectionClassConstant implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getName(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function getName() {}
 
     /**
      * Gets value
@@ -139,7 +143,8 @@ class ReflectionClassConstant implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getValue(): mixed {}
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function getValue() {}
 
     /**
      * Checks if class constant is private
@@ -150,7 +155,8 @@ class ReflectionClassConstant implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function isPrivate(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isPrivate() {}
 
     /**
      * Checks if class constant is protected
@@ -161,7 +167,8 @@ class ReflectionClassConstant implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function isProtected(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isProtected() {}
 
     /**
      * Checks if class constant is public
@@ -172,7 +179,8 @@ class ReflectionClassConstant implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function isPublic(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isPublic() {}
 
     /**
      * Returns the string representation of the ReflectionClassConstant object.

--- a/Reflection/ReflectionExtension.php
+++ b/Reflection/ReflectionExtension.php
@@ -64,7 +64,8 @@ class ReflectionExtension implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getName(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function getName() {}
 
     /**
      * Gets extension version
@@ -74,7 +75,8 @@ class ReflectionExtension implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getVersion(): ?string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string|null'], default: '')]
+    public function getVersion() {}
 
     /**
      * Gets extension functions
@@ -86,7 +88,8 @@ class ReflectionExtension implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getFunctions(): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public function getFunctions() {}
 
     /**
      * Gets constants
@@ -96,7 +99,8 @@ class ReflectionExtension implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getConstants(): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public function getConstants() {}
 
     /**
      * Gets extension ini entries
@@ -107,7 +111,8 @@ class ReflectionExtension implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getINIEntries(): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public function getINIEntries() {}
 
     /**
      * Gets classes
@@ -119,7 +124,8 @@ class ReflectionExtension implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getClasses(): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public function getClasses() {}
 
     /**
      * Gets class names
@@ -130,7 +136,8 @@ class ReflectionExtension implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getClassNames(): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public function getClassNames() {}
 
     /**
      * Gets dependencies
@@ -141,7 +148,8 @@ class ReflectionExtension implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getDependencies(): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public function getDependencies() {}
 
     /**
      * Print extension info
@@ -150,7 +158,8 @@ class ReflectionExtension implements Reflector
      * @return void Print extension info
      */
     #[TentativeType]
-    public function info(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function info() {}
 
     /**
      * Returns whether this extension is persistent
@@ -161,7 +170,8 @@ class ReflectionExtension implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function isPersistent(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isPersistent() {}
 
     /**
      * Returns whether this extension is temporary
@@ -172,7 +182,8 @@ class ReflectionExtension implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function isTemporary(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isTemporary() {}
 
     /**
      * Clones

--- a/Reflection/ReflectionFunction.php
+++ b/Reflection/ReflectionFunction.php
@@ -70,7 +70,8 @@ class ReflectionFunction extends ReflectionFunctionAbstract
     #[Deprecated(since: '8.0')]
     #[Pure]
     #[TentativeType]
-    public function isDisabled(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isDisabled() {}
 
     /**
      * Invokes function
@@ -82,7 +83,8 @@ class ReflectionFunction extends ReflectionFunctionAbstract
      * @return mixed Returns the result of the invoked function call.
      */
     #[TentativeType]
-    public function invoke(#[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] ...$args): mixed {}
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function invoke(#[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] ...$args) {}
 
     /**
      * Invokes function args
@@ -93,7 +95,8 @@ class ReflectionFunction extends ReflectionFunctionAbstract
      * @return mixed the result of the invoked function
      */
     #[TentativeType]
-    public function invokeArgs(array $args): mixed {}
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function invokeArgs(array $args) {}
 
     /**
      * Returns a dynamically created closure for the function
@@ -103,7 +106,8 @@ class ReflectionFunction extends ReflectionFunctionAbstract
      */
     #[Pure]
     #[TentativeType]
-    public function getClosure(): Closure {}
+    #[LanguageLevelTypeAware(['8.1' => 'Closure'], default: '')]
+    public function getClosure() {}
 
     #[PhpStormStubsElementAvailable(from: '8.2')]
     public function isAnonymous(): bool {}

--- a/Reflection/ReflectionFunctionAbstract.php
+++ b/Reflection/ReflectionFunctionAbstract.php
@@ -46,7 +46,8 @@ abstract class ReflectionFunctionAbstract implements Reflector
      * @return bool {@see true} if it's in a namespace, otherwise {@see false}
      */
     #[TentativeType]
-    public function inNamespace(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function inNamespace() {}
 
     /**
      * Checks if closure
@@ -56,7 +57,8 @@ abstract class ReflectionFunctionAbstract implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function isClosure(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isClosure() {}
 
     /**
      * Checks if deprecated
@@ -66,7 +68,8 @@ abstract class ReflectionFunctionAbstract implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function isDeprecated(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isDeprecated() {}
 
     /**
      * Checks if is internal
@@ -76,7 +79,8 @@ abstract class ReflectionFunctionAbstract implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function isInternal(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isInternal() {}
 
     /**
      * Checks if user defined
@@ -86,7 +90,8 @@ abstract class ReflectionFunctionAbstract implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function isUserDefined(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isUserDefined() {}
 
     /**
      * Returns whether this function is a generator
@@ -97,7 +102,8 @@ abstract class ReflectionFunctionAbstract implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function isGenerator(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isGenerator() {}
 
     /**
      * Returns whether this function is variadic
@@ -108,7 +114,8 @@ abstract class ReflectionFunctionAbstract implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function isVariadic(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isVariadic() {}
 
     /**
      * Returns this pointer bound to closure
@@ -118,7 +125,8 @@ abstract class ReflectionFunctionAbstract implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getClosureThis(): ?object {}
+    #[LanguageLevelTypeAware(['8.1' => 'object|null'], default: '')]
+    public function getClosureThis() {}
 
     /**
      * Returns the scope associated to the closure
@@ -130,7 +138,8 @@ abstract class ReflectionFunctionAbstract implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getClosureScopeClass(): ?ReflectionClass {}
+    #[LanguageLevelTypeAware(['8.1' => 'ReflectionClass|null'], default: '')]
+    public function getClosureScopeClass() {}
 
     /**
      * @return ReflectionClass|null Returns the class on success or {@see null}
@@ -139,7 +148,8 @@ abstract class ReflectionFunctionAbstract implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getClosureCalledClass(): ?ReflectionClass {}
+    #[LanguageLevelTypeAware(['8.1' => 'ReflectionClass|null'], default: '')]
+    public function getClosureCalledClass() {}
 
     /**
      * Gets doc comment
@@ -149,7 +159,8 @@ abstract class ReflectionFunctionAbstract implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getDocComment(): string|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'string|false'], default: '')]
+    public function getDocComment() {}
 
     /**
      * Gets end line number
@@ -160,7 +171,8 @@ abstract class ReflectionFunctionAbstract implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getEndLine(): int|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'int|false'], default: '')]
+    public function getEndLine() {}
 
     /**
      * Gets extension info
@@ -171,7 +183,8 @@ abstract class ReflectionFunctionAbstract implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getExtension(): ?ReflectionExtension {}
+    #[LanguageLevelTypeAware(['8.1' => 'ReflectionExtension|null'], default: '')]
+    public function getExtension() {}
 
     /**
      * Gets extension name
@@ -181,7 +194,8 @@ abstract class ReflectionFunctionAbstract implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getExtensionName(): string|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'string|false'], default: '')]
+    public function getExtensionName() {}
 
     /**
      * Gets file name
@@ -191,7 +205,8 @@ abstract class ReflectionFunctionAbstract implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getFileName(): string|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'string|false'], default: '')]
+    public function getFileName() {}
 
     /**
      * Gets function name
@@ -201,7 +216,8 @@ abstract class ReflectionFunctionAbstract implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getName(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function getName() {}
 
     /**
      * Gets namespace name
@@ -211,7 +227,8 @@ abstract class ReflectionFunctionAbstract implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getNamespaceName(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function getNamespaceName() {}
 
     /**
      * Gets number of parameters
@@ -222,7 +239,8 @@ abstract class ReflectionFunctionAbstract implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getNumberOfParameters(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function getNumberOfParameters() {}
 
     /**
      * Gets number of required parameters
@@ -233,7 +251,8 @@ abstract class ReflectionFunctionAbstract implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getNumberOfRequiredParameters(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function getNumberOfRequiredParameters() {}
 
     /**
      * Gets parameters
@@ -243,7 +262,8 @@ abstract class ReflectionFunctionAbstract implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getParameters(): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public function getParameters() {}
 
     /**
      * Gets the specified return type of a function
@@ -273,7 +293,8 @@ abstract class ReflectionFunctionAbstract implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getShortName(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function getShortName() {}
 
     /**
      * Gets starting line number
@@ -283,7 +304,8 @@ abstract class ReflectionFunctionAbstract implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getStartLine(): int|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'int|false'], default: '')]
+    public function getStartLine() {}
 
     /**
      * Gets static variables
@@ -293,7 +315,8 @@ abstract class ReflectionFunctionAbstract implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getStaticVariables(): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public function getStaticVariables() {}
 
     /**
      * Checks if returns reference
@@ -302,7 +325,8 @@ abstract class ReflectionFunctionAbstract implements Reflector
      * @return bool {@see true} if it returns a reference, otherwise {@see false}
      */
     #[TentativeType]
-    public function returnsReference(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function returnsReference() {}
 
     /**
      * Checks if the function has a specified return type
@@ -313,7 +337,8 @@ abstract class ReflectionFunctionAbstract implements Reflector
      * @since 7.0
      */
     #[TentativeType]
-    public function hasReturnType(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function hasReturnType() {}
 
     /**
      * @template T
@@ -343,7 +368,8 @@ abstract class ReflectionFunctionAbstract implements Reflector
     #[PhpStormStubsElementAvailable('8.1')]
     #[Pure]
     #[TentativeType]
-    public function isStatic(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isStatic() {}
 
     #[LanguageLevelTypeAware(['7.0' => 'string'], default: '')]
     public function __toString() {}

--- a/Reflection/ReflectionMethod.php
+++ b/Reflection/ReflectionMethod.php
@@ -114,7 +114,8 @@ class ReflectionMethod extends ReflectionFunctionAbstract
      */
     #[Pure]
     #[TentativeType]
-    public function isPublic(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isPublic() {}
 
     /**
      * Checks if method is private
@@ -124,7 +125,8 @@ class ReflectionMethod extends ReflectionFunctionAbstract
      */
     #[Pure]
     #[TentativeType]
-    public function isPrivate(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isPrivate() {}
 
     /**
      * Checks if method is protected
@@ -134,7 +136,8 @@ class ReflectionMethod extends ReflectionFunctionAbstract
      */
     #[Pure]
     #[TentativeType]
-    public function isProtected(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isProtected() {}
 
     /**
      * Checks if method is abstract
@@ -144,7 +147,8 @@ class ReflectionMethod extends ReflectionFunctionAbstract
      */
     #[Pure]
     #[TentativeType]
-    public function isAbstract(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isAbstract() {}
 
     /**
      * Checks if method is final
@@ -154,7 +158,8 @@ class ReflectionMethod extends ReflectionFunctionAbstract
      */
     #[Pure]
     #[TentativeType]
-    public function isFinal(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isFinal() {}
 
     /**
      * Checks if method is static
@@ -164,7 +169,8 @@ class ReflectionMethod extends ReflectionFunctionAbstract
      */
     #[Pure]
     #[TentativeType]
-    public function isStatic(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isStatic() {}
 
     /**
      * Checks if method is a constructor
@@ -174,7 +180,8 @@ class ReflectionMethod extends ReflectionFunctionAbstract
      */
     #[Pure]
     #[TentativeType]
-    public function isConstructor(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isConstructor() {}
 
     /**
      * Checks if method is a destructor
@@ -184,7 +191,8 @@ class ReflectionMethod extends ReflectionFunctionAbstract
      */
     #[Pure]
     #[TentativeType]
-    public function isDestructor(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isDestructor() {}
 
     /**
      * Returns a dynamically created closure for the method
@@ -198,10 +206,11 @@ class ReflectionMethod extends ReflectionFunctionAbstract
      */
     #[Pure]
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'Closure'], default: '')]
     public function getClosure(
         #[PhpStormStubsElementAvailable(from: '5.3', to: '7.3')] $object,
         #[PhpStormStubsElementAvailable(from: '7.4')] #[LanguageLevelTypeAware(['8.0' => 'object|null'], default: '')] $object = null
-    ): Closure {}
+    ) {}
 
     /**
      * Gets the method modifiers
@@ -222,7 +231,8 @@ class ReflectionMethod extends ReflectionFunctionAbstract
      */
     #[Pure]
     #[TentativeType]
-    public function getModifiers(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function getModifiers() {}
 
     /**
      * Invokes a reflected method.
@@ -239,10 +249,11 @@ class ReflectionMethod extends ReflectionFunctionAbstract
      * invocation failed.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
     public function invoke(
         #[LanguageLevelTypeAware(['8.0' => 'object|null'], default: '')] $object,
         mixed ...$args
-    ): mixed {}
+    ) {}
 
     /**
      * Invokes the reflected method and pass its arguments as array.
@@ -257,7 +268,8 @@ class ReflectionMethod extends ReflectionFunctionAbstract
      * invocation failed.
      */
     #[TentativeType]
-    public function invokeArgs(#[LanguageLevelTypeAware(['8.0' => 'object|null'], default: '')] $object, array $args): mixed {}
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function invokeArgs(#[LanguageLevelTypeAware(['8.0' => 'object|null'], default: '')] $object, array $args) {}
 
     /**
      * Gets declaring class for the reflected method.
@@ -268,7 +280,8 @@ class ReflectionMethod extends ReflectionFunctionAbstract
      */
     #[Pure]
     #[TentativeType]
-    public function getDeclaringClass(): ReflectionClass {}
+    #[LanguageLevelTypeAware(['8.1' => 'ReflectionClass'], default: '')]
+    public function getDeclaringClass() {}
 
     /**
      * Gets the method prototype (if there is one).
@@ -279,7 +292,8 @@ class ReflectionMethod extends ReflectionFunctionAbstract
      */
     #[Pure]
     #[TentativeType]
-    public function getPrototype(): ReflectionMethod {}
+    #[LanguageLevelTypeAware(['8.1' => 'ReflectionMethod'], default: '')]
+    public function getPrototype() {}
 
     /**
      * Set method accessibility
@@ -290,7 +304,8 @@ class ReflectionMethod extends ReflectionFunctionAbstract
      */
     #[PhpStormStubsElementAvailable(from: "5.3", to: "8.0")]
     #[TentativeType]
-    public function setAccessible(#[LanguageLevelTypeAware(['8.0' => 'bool'], default: '')] $accessible): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function setAccessible(#[LanguageLevelTypeAware(['8.0' => 'bool'], default: '')] $accessible) {}
 
     /**
      * Set method accessibility
@@ -302,8 +317,9 @@ class ReflectionMethod extends ReflectionFunctionAbstract
      */
     #[PhpStormStubsElementAvailable(from: "8.1")]
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
     #[Deprecated('Deprecated: it has no effect', since: '8.5')]
-    public function setAccessible(bool $accessible): void {}
+    public function setAccessible(bool $accessible) {}
 
     #[PhpStormStubsElementAvailable(from: '8.2')]
     public function hasPrototype(): bool {}

--- a/Reflection/ReflectionNamedType.php
+++ b/Reflection/ReflectionNamedType.php
@@ -2,6 +2,7 @@
 
 use JetBrains\PhpStorm\Internal\TentativeType;
 use JetBrains\PhpStorm\Pure;
+use JetBrains\PhpStorm\Internal\LanguageLevelTypeAware;
 
 /**
  * @since 7.1
@@ -17,7 +18,8 @@ class ReflectionNamedType extends ReflectionType
      */
     #[Pure]
     #[TentativeType]
-    public function getName(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function getName() {}
 
     /**
      * Checks if it is a built-in type
@@ -30,5 +32,6 @@ class ReflectionNamedType extends ReflectionType
      */
     #[Pure]
     #[TentativeType]
-    public function isBuiltin(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isBuiltin() {}
 }

--- a/Reflection/ReflectionParameter.php
+++ b/Reflection/ReflectionParameter.php
@@ -65,7 +65,8 @@ class ReflectionParameter implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getName(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function getName() {}
 
     /**
      * Checks if passed by reference
@@ -75,7 +76,8 @@ class ReflectionParameter implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function isPassedByReference(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isPassedByReference() {}
 
     /**
      * Returns whether this parameter can be passed by value
@@ -86,7 +88,8 @@ class ReflectionParameter implements Reflector
      * @since 5.4
      */
     #[TentativeType]
-    public function canBePassedByValue(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function canBePassedByValue() {}
 
     /**
      * Gets declaring function
@@ -97,7 +100,8 @@ class ReflectionParameter implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getDeclaringFunction(): ReflectionFunctionAbstract {}
+    #[LanguageLevelTypeAware(['8.1' => 'ReflectionFunctionAbstract'], default: '')]
+    public function getDeclaringFunction() {}
 
     /**
      * Gets declaring class
@@ -108,7 +112,8 @@ class ReflectionParameter implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getDeclaringClass(): ?ReflectionClass {}
+    #[LanguageLevelTypeAware(['8.1' => 'ReflectionClass|null'], default: '')]
+    public function getDeclaringClass() {}
 
     /**
      * Gets the class type hinted for the parameter as a ReflectionClass object.
@@ -120,7 +125,8 @@ class ReflectionParameter implements Reflector
     #[Deprecated(reason: "Use ReflectionParameter::getType() and the ReflectionType APIs should be used instead.", since: "8.0")]
     #[Pure]
     #[TentativeType]
-    public function getClass(): ?ReflectionClass {}
+    #[LanguageLevelTypeAware(['8.1' => 'ReflectionClass|null'], default: '')]
+    public function getClass() {}
 
     /**
      * Checks if the parameter has a type associated with it.
@@ -130,7 +136,8 @@ class ReflectionParameter implements Reflector
      * @since 7.0
      */
     #[TentativeType]
-    public function hasType(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function hasType() {}
 
     /**
      * Gets a parameter's type
@@ -162,7 +169,8 @@ class ReflectionParameter implements Reflector
     #[Deprecated(reason: "Use ReflectionParameter::getType() and the ReflectionType APIs should be used instead.", since: "8.0")]
     #[Pure]
     #[TentativeType]
-    public function isArray(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isArray() {}
 
     /**
      * Returns whether parameter MUST be callable
@@ -176,7 +184,8 @@ class ReflectionParameter implements Reflector
     #[Deprecated(reason: "Use ReflectionParameter::getType() and the ReflectionType APIs should be used instead.", since: "8.0")]
     #[Pure]
     #[TentativeType]
-    public function isCallable(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isCallable() {}
 
     /**
      * Checks if null is allowed
@@ -186,7 +195,8 @@ class ReflectionParameter implements Reflector
      * otherwise {@see false}
      */
     #[TentativeType]
-    public function allowsNull(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function allowsNull() {}
 
     /**
      * Gets parameter position
@@ -197,7 +207,8 @@ class ReflectionParameter implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getPosition(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function getPosition() {}
 
     /**
      * Checks if optional
@@ -208,7 +219,8 @@ class ReflectionParameter implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function isOptional(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isOptional() {}
 
     /**
      * Checks if a default value is available
@@ -219,7 +231,8 @@ class ReflectionParameter implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function isDefaultValueAvailable(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isDefaultValueAvailable() {}
 
     /**
      * Gets default parameter value
@@ -231,7 +244,8 @@ class ReflectionParameter implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getDefaultValue(): mixed {}
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function getDefaultValue() {}
 
     /**
      * Returns whether the default value of this parameter is constant
@@ -242,7 +256,8 @@ class ReflectionParameter implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function isDefaultValueConstant(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isDefaultValueConstant() {}
 
     /**
      * Returns the default value's constant name if default value is constant or null
@@ -254,7 +269,8 @@ class ReflectionParameter implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getDefaultValueConstantName(): ?string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string|null'], default: '')]
+    public function getDefaultValueConstantName() {}
 
     /**
      * Returns whether this function is variadic
@@ -265,7 +281,8 @@ class ReflectionParameter implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function isVariadic(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isVariadic() {}
 
     /**
      * Returns information about whether the parameter is a promoted.

--- a/Reflection/ReflectionProperty.php
+++ b/Reflection/ReflectionProperty.php
@@ -132,7 +132,8 @@ class ReflectionProperty implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getName(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function getName() {}
 
     /**
      * Gets value
@@ -146,7 +147,8 @@ class ReflectionProperty implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getValue(#[LanguageLevelTypeAware(['8.0' => 'object|null'], default: '')] $object = null): mixed {}
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function getValue(#[LanguageLevelTypeAware(['8.0' => 'object|null'], default: '')] $object = null) {}
 
     /**
      * Set property value
@@ -159,10 +161,11 @@ class ReflectionProperty implements Reflector
      * @return void No value is returned.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
     public function setValue(
         #[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $objectOrValue,
         #[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $value
-    ): void {}
+    ) {}
 
     /**
      * Checks if property is public
@@ -172,7 +175,8 @@ class ReflectionProperty implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function isPublic(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isPublic() {}
 
     /**
      * Checks if property is private
@@ -182,7 +186,8 @@ class ReflectionProperty implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function isPrivate(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isPrivate() {}
 
     /**
      * Checks if property is protected
@@ -192,7 +197,8 @@ class ReflectionProperty implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function isProtected(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isProtected() {}
 
     /**
      * Checks if property is static
@@ -202,7 +208,8 @@ class ReflectionProperty implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function isStatic(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isStatic() {}
 
     /**
      * Checks if default value
@@ -213,7 +220,8 @@ class ReflectionProperty implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function isDefault(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isDefault() {}
 
     /**
      * Gets modifiers
@@ -223,7 +231,8 @@ class ReflectionProperty implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getModifiers(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function getModifiers() {}
 
     /**
      * Gets declaring class
@@ -233,7 +242,8 @@ class ReflectionProperty implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getDeclaringClass(): ReflectionClass {}
+    #[LanguageLevelTypeAware(['8.1' => 'ReflectionClass'], default: '')]
+    public function getDeclaringClass() {}
 
     /**
      * Gets doc comment
@@ -243,7 +253,8 @@ class ReflectionProperty implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getDocComment(): string|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'string|false'], default: '')]
+    public function getDocComment() {}
 
     /**
      * Set property accessibility
@@ -254,7 +265,8 @@ class ReflectionProperty implements Reflector
      */
     #[PhpStormStubsElementAvailable(to: "8.0")]
     #[TentativeType]
-    public function setAccessible(#[LanguageLevelTypeAware(['8.0' => 'bool'], default: '')] $accessible): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function setAccessible(#[LanguageLevelTypeAware(['8.0' => 'bool'], default: '')] $accessible) {}
 
     /**
      * Set property accessibility
@@ -266,8 +278,9 @@ class ReflectionProperty implements Reflector
      */
     #[PhpStormStubsElementAvailable(from: "8.1")]
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
     #[Deprecated('Deprecated: it has no effect', since: '8.5')]
-    public function setAccessible(bool $accessible): void {}
+    public function setAccessible(bool $accessible) {}
 
     /**
      * Gets property type
@@ -296,7 +309,8 @@ class ReflectionProperty implements Reflector
      * @since 7.4
      */
     #[TentativeType]
-    public function hasType(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function hasType() {}
 
     /**
      * Checks if property is initialized
@@ -309,7 +323,8 @@ class ReflectionProperty implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function isInitialized(?object $object = null): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isInitialized(?object $object = null) {}
 
     /**
      * Returns information about whether the property was promoted.
@@ -350,7 +365,8 @@ class ReflectionProperty implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getDefaultValue(): mixed {}
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function getDefaultValue() {}
 
     /**
      * @template T

--- a/Reflection/ReflectionType.php
+++ b/Reflection/ReflectionType.php
@@ -3,6 +3,7 @@
 use JetBrains\PhpStorm\Internal\PhpStormStubsElementAvailable;
 use JetBrains\PhpStorm\Internal\TentativeType;
 use JetBrains\PhpStorm\Pure;
+use JetBrains\PhpStorm\Internal\LanguageLevelTypeAware;
 
 /**
  * The ReflectionType class reports information about a function's parameters.
@@ -20,7 +21,8 @@ abstract class ReflectionType implements Stringable
      * @since 7.0
      */
     #[TentativeType]
-    public function allowsNull(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function allowsNull() {}
 
     /**
      * Checks if it is a built-in type

--- a/Reflection/ReflectionZendExtension.php
+++ b/Reflection/ReflectionZendExtension.php
@@ -62,7 +62,8 @@ class ReflectionZendExtension implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getName(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function getName() {}
 
     /**
      * Gets version
@@ -73,7 +74,8 @@ class ReflectionZendExtension implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getVersion(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function getVersion() {}
 
     /**
      * Gets author
@@ -84,7 +86,8 @@ class ReflectionZendExtension implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getAuthor(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function getAuthor() {}
 
     /**
      * Gets URL
@@ -95,7 +98,8 @@ class ReflectionZendExtension implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getURL(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function getURL() {}
 
     /**
      * Gets copyright
@@ -106,7 +110,8 @@ class ReflectionZendExtension implements Reflector
      */
     #[Pure]
     #[TentativeType]
-    public function getCopyright(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function getCopyright() {}
 
     /**
      * Clone handler

--- a/SPL/SPL.php
+++ b/SPL/SPL.php
@@ -106,7 +106,8 @@ class EmptyIterator implements Iterator
      * @return mixed Can return any type.
      */
     #[TentativeType]
-    public function current(): never {}
+    #[LanguageLevelTypeAware(['8.1' => 'never'], default: '')]
+    public function current() {}
 
     /**
      * Move forward to next element
@@ -114,7 +115,8 @@ class EmptyIterator implements Iterator
      * @return void Any returned value is ignored.
      */
     #[TentativeType]
-    public function next(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function next() {}
 
     /**
      * Return the key of the current element
@@ -122,7 +124,8 @@ class EmptyIterator implements Iterator
      * @return mixed The key of the current element.
      */
     #[TentativeType]
-    public function key(): never {}
+    #[LanguageLevelTypeAware(['8.1' => 'never'], default: '')]
+    public function key() {}
 
     /**
      * Checks if current position is valid
@@ -140,7 +143,8 @@ class EmptyIterator implements Iterator
      * @return void Any returned value is ignored.
      */
     #[TentativeType]
-    public function rewind(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function rewind() {}
 }
 
 /**
@@ -168,7 +172,8 @@ class CallbackFilterIterator extends FilterIterator
      * @return bool true if the current element is acceptable, otherwise false.
      */
     #[TentativeType]
-    public function accept(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function accept() {}
 }
 
 /**
@@ -197,7 +202,8 @@ class RecursiveCallbackFilterIterator extends CallbackFilterIterator implements 
      * @return bool Returns TRUE if the current element has children, FALSE otherwise.
      */
     #[TentativeType]
-    public function hasChildren(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function hasChildren() {}
 
     /**
      * Returns an iterator for the current entry.
@@ -205,7 +211,8 @@ class RecursiveCallbackFilterIterator extends CallbackFilterIterator implements 
      * @return RecursiveCallbackFilterIterator containing the children.
      */
     #[TentativeType]
-    public function getChildren(): RecursiveCallbackFilterIterator {}
+    #[LanguageLevelTypeAware(['8.1' => 'RecursiveCallbackFilterIterator'], default: '')]
+    public function getChildren() {}
 }
 
 /**
@@ -221,7 +228,8 @@ interface RecursiveIterator extends Iterator
      * @return bool true if the current entry can be iterated over, otherwise returns false.
      */
     #[TentativeType]
-    public function hasChildren(): bool;
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function hasChildren();
 
     /**
      * Returns an iterator for the current entry.
@@ -229,7 +237,8 @@ interface RecursiveIterator extends Iterator
      * @return RecursiveIterator|null An iterator for the current entry.
      */
     #[TentativeType]
-    public function getChildren(): ?RecursiveIterator;
+    #[LanguageLevelTypeAware(['8.1' => 'RecursiveIterator|null'], default: '')]
+    public function getChildren();
 }
 
 /**
@@ -278,7 +287,8 @@ class RecursiveIteratorIterator implements OuterIterator
      * @return void
      */
     #[TentativeType]
-    public function rewind(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function rewind() {}
 
     /**
      * Check whether the current position is valid
@@ -286,7 +296,8 @@ class RecursiveIteratorIterator implements OuterIterator
      * @return bool true if the current position is valid, otherwise false
      */
     #[TentativeType]
-    public function valid(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function valid() {}
 
     /**
      * Access the current key
@@ -294,7 +305,8 @@ class RecursiveIteratorIterator implements OuterIterator
      * @return mixed The key of the current element.
      */
     #[TentativeType]
-    public function key(): mixed {}
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function key() {}
 
     /**
      * Access the current element value
@@ -302,7 +314,8 @@ class RecursiveIteratorIterator implements OuterIterator
      * @return mixed The current elements value.
      */
     #[TentativeType]
-    public function current(): mixed {}
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function current() {}
 
     /**
      * Move forward to the next element
@@ -310,7 +323,8 @@ class RecursiveIteratorIterator implements OuterIterator
      * @return void
      */
     #[TentativeType]
-    public function next(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function next() {}
 
     /**
      * Get the current depth of the recursive iteration
@@ -318,7 +332,8 @@ class RecursiveIteratorIterator implements OuterIterator
      * @return int The current depth of the recursive iteration.
      */
     #[TentativeType]
-    public function getDepth(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function getDepth() {}
 
     /**
      * The current active sub iterator
@@ -327,7 +342,8 @@ class RecursiveIteratorIterator implements OuterIterator
      * @return RecursiveIterator|null The current active sub iterator.
      */
     #[TentativeType]
-    public function getSubIterator(#[LanguageLevelTypeAware(['8.0' => 'int|null'], default: '')] $level = null): ?RecursiveIterator {}
+    #[LanguageLevelTypeAware(['8.1' => 'RecursiveIterator|null'], default: '')]
+    public function getSubIterator(#[LanguageLevelTypeAware(['8.0' => 'int|null'], default: '')] $level = null) {}
 
     /**
      * Get inner iterator
@@ -335,7 +351,8 @@ class RecursiveIteratorIterator implements OuterIterator
      * @return RecursiveIterator The current active sub iterator.
      */
     #[TentativeType]
-    public function getInnerIterator(): RecursiveIterator {}
+    #[LanguageLevelTypeAware(['8.1' => 'RecursiveIterator'], default: '')]
+    public function getInnerIterator() {}
 
     /**
      * Begin Iteration
@@ -343,7 +360,8 @@ class RecursiveIteratorIterator implements OuterIterator
      * @return void
      */
     #[TentativeType]
-    public function beginIteration(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function beginIteration() {}
 
     /**
      * End Iteration
@@ -351,7 +369,8 @@ class RecursiveIteratorIterator implements OuterIterator
      * @return void
      */
     #[TentativeType]
-    public function endIteration(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function endIteration() {}
 
     /**
      * Has children
@@ -359,7 +378,8 @@ class RecursiveIteratorIterator implements OuterIterator
      * @return bool true if the element has children, otherwise false
      */
     #[TentativeType]
-    public function callHasChildren(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function callHasChildren() {}
 
     /**
      * Get children
@@ -367,7 +387,8 @@ class RecursiveIteratorIterator implements OuterIterator
      * @return RecursiveIterator|null A <b>RecursiveIterator</b>.
      */
     #[TentativeType]
-    public function callGetChildren(): ?RecursiveIterator {}
+    #[LanguageLevelTypeAware(['8.1' => 'RecursiveIterator|null'], default: '')]
+    public function callGetChildren() {}
 
     /**
      * Begin children
@@ -375,7 +396,8 @@ class RecursiveIteratorIterator implements OuterIterator
      * @return void
      */
     #[TentativeType]
-    public function beginChildren(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function beginChildren() {}
 
     /**
      * End children
@@ -383,7 +405,8 @@ class RecursiveIteratorIterator implements OuterIterator
      * @return void
      */
     #[TentativeType]
-    public function endChildren(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function endChildren() {}
 
     /**
      * Next element
@@ -391,7 +414,8 @@ class RecursiveIteratorIterator implements OuterIterator
      * @return void
      */
     #[TentativeType]
-    public function nextElement(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function nextElement() {}
 
     /**
      * Set max depth
@@ -403,7 +427,8 @@ class RecursiveIteratorIterator implements OuterIterator
      * @return void
      */
     #[TentativeType]
-    public function setMaxDepth(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $maxDepth = -1): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function setMaxDepth(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $maxDepth = -1) {}
 
     /**
      * Get max depth
@@ -411,7 +436,8 @@ class RecursiveIteratorIterator implements OuterIterator
      * @return int|false The maximum accepted depth, or false if any depth is allowed.
      */
     #[TentativeType]
-    public function getMaxDepth(): int|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'int|false'], default: '')]
+    public function getMaxDepth() {}
 }
 
 /**
@@ -427,7 +453,8 @@ interface OuterIterator extends Iterator
      * @return Iterator|null The inner iterator for the current entry.
      */
     #[TentativeType]
-    public function getInnerIterator(): ?Iterator;
+    #[LanguageLevelTypeAware(['8.1' => 'Iterator|null'], default: '')]
+    public function getInnerIterator();
 }
 
 /**
@@ -455,7 +482,8 @@ class IteratorIterator implements OuterIterator
      * @return Iterator|null The inner iterator as passed to IteratorIterator::__construct.
      */
     #[TentativeType]
-    public function getInnerIterator(): ?Iterator {}
+    #[LanguageLevelTypeAware(['8.1' => 'Iterator|null'], default: '')]
+    public function getInnerIterator() {}
 
     /**
      * Rewind to the first element
@@ -463,7 +491,8 @@ class IteratorIterator implements OuterIterator
      * @return void
      */
     #[TentativeType]
-    public function rewind(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function rewind() {}
 
     /**
      * Checks if the iterator is valid
@@ -471,7 +500,8 @@ class IteratorIterator implements OuterIterator
      * @return bool true if the iterator is valid, otherwise false
      */
     #[TentativeType]
-    public function valid(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function valid() {}
 
     /**
      * Get the key of the current element
@@ -479,7 +509,8 @@ class IteratorIterator implements OuterIterator
      * @return mixed The key of the current element.
      */
     #[TentativeType]
-    public function key(): mixed {}
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function key() {}
 
     /**
      * Get the current value
@@ -487,7 +518,8 @@ class IteratorIterator implements OuterIterator
      * @return mixed The value of the current element.
      */
     #[TentativeType]
-    public function current(): mixed {}
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function current() {}
 
     /**
      * Forward to the next element
@@ -495,7 +527,8 @@ class IteratorIterator implements OuterIterator
      * @return void
      */
     #[TentativeType]
-    public function next(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function next() {}
 }
 
 /**
@@ -512,7 +545,8 @@ abstract class FilterIterator extends IteratorIterator
      * @return bool true if the current element is acceptable, otherwise false.
      */
     #[TentativeType]
-    abstract public function accept(): bool;
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    abstract public function accept();
 
     /**
      * Construct a filterIterator
@@ -527,7 +561,8 @@ abstract class FilterIterator extends IteratorIterator
      * @return void
      */
     #[TentativeType]
-    public function rewind(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function rewind() {}
 
     /**
      * Check whether the current element is valid
@@ -535,7 +570,8 @@ abstract class FilterIterator extends IteratorIterator
      * @return bool true if the current element is valid, otherwise false
      */
     #[TentativeType]
-    public function valid(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function valid() {}
 
     /**
      * Get the current key
@@ -543,7 +579,8 @@ abstract class FilterIterator extends IteratorIterator
      * @return mixed The key of the current element.
      */
     #[TentativeType]
-    public function key(): mixed {}
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function key() {}
 
     /**
      * Get the current element value
@@ -551,7 +588,8 @@ abstract class FilterIterator extends IteratorIterator
      * @return mixed The current element value.
      */
     #[TentativeType]
-    public function current(): mixed {}
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function current() {}
 
     /**
      * Move the iterator forward
@@ -559,7 +597,8 @@ abstract class FilterIterator extends IteratorIterator
      * @return void
      */
     #[TentativeType]
-    public function next(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function next() {}
 
     /**
      * Get the inner iterator
@@ -567,7 +606,8 @@ abstract class FilterIterator extends IteratorIterator
      * @return Iterator The inner iterator.
      */
     #[TentativeType]
-    public function getInnerIterator(): ?Iterator {}
+    #[LanguageLevelTypeAware(['8.1' => 'Iterator|null'], default: '')]
+    public function getInnerIterator() {}
 }
 
 /**
@@ -591,7 +631,8 @@ abstract class RecursiveFilterIterator extends FilterIterator implements Recursi
      * @return bool true if the inner iterator has children, otherwise false
      */
     #[TentativeType]
-    public function hasChildren(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function hasChildren() {}
 
     /**
      * Return the inner iterator's children contained in a RecursiveFilterIterator
@@ -599,7 +640,8 @@ abstract class RecursiveFilterIterator extends FilterIterator implements Recursi
      * @return RecursiveFilterIterator|null containing the inner iterator's children.
      */
     #[TentativeType]
-    public function getChildren(): ?RecursiveFilterIterator {}
+    #[LanguageLevelTypeAware(['8.1' => 'RecursiveFilterIterator|null'], default: '')]
+    public function getChildren() {}
 }
 
 /**
@@ -614,7 +656,8 @@ class ParentIterator extends RecursiveFilterIterator
      * @return bool true if the current element is acceptable, otherwise false.
      */
     #[TentativeType]
-    public function accept(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function accept() {}
 
     /**
      * Constructs a ParentIterator
@@ -629,7 +672,8 @@ class ParentIterator extends RecursiveFilterIterator
      * @return bool true if the inner iterator has children, otherwise false
      */
     #[TentativeType]
-    public function hasChildren(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function hasChildren() {}
 
     /**
      * Return the inner iterator's children contained in a RecursiveFilterIterator
@@ -637,7 +681,8 @@ class ParentIterator extends RecursiveFilterIterator
      * @return ParentIterator containing the inner iterator's children.
      */
     #[TentativeType]
-    public function getChildren(): ?RecursiveFilterIterator {}
+    #[LanguageLevelTypeAware(['8.1' => 'RecursiveFilterIterator|null'], default: '')]
+    public function getChildren() {}
 }
 
 /**
@@ -658,7 +703,8 @@ interface SeekableIterator extends Iterator
      * @return void
      */
     #[TentativeType]
-    public function seek(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $offset): void;
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function seek(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $offset);
 }
 
 /**
@@ -687,7 +733,8 @@ class LimitIterator extends IteratorIterator
      * @return void
      */
     #[TentativeType]
-    public function rewind(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function rewind() {}
 
     /**
      * Check whether the current element is valid
@@ -695,7 +742,8 @@ class LimitIterator extends IteratorIterator
      * @return bool true on success or false on failure.
      */
     #[TentativeType]
-    public function valid(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function valid() {}
 
     /**
      * Get current key
@@ -703,7 +751,8 @@ class LimitIterator extends IteratorIterator
      * @return mixed The key of the current element.
      */
     #[TentativeType]
-    public function key(): mixed {}
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function key() {}
 
     /**
      * Get current element
@@ -711,7 +760,8 @@ class LimitIterator extends IteratorIterator
      * @return mixed the current element or null if there is none.
      */
     #[TentativeType]
-    public function current(): mixed {}
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function current() {}
 
     /**
      * Move the iterator forward
@@ -719,7 +769,8 @@ class LimitIterator extends IteratorIterator
      * @return void
      */
     #[TentativeType]
-    public function next(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function next() {}
 
     /**
      * Seek to the given position
@@ -730,7 +781,8 @@ class LimitIterator extends IteratorIterator
      * @return int the offset position after seeking.
      */
     #[TentativeType]
-    public function seek(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $offset): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function seek(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $offset) {}
 
     /**
      * Return the current position
@@ -738,7 +790,8 @@ class LimitIterator extends IteratorIterator
      * @return int The current position.
      */
     #[TentativeType]
-    public function getPosition(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function getPosition() {}
 
     /**
      * Get inner iterator
@@ -746,7 +799,8 @@ class LimitIterator extends IteratorIterator
      * @return Iterator The inner iterator passed to <b>LimitIterator::__construct</b>.
      */
     #[TentativeType]
-    public function getInnerIterator(): ?Iterator {}
+    #[LanguageLevelTypeAware(['8.1' => 'Iterator|null'], default: '')]
+    public function getInnerIterator() {}
 }
 
 /**
@@ -802,7 +856,8 @@ class CachingIterator extends IteratorIterator implements ArrayAccess, Countable
      * @return void
      */
     #[TentativeType]
-    public function rewind(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function rewind() {}
 
     /**
      * Check whether the current element is valid
@@ -810,7 +865,8 @@ class CachingIterator extends IteratorIterator implements ArrayAccess, Countable
      * @return bool true on success or false on failure.
      */
     #[TentativeType]
-    public function valid(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function valid() {}
 
     /**
      * Return the key for the current element
@@ -818,7 +874,8 @@ class CachingIterator extends IteratorIterator implements ArrayAccess, Countable
      * @return mixed The key of the current element.
      */
     #[TentativeType]
-    public function key(): mixed {}
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function key() {}
 
     /**
      * Return the current element
@@ -826,7 +883,8 @@ class CachingIterator extends IteratorIterator implements ArrayAccess, Countable
      * @return mixed
      */
     #[TentativeType]
-    public function current(): mixed {}
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function current() {}
 
     /**
      * Move the iterator forward
@@ -834,7 +892,8 @@ class CachingIterator extends IteratorIterator implements ArrayAccess, Countable
      * @return void
      */
     #[TentativeType]
-    public function next(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function next() {}
 
     /**
      * Check whether the inner iterator has a valid next element
@@ -842,7 +901,8 @@ class CachingIterator extends IteratorIterator implements ArrayAccess, Countable
      * @return bool true on success or false on failure.
      */
     #[TentativeType]
-    public function hasNext(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function hasNext() {}
 
     /**
      * Return the string representation of the current iteration based on the flag being used.
@@ -858,7 +918,8 @@ class CachingIterator extends IteratorIterator implements ArrayAccess, Countable
      * @return Iterator an object implementing the Iterator interface.
      */
     #[TentativeType]
-    public function getInnerIterator(): ?Iterator {}
+    #[LanguageLevelTypeAware(['8.1' => 'Iterator|null'], default: '')]
+    public function getInnerIterator() {}
 
     /**
      * Get flags used
@@ -866,7 +927,8 @@ class CachingIterator extends IteratorIterator implements ArrayAccess, Countable
      * @return int Bitmask of the flags
      */
     #[TentativeType]
-    public function getFlags(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function getFlags() {}
 
     /**
      * The setFlags purpose
@@ -875,7 +937,8 @@ class CachingIterator extends IteratorIterator implements ArrayAccess, Countable
      * @return void
      */
     #[TentativeType]
-    public function setFlags(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $flags): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function setFlags(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $flags) {}
 
     /**
      * Internal cache array index to retrieve.
@@ -885,7 +948,8 @@ class CachingIterator extends IteratorIterator implements ArrayAccess, Countable
      * @throws BadMethodCallException when the {@see CachingIterator::FULL_CACHE} flag is not being used.
      */
     #[TentativeType]
-    public function offsetGet($key): mixed {}
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function offsetGet($key) {}
 
     /**
      * Set an element on the internal cache array.
@@ -896,7 +960,8 @@ class CachingIterator extends IteratorIterator implements ArrayAccess, Countable
      * @throws BadMethodCallException when the {@see CachingIterator::FULL_CACHE} flag is not being used.
      */
     #[TentativeType]
-    public function offsetSet($key, #[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $value): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function offsetSet($key, #[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $value) {}
 
     /**
      * Remove an element from the internal cache array.
@@ -906,7 +971,8 @@ class CachingIterator extends IteratorIterator implements ArrayAccess, Countable
      * @throws BadMethodCallException when the {@see CachingIterator::FULL_CACHE} flag is not being used.
      */
     #[TentativeType]
-    public function offsetUnset($key): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function offsetUnset($key) {}
 
     /**
      * Return whether an element at the index exists on the internal cache array.
@@ -916,7 +982,8 @@ class CachingIterator extends IteratorIterator implements ArrayAccess, Countable
      * @throws BadMethodCallException when the {@see CachingIterator::FULL_CACHE} flag is not being used.
      */
     #[TentativeType]
-    public function offsetExists($key): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function offsetExists($key) {}
 
     /**
      * Retrieve the contents of the cache
@@ -925,7 +992,8 @@ class CachingIterator extends IteratorIterator implements ArrayAccess, Countable
      * @throws BadMethodCallException when the {@see CachingIterator::FULL_CACHE} flag is not being used.
      */
     #[TentativeType]
-    public function getCache(): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public function getCache() {}
 
     /**
      * The number of elements in the iterator
@@ -935,7 +1003,8 @@ class CachingIterator extends IteratorIterator implements ArrayAccess, Countable
      * @since 5.2
      */
     #[TentativeType]
-    public function count(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function count() {}
 }
 
 /**
@@ -958,7 +1027,8 @@ class RecursiveCachingIterator extends CachingIterator implements RecursiveItera
      * @return bool true if the inner iterator has children, otherwise false
      */
     #[TentativeType]
-    public function hasChildren(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function hasChildren() {}
 
     /**
      * Return the inner iterator's children as a RecursiveCachingIterator
@@ -966,7 +1036,8 @@ class RecursiveCachingIterator extends CachingIterator implements RecursiveItera
      * @return RecursiveCachingIterator|null The inner iterator's children, as a RecursiveCachingIterator.
      */
     #[TentativeType]
-    public function getChildren(): ?RecursiveCachingIterator {}
+    #[LanguageLevelTypeAware(['8.1' => 'RecursiveCachingIterator|null'], default: '')]
+    public function getChildren() {}
 }
 
 /**
@@ -988,7 +1059,8 @@ class NoRewindIterator extends IteratorIterator
      * @return void
      */
     #[TentativeType]
-    public function rewind(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function rewind() {}
 
     /**
      * Validates the iterator
@@ -996,7 +1068,8 @@ class NoRewindIterator extends IteratorIterator
      * @return bool true on success or false on failure.
      */
     #[TentativeType]
-    public function valid(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function valid() {}
 
     /**
      * Get the current key
@@ -1004,7 +1077,8 @@ class NoRewindIterator extends IteratorIterator
      * @return mixed The key of the current element.
      */
     #[TentativeType]
-    public function key(): mixed {}
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function key() {}
 
     /**
      * Get the current value
@@ -1012,7 +1086,8 @@ class NoRewindIterator extends IteratorIterator
      * @return mixed The current value.
      */
     #[TentativeType]
-    public function current(): mixed {}
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function current() {}
 
     /**
      * Forward to the next element
@@ -1020,7 +1095,8 @@ class NoRewindIterator extends IteratorIterator
      * @return void
      */
     #[TentativeType]
-    public function next(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function next() {}
 
     /**
      * Get the inner iterator
@@ -1028,7 +1104,8 @@ class NoRewindIterator extends IteratorIterator
      * @return Iterator The inner iterator, as passed to <b>NoRewindIterator::__construct</b>.
      */
     #[TentativeType]
-    public function getInnerIterator(): ?Iterator {}
+    #[LanguageLevelTypeAware(['8.1' => 'Iterator|null'], default: '')]
+    public function getInnerIterator() {}
 }
 
 /**
@@ -1052,7 +1129,8 @@ class AppendIterator extends IteratorIterator
      * @return void
      */
     #[TentativeType]
-    public function append(Iterator $iterator): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function append(Iterator $iterator) {}
 
     /**
      * Rewinds the Iterator
@@ -1060,7 +1138,8 @@ class AppendIterator extends IteratorIterator
      * @return void
      */
     #[TentativeType]
-    public function rewind(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function rewind() {}
 
     /**
      * Checks validity of the current element
@@ -1068,7 +1147,8 @@ class AppendIterator extends IteratorIterator
      * @return bool true on success or false on failure.
      */
     #[TentativeType]
-    public function valid(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function valid() {}
 
     /**
      * Gets the current key
@@ -1076,7 +1156,8 @@ class AppendIterator extends IteratorIterator
      * @return mixed The key of the current element.
      */
     #[TentativeType]
-    public function key(): mixed {}
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function key() {}
 
     /**
      * Gets the current value
@@ -1084,7 +1165,8 @@ class AppendIterator extends IteratorIterator
      * @return mixed The current value if it is valid or null otherwise.
      */
     #[TentativeType]
-    public function current(): mixed {}
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function current() {}
 
     /**
      * Moves to the next element
@@ -1092,7 +1174,8 @@ class AppendIterator extends IteratorIterator
      * @return void
      */
     #[TentativeType]
-    public function next(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function next() {}
 
     /**
      * Gets an inner iterator
@@ -1100,7 +1183,8 @@ class AppendIterator extends IteratorIterator
      * @return Iterator the current inner Iterator.
      */
     #[TentativeType]
-    public function getInnerIterator(): ?Iterator {}
+    #[LanguageLevelTypeAware(['8.1' => 'Iterator|null'], default: '')]
+    public function getInnerIterator() {}
 
     /**
      * Gets an index of iterators
@@ -1108,7 +1192,8 @@ class AppendIterator extends IteratorIterator
      * @return int|null The index of iterators.
      */
     #[TentativeType]
-    public function getIteratorIndex(): ?int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int|null'], default: '')]
+    public function getIteratorIndex() {}
 
     /**
      * The getArrayIterator method
@@ -1116,7 +1201,8 @@ class AppendIterator extends IteratorIterator
      * @return ArrayIterator containing the appended iterators.
      */
     #[TentativeType]
-    public function getArrayIterator(): ArrayIterator {}
+    #[LanguageLevelTypeAware(['8.1' => 'ArrayIterator'], default: '')]
+    public function getArrayIterator() {}
 }
 
 /**
@@ -1140,7 +1226,8 @@ class InfiniteIterator extends IteratorIterator
      * @return void
      */
     #[TentativeType]
-    public function next(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function next() {}
 }
 
 /**
@@ -1206,7 +1293,8 @@ class RegexIterator extends FilterIterator
      * @return bool true if a match, false otherwise.
      */
     #[TentativeType]
-    public function accept(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function accept() {}
 
     /**
      * Returns operation mode.
@@ -1214,7 +1302,8 @@ class RegexIterator extends FilterIterator
      * @return int the operation mode.
      */
     #[TentativeType]
-    public function getMode(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function getMode() {}
 
     /**
      * Sets the operation mode.
@@ -1267,7 +1356,8 @@ class RegexIterator extends FilterIterator
      * @return void
      */
     #[TentativeType]
-    public function setMode(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $mode): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function setMode(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $mode) {}
 
     /**
      * Get flags
@@ -1275,7 +1365,8 @@ class RegexIterator extends FilterIterator
      * @return int the set flags.
      */
     #[TentativeType]
-    public function getFlags(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function getFlags() {}
 
     /**
      * Sets the flags.
@@ -1304,7 +1395,8 @@ class RegexIterator extends FilterIterator
      * @return void
      */
     #[TentativeType]
-    public function setFlags(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $flags): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function setFlags(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $flags) {}
 
     /**
      * Returns current regular expression
@@ -1313,7 +1405,8 @@ class RegexIterator extends FilterIterator
      * @since 5.4
      */
     #[TentativeType]
-    public function getRegex(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function getRegex() {}
 
     /**
      * Returns the regular expression flags.
@@ -1321,7 +1414,8 @@ class RegexIterator extends FilterIterator
      * @return int a bitmask of the regular expression flags.
      */
     #[TentativeType]
-    public function getPregFlags(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function getPregFlags() {}
 
     /**
      * Sets the regular expression flags.
@@ -1333,7 +1427,8 @@ class RegexIterator extends FilterIterator
      * @return void
      */
     #[TentativeType]
-    public function setPregFlags(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $pregFlags): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function setPregFlags(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $pregFlags) {}
 }
 
 /**
@@ -1365,7 +1460,8 @@ class RecursiveRegexIterator extends RegexIterator implements RecursiveIterator
      * @return bool true if an iterator can be obtained for the current entry, otherwise returns false.
      */
     #[TentativeType]
-    public function hasChildren(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function hasChildren() {}
 
     /**
      * Returns an iterator for the current entry.
@@ -1373,7 +1469,8 @@ class RecursiveRegexIterator extends RegexIterator implements RecursiveIterator
      * @return RecursiveRegexIterator An iterator for the current entry, if it can be iterated over by the inner iterator.
      */
     #[TentativeType]
-    public function getChildren(): RecursiveRegexIterator {}
+    #[LanguageLevelTypeAware(['8.1' => 'RecursiveRegexIterator'], default: '')]
+    public function getChildren() {}
 }
 
 /**
@@ -1412,7 +1509,8 @@ class RecursiveTreeIterator extends RecursiveIteratorIterator
      * @return void
      */
     #[TentativeType]
-    public function rewind(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function rewind() {}
 
     /**
      * Check validity
@@ -1420,7 +1518,8 @@ class RecursiveTreeIterator extends RecursiveIteratorIterator
      * @return bool true if the current position is valid, otherwise false
      */
     #[TentativeType]
-    public function valid(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function valid() {}
 
     /**
      * Get the key of the current element
@@ -1428,7 +1527,8 @@ class RecursiveTreeIterator extends RecursiveIteratorIterator
      * @return string the current key prefixed and postfixed.
      */
     #[TentativeType]
-    public function key(): mixed {}
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function key() {}
 
     /**
      * Get current element
@@ -1436,7 +1536,8 @@ class RecursiveTreeIterator extends RecursiveIteratorIterator
      * @return string the current element prefixed and postfixed.
      */
     #[TentativeType]
-    public function current(): mixed {}
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function current() {}
 
     /**
      * Move to next element
@@ -1444,7 +1545,8 @@ class RecursiveTreeIterator extends RecursiveIteratorIterator
      * @return void
      */
     #[TentativeType]
-    public function next(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function next() {}
 
     /**
      * Begin iteration
@@ -1452,7 +1554,8 @@ class RecursiveTreeIterator extends RecursiveIteratorIterator
      * @return void
      */
     #[TentativeType]
-    public function beginIteration(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function beginIteration() {}
 
     /**
      * End iteration
@@ -1460,7 +1563,8 @@ class RecursiveTreeIterator extends RecursiveIteratorIterator
      * @return void
      */
     #[TentativeType]
-    public function endIteration(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function endIteration() {}
 
     /**
      * Has children
@@ -1468,7 +1572,8 @@ class RecursiveTreeIterator extends RecursiveIteratorIterator
      * @return bool true if there are children, otherwise false
      */
     #[TentativeType]
-    public function callHasChildren(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function callHasChildren() {}
 
     /**
      * Get children
@@ -1476,7 +1581,8 @@ class RecursiveTreeIterator extends RecursiveIteratorIterator
      * @return RecursiveIterator|null A <b>RecursiveIterator</b>.
      */
     #[TentativeType]
-    public function callGetChildren(): ?RecursiveIterator {}
+    #[LanguageLevelTypeAware(['8.1' => 'RecursiveIterator|null'], default: '')]
+    public function callGetChildren() {}
 
     /**
      * Begin children
@@ -1484,7 +1590,8 @@ class RecursiveTreeIterator extends RecursiveIteratorIterator
      * @return void
      */
     #[TentativeType]
-    public function beginChildren(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function beginChildren() {}
 
     /**
      * End children
@@ -1492,7 +1599,8 @@ class RecursiveTreeIterator extends RecursiveIteratorIterator
      * @return void
      */
     #[TentativeType]
-    public function endChildren(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function endChildren() {}
 
     /**
      * Next element
@@ -1500,7 +1608,8 @@ class RecursiveTreeIterator extends RecursiveIteratorIterator
      * @return void
      */
     #[TentativeType]
-    public function nextElement(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function nextElement() {}
 
     /**
      * Get the prefix
@@ -1508,13 +1617,15 @@ class RecursiveTreeIterator extends RecursiveIteratorIterator
      * @return string the string to place in front of current element
      */
     #[TentativeType]
-    public function getPrefix(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function getPrefix() {}
 
     /**
      * @param string $postfix
      */
     #[TentativeType]
-    public function setPostfix(#[PhpStormStubsElementAvailable(from: '7.3')] string $postfix): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function setPostfix(#[PhpStormStubsElementAvailable(from: '7.3')] string $postfix) {}
 
     /**
      * Set a part of the prefix
@@ -1528,10 +1639,11 @@ class RecursiveTreeIterator extends RecursiveIteratorIterator
      * @return void
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
     public function setPrefixPart(
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $part,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $value
-    ): void {}
+    ) {}
 
     /**
      * Get current entry
@@ -1539,7 +1651,8 @@ class RecursiveTreeIterator extends RecursiveIteratorIterator
      * @return string the part of the tree built for the current element.
      */
     #[TentativeType]
-    public function getEntry(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function getEntry() {}
 
     /**
      * Get the postfix
@@ -1547,7 +1660,8 @@ class RecursiveTreeIterator extends RecursiveIteratorIterator
      * @return string to place after the current element.
      */
     #[TentativeType]
-    public function getPostfix(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function getPostfix() {}
 }
 
 /**
@@ -1592,7 +1706,8 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
      * @return bool true if the requested index exists, otherwise false
      */
     #[TentativeType]
-    public function offsetExists(#[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $key): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function offsetExists(#[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $key) {}
 
     /**
      * Returns the value at the specified index
@@ -1603,7 +1718,8 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
      * @return TValue|null The value at the specified index or null.
      */
     #[TentativeType]
-    public function offsetGet(#[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $key): mixed {}
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function offsetGet(#[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $key) {}
 
     /**
      * Sets the value at the specified index to newval
@@ -1617,10 +1733,11 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
      * @return void
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
     public function offsetSet(
         #[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $key,
         #[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $value
-    ): void {}
+    ) {}
 
     /**
      * Unsets the value at the specified index
@@ -1631,7 +1748,8 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
      * @return void
      */
     #[TentativeType]
-    public function offsetUnset(#[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $key): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function offsetUnset(#[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $key) {}
 
     /**
      * Appends the value
@@ -1642,7 +1760,8 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
      * @return void
      */
     #[TentativeType]
-    public function append(#[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $value): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function append(#[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $value) {}
 
     /**
      * Creates a copy of the ArrayObject.
@@ -1651,7 +1770,8 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
      * an array of the public properties of that object will be returned.
      */
     #[TentativeType]
-    public function getArrayCopy(): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public function getArrayCopy() {}
 
     /**
      * Get the number of public properties in the ArrayObject
@@ -1660,7 +1780,8 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
      * @return int The number of public properties in the ArrayObject.
      */
     #[TentativeType]
-    public function count(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function count() {}
 
     /**
      * Gets the behavior flags.
@@ -1668,7 +1789,8 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
      * @return int the behavior flags of the ArrayObject.
      */
     #[TentativeType]
-    public function getFlags(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function getFlags() {}
 
     /**
      * Sets the behavior flags.
@@ -1706,7 +1828,8 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
      * @return void
      */
     #[TentativeType]
-    public function setFlags(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $flags): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function setFlags(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $flags) {}
 
     /**
      * Sort the entries by value
@@ -1784,7 +1907,8 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
      * @return void
      */
     #[TentativeType]
-    public function unserialize(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $data): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function unserialize(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $data) {}
 
     /**
      * Serialize an ArrayObject
@@ -1792,28 +1916,32 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
      * @return string The serialized representation of the <b>ArrayObject</b>.
      */
     #[TentativeType]
-    public function serialize(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function serialize() {}
 
     /**
      * @return array
      * @since 7.4
      */
     #[TentativeType]
-    public function __debugInfo(): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public function __debugInfo() {}
 
     /**
      * @return array
      * @since 7.4
      */
     #[TentativeType]
-    public function __serialize(): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public function __serialize() {}
 
     /**
      * @param array $data
      * @since 7.4
      */
     #[TentativeType]
-    public function __unserialize(array $data): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function __unserialize(array $data) {}
 
     /**
      * Create a new iterator from an ArrayObject instance
@@ -1821,7 +1949,8 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
      * @return ArrayIterator<TKey, TValue> An iterator from an <b>ArrayObject</b>.
      */
     #[TentativeType]
-    public function getIterator(): Iterator {}
+    #[LanguageLevelTypeAware(['8.1' => 'Iterator'], default: '')]
+    public function getIterator() {}
 
     /**
      * Exchange the array for another one.
@@ -1832,7 +1961,8 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
      * @return array the old array.
      */
     #[TentativeType]
-    public function exchangeArray(#[LanguageLevelTypeAware(['8.0' => 'object|array'], default: '')] $array): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public function exchangeArray(#[LanguageLevelTypeAware(['8.0' => 'object|array'], default: '')] $array) {}
 
     /**
      * Sets the iterator classname for the ArrayObject.
@@ -1843,7 +1973,8 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
      * @return void
      */
     #[TentativeType]
-    public function setIteratorClass(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $iteratorClass): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function setIteratorClass(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $iteratorClass) {}
 
     /**
      * Gets the iterator classname for the ArrayObject.
@@ -1851,7 +1982,8 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
      * @return class-string<ArrayIterator> the iterator class name that is used to iterate over this object.
      */
     #[TentativeType]
-    public function getIteratorClass(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function getIteratorClass() {}
 }
 
 /**
@@ -1890,7 +2022,8 @@ class ArrayIterator implements SeekableIterator, ArrayAccess, Serializable, Coun
      * @return bool true if the offset exists, otherwise false
      */
     #[TentativeType]
-    public function offsetExists(#[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $key): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function offsetExists(#[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $key) {}
 
     /**
      * Get value for an offset
@@ -1901,7 +2034,8 @@ class ArrayIterator implements SeekableIterator, ArrayAccess, Serializable, Coun
      * @return TValue|null The value at offset <i>index</i>.
      */
     #[TentativeType]
-    public function offsetGet(#[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $key): mixed {}
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function offsetGet(#[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $key) {}
 
     /**
      * Set value for an offset
@@ -1915,10 +2049,11 @@ class ArrayIterator implements SeekableIterator, ArrayAccess, Serializable, Coun
      * @return void
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
     public function offsetSet(
         #[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $key,
         #[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $value
-    ): void {}
+    ) {}
 
     /**
      * Unset value for an offset
@@ -1929,7 +2064,8 @@ class ArrayIterator implements SeekableIterator, ArrayAccess, Serializable, Coun
      * @return void
      */
     #[TentativeType]
-    public function offsetUnset(#[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $key): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function offsetUnset(#[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $key) {}
 
     /**
      * Append an element
@@ -1940,7 +2076,8 @@ class ArrayIterator implements SeekableIterator, ArrayAccess, Serializable, Coun
      * @return void
      */
     #[TentativeType]
-    public function append(#[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $value): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function append(#[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $value) {}
 
     /**
      * Get array copy
@@ -1949,7 +2086,8 @@ class ArrayIterator implements SeekableIterator, ArrayAccess, Serializable, Coun
      * if ArrayIterator refers to an object.
      */
     #[TentativeType]
-    public function getArrayCopy(): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public function getArrayCopy() {}
 
     /**
      * Count elements
@@ -1958,7 +2096,8 @@ class ArrayIterator implements SeekableIterator, ArrayAccess, Serializable, Coun
      * array or object, respectively.
      */
     #[TentativeType]
-    public function count(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function count() {}
 
     /**
      * Get flags
@@ -1966,7 +2105,8 @@ class ArrayIterator implements SeekableIterator, ArrayAccess, Serializable, Coun
      * @return int The current flags.
      */
     #[TentativeType]
-    public function getFlags(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function getFlags() {}
 
     /**
      * Set behaviour flags
@@ -1980,7 +2120,8 @@ class ArrayIterator implements SeekableIterator, ArrayAccess, Serializable, Coun
      * @return void
      */
     #[TentativeType]
-    public function setFlags(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $flags): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function setFlags(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $flags) {}
 
     /**
      * Sort array by values
@@ -2045,7 +2186,8 @@ class ArrayIterator implements SeekableIterator, ArrayAccess, Serializable, Coun
      * @return void
      */
     #[TentativeType]
-    public function unserialize(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $data): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function unserialize(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $data) {}
 
     /**
      * Serialize
@@ -2053,7 +2195,8 @@ class ArrayIterator implements SeekableIterator, ArrayAccess, Serializable, Coun
      * @return string The serialized <b>ArrayIterator</b>.
      */
     #[TentativeType]
-    public function serialize(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function serialize() {}
 
     /**
      * Rewind array back to the start
@@ -2061,7 +2204,8 @@ class ArrayIterator implements SeekableIterator, ArrayAccess, Serializable, Coun
      * @return void
      */
     #[TentativeType]
-    public function rewind(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function rewind() {}
 
     /**
      * Return current array entry
@@ -2069,7 +2213,8 @@ class ArrayIterator implements SeekableIterator, ArrayAccess, Serializable, Coun
      * @return TValue The current array entry.
      */
     #[TentativeType]
-    public function current(): mixed {}
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function current() {}
 
     /**
      * Return current array key
@@ -2077,7 +2222,8 @@ class ArrayIterator implements SeekableIterator, ArrayAccess, Serializable, Coun
      * @return TKey|null The key of the current element.
      */
     #[TentativeType]
-    public function key(): string|int|null {}
+    #[LanguageLevelTypeAware(['8.1' => 'string|int|null'], default: '')]
+    public function key() {}
 
     /**
      * Move to next entry
@@ -2085,7 +2231,8 @@ class ArrayIterator implements SeekableIterator, ArrayAccess, Serializable, Coun
      * @return void
      */
     #[TentativeType]
-    public function next(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function next() {}
 
     /**
      * Check whether array contains more entries
@@ -2093,7 +2240,8 @@ class ArrayIterator implements SeekableIterator, ArrayAccess, Serializable, Coun
      * @return bool
      */
     #[TentativeType]
-    public function valid(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function valid() {}
 
     /**
      * Seek to position
@@ -2104,28 +2252,32 @@ class ArrayIterator implements SeekableIterator, ArrayAccess, Serializable, Coun
      * @return void
      */
     #[TentativeType]
-    public function seek(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $offset): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function seek(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $offset) {}
 
     /**
      * @return array
      * @since 7.4
      */
     #[TentativeType]
-    public function __debugInfo(): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public function __debugInfo() {}
 
     /**
      * @return array
      * @since 7.4
      */
     #[TentativeType]
-    public function __serialize(): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public function __serialize() {}
 
     /**
      * @param array $data
      * @since 7.4
      */
     #[TentativeType]
-    public function __unserialize(array $data): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function __unserialize(array $data) {}
 }
 
 /**
@@ -2145,7 +2297,8 @@ class RecursiveArrayIterator extends ArrayIterator implements RecursiveIterator
      * otherwise false is returned.
      */
     #[TentativeType]
-    public function hasChildren(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function hasChildren() {}
 
     /**
      * Returns an iterator for the current entry if it is an array or an object.
@@ -2153,7 +2306,8 @@ class RecursiveArrayIterator extends ArrayIterator implements RecursiveIterator
      * @return RecursiveArrayIterator|null An iterator for the current entry, if it is an array or object.
      */
     #[TentativeType]
-    public function getChildren(): ?RecursiveArrayIterator {}
+    #[LanguageLevelTypeAware(['8.1' => 'RecursiveArrayIterator|null'], default: '')]
+    public function getChildren() {}
 
     /**
      * Return current array key
@@ -2161,5 +2315,6 @@ class RecursiveArrayIterator extends ArrayIterator implements RecursiveIterator
      * @return string|int|null The key of the current element.
      */
     #[TentativeType]
-    public function key(): string|int|null {}
+    #[LanguageLevelTypeAware(['8.1' => 'string|int|null'], default: '')]
+    public function key() {}
 }

--- a/SPL/SPL_c1.php
+++ b/SPL/SPL_c1.php
@@ -28,7 +28,8 @@ class SplFileInfo implements Stringable
      * @since 5.1
      */
     #[TentativeType]
-    public function getPath(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function getPath() {}
 
     /**
      * Gets the filename
@@ -37,7 +38,8 @@ class SplFileInfo implements Stringable
      * @since 5.1
      */
     #[TentativeType]
-    public function getFilename(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function getFilename() {}
 
     /**
      * Gets the file extension
@@ -47,7 +49,8 @@ class SplFileInfo implements Stringable
      * @since 5.3
      */
     #[TentativeType]
-    public function getExtension(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function getExtension() {}
 
     /**
      * Gets the base name of the file
@@ -59,7 +62,8 @@ class SplFileInfo implements Stringable
      * @since 5.2
      */
     #[TentativeType]
-    public function getBasename(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $suffix = ''): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function getBasename(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $suffix = '') {}
 
     /**
      * Gets the path to the file
@@ -68,7 +72,8 @@ class SplFileInfo implements Stringable
      * @since 5.1
      */
     #[TentativeType]
-    public function getPathname(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function getPathname() {}
 
     /**
      * Gets file permissions
@@ -77,7 +82,8 @@ class SplFileInfo implements Stringable
      * @since 5.1
      */
     #[TentativeType]
-    public function getPerms(): int|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'int|false'], default: '')]
+    public function getPerms() {}
 
     /**
      * Gets the inode for the file
@@ -87,7 +93,8 @@ class SplFileInfo implements Stringable
      * @throws \RuntimeException on error.
      */
     #[TentativeType]
-    public function getInode(): int|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'int|false'], default: '')]
+    public function getInode() {}
 
     /**
      * Gets file size
@@ -97,7 +104,8 @@ class SplFileInfo implements Stringable
      * @throws \RuntimeException on error.
      */
     #[TentativeType]
-    public function getSize(): int|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'int|false'], default: '')]
+    public function getSize() {}
 
     /**
      * Gets the owner of the file
@@ -107,7 +115,8 @@ class SplFileInfo implements Stringable
      * @throws \RuntimeException on error.
      */
     #[TentativeType]
-    public function getOwner(): int|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'int|false'], default: '')]
+    public function getOwner() {}
 
     /**
      * Gets the file group
@@ -117,7 +126,8 @@ class SplFileInfo implements Stringable
      * @throws \RuntimeException on error.
      */
     #[TentativeType]
-    public function getGroup(): int|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'int|false'], default: '')]
+    public function getGroup() {}
 
     /**
      * Gets last access time of the file
@@ -127,7 +137,8 @@ class SplFileInfo implements Stringable
      * @throws \RuntimeException on error.
      */
     #[TentativeType]
-    public function getATime(): int|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'int|false'], default: '')]
+    public function getATime() {}
 
     /**
      * Gets the last modified time
@@ -136,7 +147,8 @@ class SplFileInfo implements Stringable
      * @since 5.1
      */
     #[TentativeType]
-    public function getMTime(): int|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'int|false'], default: '')]
+    public function getMTime() {}
 
     /**
      * Gets the inode change time
@@ -146,7 +158,8 @@ class SplFileInfo implements Stringable
      * @throws \RuntimeException on error.
      */
     #[TentativeType]
-    public function getCTime(): int|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'int|false'], default: '')]
+    public function getCTime() {}
 
     /**
      * Gets file type
@@ -158,7 +171,8 @@ class SplFileInfo implements Stringable
      * @throws \RuntimeException on error.
      */
     #[TentativeType]
-    public function getType(): string|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'string|false'], default: '')]
+    public function getType() {}
 
     /**
      * Tells if the entry is writable
@@ -167,7 +181,8 @@ class SplFileInfo implements Stringable
      * @since 5.1
      */
     #[TentativeType]
-    public function isWritable(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isWritable() {}
 
     /**
      * Tells if file is readable
@@ -176,7 +191,8 @@ class SplFileInfo implements Stringable
      * @since 5.1
      */
     #[TentativeType]
-    public function isReadable(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isReadable() {}
 
     /**
      * Tells if the file is executable
@@ -185,7 +201,8 @@ class SplFileInfo implements Stringable
      * @since 5.1
      */
     #[TentativeType]
-    public function isExecutable(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isExecutable() {}
 
     /**
      * Tells if the object references a regular file
@@ -194,7 +211,8 @@ class SplFileInfo implements Stringable
      * @since 5.1
      */
     #[TentativeType]
-    public function isFile(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isFile() {}
 
     /**
      * Tells if the file is a directory
@@ -203,7 +221,8 @@ class SplFileInfo implements Stringable
      * @since 5.1
      */
     #[TentativeType]
-    public function isDir(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isDir() {}
 
     /**
      * Tells if the file is a link
@@ -212,7 +231,8 @@ class SplFileInfo implements Stringable
      * @since 5.1
      */
     #[TentativeType]
-    public function isLink(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isLink() {}
 
     /**
      * Gets the target of a link
@@ -222,7 +242,8 @@ class SplFileInfo implements Stringable
      * @throws \RuntimeException on error.
      */
     #[TentativeType]
-    public function getLinkTarget(): string|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'string|false'], default: '')]
+    public function getLinkTarget() {}
 
     /**
      * Gets absolute path to file
@@ -231,7 +252,8 @@ class SplFileInfo implements Stringable
      * @since 5.2
      */
     #[TentativeType]
-    public function getRealPath(): string|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'string|false'], default: '')]
+    public function getRealPath() {}
 
     /**
      * Gets an SplFileInfo object for the file
@@ -244,7 +266,8 @@ class SplFileInfo implements Stringable
      * @since 5.1
      */
     #[TentativeType]
-    public function getFileInfo(#[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $class = null): SplFileInfo {}
+    #[LanguageLevelTypeAware(['8.1' => 'SplFileInfo'], default: '')]
+    public function getFileInfo(#[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $class = null) {}
 
     /**
      * Gets an SplFileInfo object for the path
@@ -257,7 +280,8 @@ class SplFileInfo implements Stringable
      * @since 5.1
      */
     #[TentativeType]
-    public function getPathInfo(#[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $class = null): ?SplFileInfo {}
+    #[LanguageLevelTypeAware(['8.1' => 'SplFileInfo|null'], default: '')]
+    public function getPathInfo(#[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $class = null) {}
 
     /**
      * Gets an SplFileObject object for the file
@@ -276,11 +300,12 @@ class SplFileInfo implements Stringable
      * @throws \RuntimeException If the file cannot be opened (e.g. insufficient access rights).
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'SplFileObject'], default: '')]
     public function openFile(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $mode = 'r',
         #[LanguageLevelTypeAware(['8.0' => 'bool'], default: '')] $useIncludePath = false,
         $context = null
-    ): SplFileObject {}
+    ) {}
 
     /**
      * Sets the class name used with <b>SplFileInfo::openFile</b>
@@ -293,7 +318,8 @@ class SplFileInfo implements Stringable
      * @since 5.1
      */
     #[TentativeType]
-    public function setFileClass(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $class = SplFileObject::class): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function setFileClass(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $class = SplFileObject::class) {}
 
     /**
      * Sets the class used with getFileInfo and getPathInfo
@@ -306,7 +332,8 @@ class SplFileInfo implements Stringable
      * @since 5.1
      */
     #[TentativeType]
-    public function setInfoClass(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $class = SplFileInfo::class): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function setInfoClass(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $class = SplFileInfo::class) {}
 
     /**
      * Returns the path to the file as a string
@@ -329,7 +356,8 @@ class SplFileInfo implements Stringable
      * @since 7.4
      */
     #[TentativeType]
-    public function __debugInfo(): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public function __debugInfo() {}
 }
 
 /**
@@ -355,7 +383,8 @@ class DirectoryIterator extends SplFileInfo implements SeekableIterator
      * otherwise false
      */
     #[TentativeType]
-    public function isDot(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isDot() {}
 
     /**
      * Rewind the DirectoryIterator back to the start
@@ -363,7 +392,8 @@ class DirectoryIterator extends SplFileInfo implements SeekableIterator
      * @return void
      */
     #[TentativeType]
-    public function rewind(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function rewind() {}
 
     /**
      * Check whether current DirectoryIterator position is a valid file
@@ -371,7 +401,8 @@ class DirectoryIterator extends SplFileInfo implements SeekableIterator
      * @return bool true if the position is valid, otherwise false
      */
     #[TentativeType]
-    public function valid(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function valid() {}
 
     /**
      * Return the key for the current DirectoryIterator item
@@ -379,7 +410,8 @@ class DirectoryIterator extends SplFileInfo implements SeekableIterator
      * @return string The key for the current <b>DirectoryIterator</b> item.
      */
     #[TentativeType]
-    public function key(): mixed {}
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function key() {}
 
     /**
      * Return the current DirectoryIterator item.
@@ -387,7 +419,8 @@ class DirectoryIterator extends SplFileInfo implements SeekableIterator
      * @return DirectoryIterator The current <b>DirectoryIterator</b> item.
      */
     #[TentativeType]
-    public function current(): mixed {}
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function current() {}
 
     /**
      * Move forward to next DirectoryIterator item
@@ -395,7 +428,8 @@ class DirectoryIterator extends SplFileInfo implements SeekableIterator
      * @return void
      */
     #[TentativeType]
-    public function next(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function next() {}
 
     /**
      * Seek to a DirectoryIterator item
@@ -406,7 +440,8 @@ class DirectoryIterator extends SplFileInfo implements SeekableIterator
      * @return void
      */
     #[TentativeType]
-    public function seek(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $offset): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function seek(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $offset) {}
 }
 
 /**
@@ -446,7 +481,8 @@ class FilesystemIterator extends DirectoryIterator
      * @return void
      */
     #[TentativeType]
-    public function rewind(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function rewind() {}
 
     /**
      * Move to the next file
@@ -454,7 +490,8 @@ class FilesystemIterator extends DirectoryIterator
      * @return void
      */
     #[TentativeType]
-    public function next(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function next() {}
 
     /**
      * Retrieve the key for the current file
@@ -463,7 +500,8 @@ class FilesystemIterator extends DirectoryIterator
      * See the FilesystemIterator constants.
      */
     #[TentativeType]
-    public function key(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function key() {}
 
     /**
      * The current file
@@ -472,7 +510,8 @@ class FilesystemIterator extends DirectoryIterator
      * See the FilesystemIterator constants.
      */
     #[TentativeType]
-    public function current(): SplFileInfo|FilesystemIterator|string {}
+    #[LanguageLevelTypeAware(['8.1' => 'SplFileInfo|FilesystemIterator|string'], default: '')]
+    public function current() {}
 
     /**
      * Get the handling flags
@@ -480,7 +519,8 @@ class FilesystemIterator extends DirectoryIterator
      * @return int The integer value of the set flags.
      */
     #[TentativeType]
-    public function getFlags(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function getFlags() {}
 
     /**
      * Sets handling flags
@@ -492,10 +532,11 @@ class FilesystemIterator extends DirectoryIterator
      * @return void
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
     public function setFlags(
         #[PhpStormStubsElementAvailable(from: '5.3', to: '7.4')] $flags = null,
         #[PhpStormStubsElementAvailable(from: '8.0')] int $flags
-    ): void {}
+    ) {}
 }
 
 /**
@@ -526,7 +567,8 @@ class RecursiveDirectoryIterator extends FilesystemIterator implements Recursive
      * @return bool whether the current entry is a directory, but not '.' or '..'
      */
     #[TentativeType]
-    public function hasChildren(#[LanguageLevelTypeAware(['8.0' => 'bool'], default: '')] $allowLinks = false): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function hasChildren(#[LanguageLevelTypeAware(['8.0' => 'bool'], default: '')] $allowLinks = false) {}
 
     /**
      * Returns an iterator for the current entry if it is a directory
@@ -534,7 +576,8 @@ class RecursiveDirectoryIterator extends FilesystemIterator implements Recursive
      * @return RecursiveDirectoryIterator An iterator for the current entry, if it is a directory.
      */
     #[TentativeType]
-    public function getChildren(): RecursiveDirectoryIterator {}
+    #[LanguageLevelTypeAware(['8.1' => 'RecursiveDirectoryIterator'], default: '')]
+    public function getChildren() {}
 
     /**
      * Get sub path
@@ -542,7 +585,8 @@ class RecursiveDirectoryIterator extends FilesystemIterator implements Recursive
      * @return string The sub path (sub directory).
      */
     #[TentativeType]
-    public function getSubPath(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function getSubPath() {}
 
     /**
      * Get sub path and name
@@ -550,7 +594,8 @@ class RecursiveDirectoryIterator extends FilesystemIterator implements Recursive
      * @return string The sub path (sub directory) and filename.
      */
     #[TentativeType]
-    public function getSubPathname(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function getSubPathname() {}
 
     /**
      * Rewinds back to the beginning
@@ -558,7 +603,8 @@ class RecursiveDirectoryIterator extends FilesystemIterator implements Recursive
      * @return void
      */
     #[TentativeType]
-    public function rewind(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function rewind() {}
 
     /**
      * Move to the next file
@@ -566,7 +612,8 @@ class RecursiveDirectoryIterator extends FilesystemIterator implements Recursive
      * @return void
      */
     #[TentativeType]
-    public function next(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function next() {}
 
     /**
      * Retrieve the key for the current file
@@ -575,7 +622,8 @@ class RecursiveDirectoryIterator extends FilesystemIterator implements Recursive
      * See the FilesystemIterator constants.
      */
     #[TentativeType]
-    public function key(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function key() {}
 
     /**
      * The current file
@@ -584,7 +632,8 @@ class RecursiveDirectoryIterator extends FilesystemIterator implements Recursive
      * See the FilesystemIterator constants.
      */
     #[TentativeType]
-    public function current(): SplFileInfo|FilesystemIterator|string {}
+    #[LanguageLevelTypeAware(['8.1' => 'SplFileInfo|FilesystemIterator|string'], default: '')]
+    public function current() {}
 }
 
 /**
@@ -612,7 +661,8 @@ class GlobIterator extends FilesystemIterator implements Countable
      * integer.
      */
     #[TentativeType]
-    public function count(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function count() {}
 }
 
 /**
@@ -669,7 +719,8 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, SeekableIt
      * @throws RuntimeException If cannot be rewound
      */
     #[TentativeType]
-    public function rewind(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function rewind() {}
 
     /**
      * Reached end of file
@@ -677,7 +728,8 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, SeekableIt
      * @return bool true if file is at EOF, false otherwise.
      */
     #[TentativeType]
-    public function eof(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function eof() {}
 
     /**
      * Not at EOF
@@ -685,7 +737,8 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, SeekableIt
      * @return bool true if not reached EOF, false otherwise.
      */
     #[TentativeType]
-    public function valid(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function valid() {}
 
     /**
      * Gets line from file
@@ -695,7 +748,8 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, SeekableIt
      * @throws RuntimeException If the file cannot be read
      */
     #[TentativeType]
-    public function fgets(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function fgets() {}
 
     /**
      * Read from file
@@ -707,7 +761,8 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, SeekableIt
      * @since 5.5
      */
     #[TentativeType]
-    public function fread(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $length): string|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'string|false'], default: '')]
+    public function fread(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $length) {}
 
     /**
      * Gets line from file and parse as CSV fields
@@ -751,13 +806,14 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, SeekableIt
      * @since 5.4
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'int|false'], default: '')]
     public function fputcsv(
         array $fields,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $separator = ',',
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $enclosure = '"',
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $escape = "\\",
         #[PhpStormStubsElementAvailable('8.1')] string $eol = PHP_EOL
-    ): int|false {}
+    ) {}
 
     /**
      * Set the delimiter and enclosure character for CSV
@@ -774,11 +830,12 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, SeekableIt
      * @return void
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
     public function setCsvControl(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $separator = ",",
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $enclosure = "\"",
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $escape = "\\"
-    ): void {}
+    ) {}
 
     /**
      * Get the delimiter and enclosure character for CSV
@@ -786,7 +843,8 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, SeekableIt
      * @return array an indexed array containing the delimiter and enclosure character.
      */
     #[TentativeType]
-    public function getCsvControl(): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public function getCsvControl() {}
 
     /**
      * Portable file locking
@@ -801,7 +859,8 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, SeekableIt
      * @return bool true on success or false on failure.
      */
     #[TentativeType]
-    public function flock(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $operation, &$wouldBlock = null): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function flock(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $operation, &$wouldBlock = null) {}
 
     /**
      * Flushes the output to the file
@@ -809,7 +868,8 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, SeekableIt
      * @return bool true on success or false on failure.
      */
     #[TentativeType]
-    public function fflush(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function fflush() {}
 
     /**
      * Return current file position
@@ -817,7 +877,8 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, SeekableIt
      * @return int|false the position of the file pointer as an integer, or false on error.
      */
     #[TentativeType]
-    public function ftell(): int|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'int|false'], default: '')]
+    public function ftell() {}
 
     /**
      * Seek to a position
@@ -839,10 +900,11 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, SeekableIt
      * past EOF is not considered an error.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
     public function fseek(
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $offset,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $whence = SEEK_SET
-    ): int {}
+    ) {}
 
     /**
      * Gets character from file
@@ -850,7 +912,8 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, SeekableIt
      * @return string|false a string containing a single character read from the file or false on EOF.
      */
     #[TentativeType]
-    public function fgetc(): string|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'string|false'], default: '')]
+    public function fgetc() {}
 
     /**
      * Output all remaining data on a file pointer
@@ -859,7 +922,8 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, SeekableIt
      * and passed through to the output.
      */
     #[TentativeType]
-    public function fpassthru(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function fpassthru() {}
 
     /**
      * Gets line from file and strip HTML tags
@@ -890,10 +954,11 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, SeekableIt
      * parameters must be passed by reference.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'array|int|null'], default: '')]
     public function fscanf(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $format,
         #[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] &...$vars
-    ): array|int|null {}
+    ) {}
 
     /**
      * Write to file
@@ -914,7 +979,7 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, SeekableIt
     public function fwrite(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $data,
         #[LanguageLevelTypeAware(['8.0' => 'int', '8.5' => 'int|null'], default: '')] $length = null
-    ): int|false {}
+    ) {}
 
     /**
      * Gets information about the file
@@ -923,7 +988,8 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, SeekableIt
      * is described in detail on the <b>stat</b> manual page.
      */
     #[TentativeType]
-    public function fstat(): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public function fstat() {}
 
     /**
      * Truncates the file to a given length
@@ -940,7 +1006,8 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, SeekableIt
      * @return bool true on success or false on failure.
      */
     #[TentativeType]
-    public function ftruncate(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $size): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function ftruncate(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $size) {}
 
     /**
      * Retrieve current line of file
@@ -948,7 +1015,8 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, SeekableIt
      * @return string|array|false Retrieves the current line of the file. If the <b>SplFileObject::READ_CSV</b> flag is set, this method returns an array containing the current line parsed as CSV data.
      */
     #[TentativeType]
-    public function current(): string|array|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'string|array|false'], default: '')]
+    public function current() {}
 
     /**
      * Get line number
@@ -956,7 +1024,8 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, SeekableIt
      * @return int the current line number.
      */
     #[TentativeType]
-    public function key(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function key() {}
 
     /**
      * Read next line
@@ -964,7 +1033,8 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, SeekableIt
      * @return void
      */
     #[TentativeType]
-    public function next(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function next() {}
 
     /**
      * Sets flags for the SplFileObject
@@ -977,7 +1047,8 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, SeekableIt
      * @return void
      */
     #[TentativeType]
-    public function setFlags(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $flags): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function setFlags(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $flags) {}
 
     /**
      * Gets flags for the SplFileObject
@@ -985,7 +1056,8 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, SeekableIt
      * @return int an integer representing the flags.
      */
     #[TentativeType]
-    public function getFlags(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function getFlags() {}
 
     /**
      * Set maximum line length
@@ -998,7 +1070,8 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, SeekableIt
      * @throws DomainException When <i>maxLength</i> is less than zero.
      */
     #[TentativeType]
-    public function setMaxLineLen(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $maxLength): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function setMaxLineLen(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $maxLength) {}
 
     /**
      * Get maximum line length
@@ -1007,7 +1080,8 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, SeekableIt
      * <b>SplFileObject::setMaxLineLen</b>, default is 0.
      */
     #[TentativeType]
-    public function getMaxLineLen(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function getMaxLineLen() {}
 
     /**
      * SplFileObject does not have children
@@ -1038,7 +1112,8 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, SeekableIt
      * @throws LogicException If the <i>line</i> is negative
      */
     #[TentativeType]
-    public function seek(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $line): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function seek(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $line) {}
 
     /**
      * Alias of <b>SplFileObject::fgets</b>
@@ -1047,7 +1122,8 @@ class SplFileObject extends SplFileInfo implements RecursiveIterator, SeekableIt
      * @since 5.1
      */
     #[TentativeType]
-    public function getCurrentLine(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function getCurrentLine() {}
 
     /**
      * Alias of <b>SplFileObject::current</b>
@@ -1096,10 +1172,11 @@ class SplDoublyLinkedList implements Iterator, Countable, ArrayAccess, Serializa
      * @since 5.5
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
     public function add(
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $index,
         #[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $value
-    ): void {}
+    ) {}
 
     /**
      * Pops a node from the end of the doubly linked list
@@ -1107,7 +1184,8 @@ class SplDoublyLinkedList implements Iterator, Countable, ArrayAccess, Serializa
      * @return TValue The value of the popped node.
      */
     #[TentativeType]
-    public function pop(): mixed {}
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function pop() {}
 
     /**
      * Shifts a node from the beginning of the doubly linked list
@@ -1115,7 +1193,8 @@ class SplDoublyLinkedList implements Iterator, Countable, ArrayAccess, Serializa
      * @return TValue The value of the shifted node.
      */
     #[TentativeType]
-    public function shift(): mixed {}
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function shift() {}
 
     /**
      * Pushes an element at the end of the doubly linked list
@@ -1126,7 +1205,8 @@ class SplDoublyLinkedList implements Iterator, Countable, ArrayAccess, Serializa
      * @return void
      */
     #[TentativeType]
-    public function push(#[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $value): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function push(#[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $value) {}
 
     /**
      * Prepends the doubly linked list with an element
@@ -1137,7 +1217,8 @@ class SplDoublyLinkedList implements Iterator, Countable, ArrayAccess, Serializa
      * @return void
      */
     #[TentativeType]
-    public function unshift(#[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $value): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function unshift(#[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $value) {}
 
     /**
      * Peeks at the node from the end of the doubly linked list
@@ -1145,7 +1226,8 @@ class SplDoublyLinkedList implements Iterator, Countable, ArrayAccess, Serializa
      * @return TValue The value of the last node.
      */
     #[TentativeType]
-    public function top(): mixed {}
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function top() {}
 
     /**
      * Peeks at the node from the beginning of the doubly linked list
@@ -1153,7 +1235,8 @@ class SplDoublyLinkedList implements Iterator, Countable, ArrayAccess, Serializa
      * @return TValue The value of the first node.
      */
     #[TentativeType]
-    public function bottom(): mixed {}
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function bottom() {}
 
     /**
      * Counts the number of elements in the doubly linked list.
@@ -1161,7 +1244,8 @@ class SplDoublyLinkedList implements Iterator, Countable, ArrayAccess, Serializa
      * @return int the number of elements in the doubly linked list.
      */
     #[TentativeType]
-    public function count(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function count() {}
 
     /**
      * Checks whether the doubly linked list is empty.
@@ -1169,7 +1253,8 @@ class SplDoublyLinkedList implements Iterator, Countable, ArrayAccess, Serializa
      * @return bool whether the doubly linked list is empty.
      */
     #[TentativeType]
-    public function isEmpty(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isEmpty() {}
 
     /**
      * Sets the mode of iteration
@@ -1182,7 +1267,8 @@ class SplDoublyLinkedList implements Iterator, Countable, ArrayAccess, Serializa
      * @return int
      */
     #[TentativeType]
-    public function setIteratorMode(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $mode): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function setIteratorMode(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $mode) {}
 
     /**
      * Returns the mode of iteration
@@ -1190,7 +1276,8 @@ class SplDoublyLinkedList implements Iterator, Countable, ArrayAccess, Serializa
      * @return int the different modes and flags that affect the iteration.
      */
     #[TentativeType]
-    public function getIteratorMode(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function getIteratorMode() {}
 
     /**
      * Returns whether the requested $index exists
@@ -1201,7 +1288,8 @@ class SplDoublyLinkedList implements Iterator, Countable, ArrayAccess, Serializa
      * @return bool true if the requested <i>index</i> exists, otherwise false
      */
     #[TentativeType]
-    public function offsetExists($index): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function offsetExists($index) {}
 
     /**
      * Returns the value at the specified $index
@@ -1212,7 +1300,8 @@ class SplDoublyLinkedList implements Iterator, Countable, ArrayAccess, Serializa
      * @return TValue The value at the specified <i>index</i>.
      */
     #[TentativeType]
-    public function offsetGet($index): mixed {}
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function offsetGet($index) {}
 
     /**
      * Sets the value at the specified $index to $newval
@@ -1226,7 +1315,8 @@ class SplDoublyLinkedList implements Iterator, Countable, ArrayAccess, Serializa
      * @return void
      */
     #[TentativeType]
-    public function offsetSet($index, #[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $value): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function offsetSet($index, #[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $value) {}
 
     /**
      * Unsets the value at the specified $index
@@ -1237,7 +1327,8 @@ class SplDoublyLinkedList implements Iterator, Countable, ArrayAccess, Serializa
      * @return void
      */
     #[TentativeType]
-    public function offsetUnset($index): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function offsetUnset($index) {}
 
     /**
      * Rewind iterator back to the start
@@ -1245,7 +1336,8 @@ class SplDoublyLinkedList implements Iterator, Countable, ArrayAccess, Serializa
      * @return void
      */
     #[TentativeType]
-    public function rewind(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function rewind() {}
 
     /**
      * Return current array entry
@@ -1253,7 +1345,8 @@ class SplDoublyLinkedList implements Iterator, Countable, ArrayAccess, Serializa
      * @return TValue The current node value.
      */
     #[TentativeType]
-    public function current(): mixed {}
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function current() {}
 
     /**
      * Return current node index
@@ -1261,7 +1354,8 @@ class SplDoublyLinkedList implements Iterator, Countable, ArrayAccess, Serializa
      * @return string|float|int|bool|null The current node index.
      */
     #[TentativeType]
-    public function key(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function key() {}
 
     /**
      * Move to next entry
@@ -1269,7 +1363,8 @@ class SplDoublyLinkedList implements Iterator, Countable, ArrayAccess, Serializa
      * @return void
      */
     #[TentativeType]
-    public function next(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function next() {}
 
     /**
      * Move to previous entry
@@ -1277,7 +1372,8 @@ class SplDoublyLinkedList implements Iterator, Countable, ArrayAccess, Serializa
      * @return void
      */
     #[TentativeType]
-    public function prev(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function prev() {}
 
     /**
      * Check whether the doubly linked list contains more nodes
@@ -1285,7 +1381,8 @@ class SplDoublyLinkedList implements Iterator, Countable, ArrayAccess, Serializa
      * @return bool true if the doubly linked list contains any more nodes, false otherwise.
      */
     #[TentativeType]
-    public function valid(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function valid() {}
 
     /**
      * Unserializes the storage
@@ -1295,7 +1392,8 @@ class SplDoublyLinkedList implements Iterator, Countable, ArrayAccess, Serializa
      * @since 5.4
      */
     #[TentativeType]
-    public function unserialize(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $data): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function unserialize(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $data) {}
 
     /**
      * Serializes the storage
@@ -1304,28 +1402,32 @@ class SplDoublyLinkedList implements Iterator, Countable, ArrayAccess, Serializa
      * @since 5.4
      */
     #[TentativeType]
-    public function serialize(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function serialize() {}
 
     /**
      * @return array
      * @since 7.4
      */
     #[TentativeType]
-    public function __debugInfo(): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public function __debugInfo() {}
 
     /**
      * @return array
      * @since 7.4
      */
     #[TentativeType]
-    public function __serialize(): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public function __serialize() {}
 
     /**
      * @param array $data
      * @since 7.4
      */
     #[TentativeType]
-    public function __unserialize(array $data): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function __unserialize(array $data) {}
 }
 
 /**
@@ -1345,7 +1447,8 @@ class SplQueue extends SplDoublyLinkedList
      * @return void
      */
     #[TentativeType]
-    public function enqueue(#[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $value): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function enqueue(#[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $value) {}
 
     /**
      * Dequeues a node from the queue
@@ -1353,7 +1456,8 @@ class SplQueue extends SplDoublyLinkedList
      * @return TValue The value of the dequeued node.
      */
     #[TentativeType]
-    public function dequeue(): mixed {}
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function dequeue() {}
 
     /**
      * Sets the mode of iteration
@@ -1366,7 +1470,8 @@ class SplQueue extends SplDoublyLinkedList
      * @return int
      */
     #[TentativeType]
-    public function setIteratorMode(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $mode): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function setIteratorMode(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $mode) {}
 }
 
 /**
@@ -1388,7 +1493,8 @@ class SplStack extends SplDoublyLinkedList
      * @return int
      */
     #[TentativeType]
-    public function setIteratorMode(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $mode): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function setIteratorMode(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $mode) {}
 }
 
 /**
@@ -1405,7 +1511,8 @@ abstract class SplHeap implements Iterator, Countable
      * @return TValue The value of the extracted node.
      */
     #[TentativeType]
-    public function extract(): mixed {}
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function extract() {}
 
     /**
      * Inserts an element in the heap by sifting it up.
@@ -1425,7 +1532,8 @@ abstract class SplHeap implements Iterator, Countable
      * @return TValue The value of the node on the top.
      */
     #[TentativeType]
-    public function top(): mixed {}
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function top() {}
 
     /**
      * Counts the number of elements in the heap.
@@ -1433,7 +1541,8 @@ abstract class SplHeap implements Iterator, Countable
      * @return int the number of elements in the heap.
      */
     #[TentativeType]
-    public function count(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function count() {}
 
     /**
      * Checks whether the heap is empty.
@@ -1441,7 +1550,8 @@ abstract class SplHeap implements Iterator, Countable
      * @return bool whether the heap is empty.
      */
     #[TentativeType]
-    public function isEmpty(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isEmpty() {}
 
     /**
      * Rewind iterator back to the start (no-op)
@@ -1449,7 +1559,8 @@ abstract class SplHeap implements Iterator, Countable
      * @return void
      */
     #[TentativeType]
-    public function rewind(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function rewind() {}
 
     /**
      * Return current node pointed by the iterator
@@ -1457,7 +1568,8 @@ abstract class SplHeap implements Iterator, Countable
      * @return TValue The current node value.
      */
     #[TentativeType]
-    public function current(): mixed {}
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function current() {}
 
     /**
      * Return current node index
@@ -1465,7 +1577,8 @@ abstract class SplHeap implements Iterator, Countable
      * @return int The current node index.
      */
     #[TentativeType]
-    public function key(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function key() {}
 
     /**
      * Move to the next node
@@ -1473,7 +1586,8 @@ abstract class SplHeap implements Iterator, Countable
      * @return void
      */
     #[TentativeType]
-    public function next(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function next() {}
 
     /**
      * Check whether the heap contains more nodes
@@ -1481,7 +1595,8 @@ abstract class SplHeap implements Iterator, Countable
      * @return bool true if the heap contains any more nodes, false otherwise.
      */
     #[TentativeType]
-    public function valid(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function valid() {}
 
     /**
      * Recover from the corrupted state and allow further actions on the heap.
@@ -1517,27 +1632,31 @@ abstract class SplHeap implements Iterator, Countable
      * @return bool
      */
     #[TentativeType]
-    public function isCorrupted(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isCorrupted() {}
 
     /**
      * @return array
      * @since 7.4
      */
     #[TentativeType]
-    public function __debugInfo(): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public function __debugInfo() {}
 
     /**
      * @return array
      * @since 8.5
      */
     #[TentativeType]
-    public function __serialize(): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public function __serialize() {}
 
     /**
      * @since 8.5
      */
     #[TentativeType]
-    public function __unserialize(array $data): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function __unserialize(array $data) {}
 }
 
 /**
@@ -1563,10 +1682,11 @@ class SplMinHeap extends SplHeap
      * Having multiple elements with the same value in a Heap is not recommended. They will end up in an arbitrary relative position.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
     protected function compare(
         #[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $value1,
         #[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $value2
-    ): int {}
+    ) {}
 
     /**
      * Extracts a node from top of the heap and sift up.
@@ -1574,7 +1694,8 @@ class SplMinHeap extends SplHeap
      * @return TValue The value of the extracted node.
      */
     #[TentativeType]
-    public function extract(): mixed {}
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function extract() {}
 
     /**
      * Inserts an element in the heap by sifting it up.
@@ -1594,7 +1715,8 @@ class SplMinHeap extends SplHeap
      * @return TValue The value of the node on the top.
      */
     #[TentativeType]
-    public function top(): mixed {}
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function top() {}
 
     /**
      * Counts the number of elements in the heap.
@@ -1602,7 +1724,8 @@ class SplMinHeap extends SplHeap
      * @return int the number of elements in the heap.
      */
     #[TentativeType]
-    public function count(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function count() {}
 
     /**
      * Checks whether the heap is empty.
@@ -1610,7 +1733,8 @@ class SplMinHeap extends SplHeap
      * @return bool whether the heap is empty.
      */
     #[TentativeType]
-    public function isEmpty(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isEmpty() {}
 
     /**
      * Rewind iterator back to the start (no-op)
@@ -1618,7 +1742,8 @@ class SplMinHeap extends SplHeap
      * @return void
      */
     #[TentativeType]
-    public function rewind(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function rewind() {}
 
     /**
      * Return current node pointed by the iterator
@@ -1626,7 +1751,8 @@ class SplMinHeap extends SplHeap
      * @return TValue The current node value.
      */
     #[TentativeType]
-    public function current(): mixed {}
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function current() {}
 
     /**
      * Return current node index
@@ -1634,7 +1760,8 @@ class SplMinHeap extends SplHeap
      * @return int The current node index.
      */
     #[TentativeType]
-    public function key(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function key() {}
 
     /**
      * Move to the next node
@@ -1642,7 +1769,8 @@ class SplMinHeap extends SplHeap
      * @return void
      */
     #[TentativeType]
-    public function next(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function next() {}
 
     /**
      * Check whether the heap contains more nodes
@@ -1650,7 +1778,8 @@ class SplMinHeap extends SplHeap
      * @return bool true if the heap contains any more nodes, false otherwise.
      */
     #[TentativeType]
-    public function valid(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function valid() {}
 
     /**
      * Recover from the corrupted state and allow further actions on the heap.
@@ -1685,10 +1814,11 @@ class SplMaxHeap extends SplHeap
      * Having multiple elements with the same value in a Heap is not recommended. They will end up in an arbitrary relative position.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
     protected function compare(
         #[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $value1,
         #[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $value2
-    ): int {}
+    ) {}
 }
 
 /**
@@ -1720,10 +1850,11 @@ class SplPriorityQueue implements Iterator, Countable
      * Multiple elements with the same priority will get dequeued in no particular order.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
     public function compare(
         #[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $priority1,
         #[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $priority2
-    ): int {}
+    ) {}
 
     /**
      * Inserts an element in the queue by sifting it up.
@@ -1737,10 +1868,11 @@ class SplPriorityQueue implements Iterator, Countable
      * @return true
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'true'], default: '')]
     public function insert(
         #[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $value,
         #[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $priority
-    ): true {}
+    ) {}
 
     /**
      * Sets the mode of extraction
@@ -1754,7 +1886,8 @@ class SplPriorityQueue implements Iterator, Countable
      * @return int
      */
     #[TentativeType]
-    public function setExtractFlags(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $flags): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function setExtractFlags(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $flags) {}
 
     /**
      * Peeks at the node from the top of the queue
@@ -1762,7 +1895,8 @@ class SplPriorityQueue implements Iterator, Countable
      * @return TValue The value or priority (or both) of the top node, depending on the extract flag.
      */
     #[TentativeType]
-    public function top(): mixed {}
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function top() {}
 
     /**
      * Extracts a node from top of the heap and sift up.
@@ -1770,7 +1904,8 @@ class SplPriorityQueue implements Iterator, Countable
      * @return TValue The value or priority (or both) of the extracted node, depending on the extract flag.
      */
     #[TentativeType]
-    public function extract(): mixed {}
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function extract() {}
 
     /**
      * Counts the number of elements in the queue.
@@ -1778,7 +1913,8 @@ class SplPriorityQueue implements Iterator, Countable
      * @return int the number of elements in the queue.
      */
     #[TentativeType]
-    public function count(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function count() {}
 
     /**
      * Checks whether the queue is empty.
@@ -1786,7 +1922,8 @@ class SplPriorityQueue implements Iterator, Countable
      * @return bool whether the queue is empty.
      */
     #[TentativeType]
-    public function isEmpty(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isEmpty() {}
 
     /**
      * Rewind iterator back to the start (no-op)
@@ -1794,7 +1931,8 @@ class SplPriorityQueue implements Iterator, Countable
      * @return void
      */
     #[TentativeType]
-    public function rewind(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function rewind() {}
 
     /**
      * Return current node pointed by the iterator
@@ -1802,7 +1940,8 @@ class SplPriorityQueue implements Iterator, Countable
      * @return TValue The value or priority (or both) of the current node, depending on the extract flag.
      */
     #[TentativeType]
-    public function current(): mixed {}
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function current() {}
 
     /**
      * Return current node index
@@ -1810,7 +1949,8 @@ class SplPriorityQueue implements Iterator, Countable
      * @return int The current node index.
      */
     #[TentativeType]
-    public function key(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function key() {}
 
     /**
      * Move to the next node
@@ -1818,7 +1958,8 @@ class SplPriorityQueue implements Iterator, Countable
      * @return void
      */
     #[TentativeType]
-    public function next(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function next() {}
 
     /**
      * Check whether the queue contains more nodes
@@ -1826,46 +1967,53 @@ class SplPriorityQueue implements Iterator, Countable
      * @return bool true if the queue contains any more nodes, false otherwise.
      */
     #[TentativeType]
-    public function valid(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function valid() {}
 
     /**
      * Recover from the corrupted state and allow further actions on the queue.
      * @link https://php.net/manual/en/splpriorityqueue.recoverfromcorruption.php
      */
     #[TentativeType]
-    public function recoverFromCorruption(): true {}
+    #[LanguageLevelTypeAware(['8.1' => 'true'], default: '')]
+    public function recoverFromCorruption() {}
 
     /**
      * @return bool
      */
     #[TentativeType]
-    public function isCorrupted(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isCorrupted() {}
 
     /**
      * @return int
      */
     #[TentativeType]
-    public function getExtractFlags(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function getExtractFlags() {}
 
     /**
      * @return array
      * @since 7.4
      */
     #[TentativeType]
-    public function __debugInfo(): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public function __debugInfo() {}
 
     /**
      * @return array
      * @since 8.5
      */
     #[TentativeType]
-    public function __serialize(): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public function __serialize() {}
 
     /**
      * @since 8.5
      */
     #[TentativeType]
-    public function __unserialize(array $data): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function __unserialize(array $data) {}
 }
 
 /**
@@ -1895,7 +2043,8 @@ class SplFixedArray implements Iterator, ArrayAccess, Countable, IteratorAggrega
      * @return int the size of the array.
      */
     #[TentativeType]
-    public function count(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function count() {}
 
     /**
      * Returns a PHP array from the fixed array
@@ -1903,7 +2052,8 @@ class SplFixedArray implements Iterator, ArrayAccess, Countable, IteratorAggrega
      * @return TValue[] a PHP array, similar to the fixed array.
      */
     #[TentativeType]
-    public function toArray(): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public function toArray() {}
 
     /**
      * Import a PHP array in a <b>SplFixedArray</b> instance
@@ -1918,10 +2068,11 @@ class SplFixedArray implements Iterator, ArrayAccess, Countable, IteratorAggrega
      * containing the array content.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'SplFixedArray'], default: '')]
     public static function fromArray(
         #[LanguageLevelTypeAware(['8.0' => 'array'], default: '')] $array,
         #[LanguageLevelTypeAware(['8.0' => 'bool'], default: '')] $preserveKeys = true
-    ): SplFixedArray {}
+    ) {}
 
     /**
      * Gets the size of the array
@@ -1929,7 +2080,8 @@ class SplFixedArray implements Iterator, ArrayAccess, Countable, IteratorAggrega
      * @return int the size of the array, as an integer.
      */
     #[TentativeType]
-    public function getSize(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function getSize() {}
 
     /**
      * Change the size of an array
@@ -1952,7 +2104,8 @@ class SplFixedArray implements Iterator, ArrayAccess, Countable, IteratorAggrega
      * @return bool true if the requested <i>index</i> exists, otherwise false
      */
     #[TentativeType]
-    public function offsetExists($index): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function offsetExists($index) {}
 
     /**
      * Returns the value at the specified index
@@ -1963,7 +2116,8 @@ class SplFixedArray implements Iterator, ArrayAccess, Countable, IteratorAggrega
      * @return TValue The value at the specified <i>index</i>.
      */
     #[TentativeType]
-    public function offsetGet($index): mixed {}
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function offsetGet($index) {}
 
     /**
      * Sets a new value at a specified index
@@ -1977,7 +2131,8 @@ class SplFixedArray implements Iterator, ArrayAccess, Countable, IteratorAggrega
      * @return void
      */
     #[TentativeType]
-    public function offsetSet($index, #[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $value): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function offsetSet($index, #[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $value) {}
 
     /**
      * Unsets the value at the specified $index
@@ -1988,7 +2143,8 @@ class SplFixedArray implements Iterator, ArrayAccess, Countable, IteratorAggrega
      * @return void
      */
     #[TentativeType]
-    public function offsetUnset($index): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function offsetUnset($index) {}
 
     /**
      * Rewind iterator back to the start
@@ -2024,11 +2180,13 @@ class SplFixedArray implements Iterator, ArrayAccess, Countable, IteratorAggrega
      * @return bool true if the array contains any more elements, false otherwise.
      */
     #[TentativeType]
-    public function valid(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function valid() {}
 
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
     #[Deprecated("The function is deprecated", since: "8.4")]
-    public function __wakeup(): void {}
+    public function __wakeup() {}
 
     #[PhpStormStubsElementAvailable(from: '8.2')]
     public function __serialize(): array {}
@@ -2062,7 +2220,8 @@ interface SplObserver
      * @return void
      */
     #[TentativeType]
-    public function update(SplSubject $subject): void;
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function update(SplSubject $subject);
 }
 
 /**
@@ -2081,7 +2240,8 @@ interface SplSubject
      * @return void
      */
     #[TentativeType]
-    public function attach(SplObserver $observer): void;
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function attach(SplObserver $observer);
 
     /**
      * Detach an observer
@@ -2092,7 +2252,8 @@ interface SplSubject
      * @return void
      */
     #[TentativeType]
-    public function detach(SplObserver $observer): void;
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function detach(SplObserver $observer);
 
     /**
      * Notify an observer
@@ -2100,7 +2261,8 @@ interface SplSubject
      * @return void
      */
     #[TentativeType]
-    public function notify(): void;
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function notify();
 }
 
 /**
@@ -2127,11 +2289,12 @@ class SplObjectStorage implements Countable, SeekableIterator, Serializable, Arr
      * @return void
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
     #[Deprecated('use method SplObjectStorage::offset{Exists|Set|Unset}() instead', since: '8.5')]
     public function attach(
         #[LanguageLevelTypeAware(['8.0' => 'object'], default: '')] $object,
         #[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $info = null
-    ): void {}
+    ) {}
 
     /**
      * Removes an object from the storage
@@ -2142,8 +2305,9 @@ class SplObjectStorage implements Countable, SeekableIterator, Serializable, Arr
      * @return void
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
     #[Deprecated('use method SplObjectStorage::offset{Exists|Set|Unset}() instead', since: '8.5')]
-    public function detach(#[LanguageLevelTypeAware(['8.0' => 'object'], default: '')] $object): void {}
+    public function detach(#[LanguageLevelTypeAware(['8.0' => 'object'], default: '')] $object) {}
 
     /**
      * Checks if the storage contains a specific object
@@ -2154,8 +2318,9 @@ class SplObjectStorage implements Countable, SeekableIterator, Serializable, Arr
      * @return bool true if the object is in the storage, false otherwise.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     #[Deprecated('use method SplObjectStorage::offset{Exists|Set|Unset}() instead', since: '8.5')]
-    public function contains(#[LanguageLevelTypeAware(['8.0' => 'object'], default: '')] $object): bool {}
+    public function contains(#[LanguageLevelTypeAware(['8.0' => 'object'], default: '')] $object) {}
 
     /**
      * Adds all objects from another storage
@@ -2166,7 +2331,8 @@ class SplObjectStorage implements Countable, SeekableIterator, Serializable, Arr
      * @return int
      */
     #[TentativeType]
-    public function addAll(#[LanguageLevelTypeAware(['8.0' => 'SplObjectStorage'], default: '')] $storage): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function addAll(#[LanguageLevelTypeAware(['8.0' => 'SplObjectStorage'], default: '')] $storage) {}
 
     /**
      * Removes objects contained in another storage from the current storage
@@ -2177,7 +2343,8 @@ class SplObjectStorage implements Countable, SeekableIterator, Serializable, Arr
      * @return int
      */
     #[TentativeType]
-    public function removeAll(#[LanguageLevelTypeAware(['8.0' => 'SplObjectStorage'], default: '')] $storage): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function removeAll(#[LanguageLevelTypeAware(['8.0' => 'SplObjectStorage'], default: '')] $storage) {}
 
     /**
      * Removes all objects except for those contained in another storage from the current storage
@@ -2189,7 +2356,8 @@ class SplObjectStorage implements Countable, SeekableIterator, Serializable, Arr
      * @since 5.3
      */
     #[TentativeType]
-    public function removeAllExcept(#[LanguageLevelTypeAware(['8.0' => 'SplObjectStorage'], default: '')] $storage): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function removeAllExcept(#[LanguageLevelTypeAware(['8.0' => 'SplObjectStorage'], default: '')] $storage) {}
 
     /**
      * Returns the data associated with the current iterator entry
@@ -2197,7 +2365,8 @@ class SplObjectStorage implements Countable, SeekableIterator, Serializable, Arr
      * @return TValue The data associated with the current iterator position.
      */
     #[TentativeType]
-    public function getInfo(): mixed {}
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function getInfo() {}
 
     /**
      * Sets the data associated with the current iterator entry
@@ -2208,7 +2377,8 @@ class SplObjectStorage implements Countable, SeekableIterator, Serializable, Arr
      * @return void
      */
     #[TentativeType]
-    public function setInfo(#[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $info): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function setInfo(#[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $info) {}
 
     /**
      * Returns the number of objects in the storage
@@ -2217,7 +2387,8 @@ class SplObjectStorage implements Countable, SeekableIterator, Serializable, Arr
      * @return int The number of objects in the storage.
      */
     #[TentativeType]
-    public function count(#[PhpStormStubsElementAvailable(from: '8.0')] int $mode = COUNT_NORMAL): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function count(#[PhpStormStubsElementAvailable(from: '8.0')] int $mode = COUNT_NORMAL) {}
 
     /**
      * Rewind the iterator to the first storage element
@@ -2225,7 +2396,8 @@ class SplObjectStorage implements Countable, SeekableIterator, Serializable, Arr
      * @return void
      */
     #[TentativeType]
-    public function rewind(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function rewind() {}
 
     /**
      * Returns if the current iterator entry is valid
@@ -2233,7 +2405,8 @@ class SplObjectStorage implements Countable, SeekableIterator, Serializable, Arr
      * @return bool true if the iterator entry is valid, false otherwise.
      */
     #[TentativeType]
-    public function valid(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function valid() {}
 
     /**
      * Returns the index at which the iterator currently is
@@ -2241,7 +2414,8 @@ class SplObjectStorage implements Countable, SeekableIterator, Serializable, Arr
      * @return int The index corresponding to the position of the iterator.
      */
     #[TentativeType]
-    public function key(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function key() {}
 
     /**
      * Returns the current storage entry
@@ -2249,7 +2423,8 @@ class SplObjectStorage implements Countable, SeekableIterator, Serializable, Arr
      * @return TObject The object at the current iterator position.
      */
     #[TentativeType]
-    public function current(): object {}
+    #[LanguageLevelTypeAware(['8.1' => 'object'], default: '')]
+    public function current() {}
 
     /**
      * Move to the next entry
@@ -2257,7 +2432,8 @@ class SplObjectStorage implements Countable, SeekableIterator, Serializable, Arr
      * @return void
      */
     #[TentativeType]
-    public function next(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function next() {}
 
     /**
      * Unserializes a storage from its string representation
@@ -2269,7 +2445,8 @@ class SplObjectStorage implements Countable, SeekableIterator, Serializable, Arr
      * @since 5.2
      */
     #[TentativeType]
-    public function unserialize(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $data): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function unserialize(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $data) {}
 
     /**
      * Serializes the storage
@@ -2278,7 +2455,8 @@ class SplObjectStorage implements Countable, SeekableIterator, Serializable, Arr
      * @since 5.2
      */
     #[TentativeType]
-    public function serialize(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function serialize() {}
 
     /**
      * Checks whether an object exists in the storage
@@ -2290,7 +2468,8 @@ class SplObjectStorage implements Countable, SeekableIterator, Serializable, Arr
      * and false otherwise.
      */
     #[TentativeType]
-    public function offsetExists($object): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function offsetExists($object) {}
 
     /**
      * Associates data to an object in the storage
@@ -2304,10 +2483,11 @@ class SplObjectStorage implements Countable, SeekableIterator, Serializable, Arr
      * @return void
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
     public function offsetSet(
         #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')] $object,
         #[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $info = null
-    ): void {}
+    ) {}
 
     /**
      * Removes an object from the storage
@@ -2318,7 +2498,8 @@ class SplObjectStorage implements Countable, SeekableIterator, Serializable, Arr
      * @return void
      */
     #[TentativeType]
-    public function offsetUnset($object): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function offsetUnset($object) {}
 
     /**
      * Returns the data associated with an <type>object</type>
@@ -2329,7 +2510,8 @@ class SplObjectStorage implements Countable, SeekableIterator, Serializable, Arr
      * @return TValue The data previously associated with the object in the storage.
      */
     #[TentativeType]
-    public function offsetGet($object): mixed {}
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function offsetGet($object) {}
 
     /**
      * Calculate a unique identifier for the contained objects
@@ -2341,28 +2523,32 @@ class SplObjectStorage implements Countable, SeekableIterator, Serializable, Arr
      * @since 5.4
      */
     #[TentativeType]
-    public function getHash(#[LanguageLevelTypeAware(['8.0' => 'object'], default: '')] $object): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function getHash(#[LanguageLevelTypeAware(['8.0' => 'object'], default: '')] $object) {}
 
     /**
      * @return array
      * @since 7.4
      */
     #[TentativeType]
-    public function __serialize(): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public function __serialize() {}
 
     /**
      * @param array $data
      * @since 7.4
      */
     #[TentativeType]
-    public function __unserialize(array $data): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function __unserialize(array $data) {}
 
     /**
      * @return array
      * @since 7.4
      */
     #[TentativeType]
-    public function __debugInfo(): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public function __debugInfo() {}
 
     /**
      * @since 8.4
@@ -2397,7 +2583,8 @@ class MultipleIterator implements Iterator
      * @return int Information about the flags, as an integer.
      */
     #[TentativeType]
-    public function getFlags(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function getFlags() {}
 
     /**
      * Sets flags
@@ -2409,7 +2596,8 @@ class MultipleIterator implements Iterator
      * @return void
      */
     #[TentativeType]
-    public function setFlags(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $flags): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function setFlags(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $flags) {}
 
     /**
      * Attaches iterator information
@@ -2424,7 +2612,8 @@ class MultipleIterator implements Iterator
      * @return void Description...
      */
     #[TentativeType]
-    public function attachIterator(Iterator $iterator, #[LanguageLevelTypeAware(['8.0' => 'int|string|null'], default: '')] $info = null): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function attachIterator(Iterator $iterator, #[LanguageLevelTypeAware(['8.0' => 'int|string|null'], default: '')] $info = null) {}
 
     /**
      * Detaches an iterator
@@ -2435,7 +2624,8 @@ class MultipleIterator implements Iterator
      * @return void
      */
     #[TentativeType]
-    public function detachIterator(Iterator $iterator): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function detachIterator(Iterator $iterator) {}
 
     /**
      * Checks if an iterator is attached
@@ -2446,7 +2636,8 @@ class MultipleIterator implements Iterator
      * @return bool true on success or false on failure.
      */
     #[TentativeType]
-    public function containsIterator(Iterator $iterator): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function containsIterator(Iterator $iterator) {}
 
     /**
      * Gets the number of attached iterator instances
@@ -2454,7 +2645,8 @@ class MultipleIterator implements Iterator
      * @return int The number of attached iterator instances (as an integer).
      */
     #[TentativeType]
-    public function countIterators(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function countIterators() {}
 
     /**
      * Rewinds all attached iterator instances
@@ -2462,7 +2654,8 @@ class MultipleIterator implements Iterator
      * @return void
      */
     #[TentativeType]
-    public function rewind(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function rewind() {}
 
     /**
      * Checks the validity of sub iterators
@@ -2471,7 +2664,8 @@ class MultipleIterator implements Iterator
      * otherwise false
      */
     #[TentativeType]
-    public function valid(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function valid() {}
 
     /**
      * Gets the registered iterator instances
@@ -2480,7 +2674,8 @@ class MultipleIterator implements Iterator
      * or false if no sub iterator is attached.
      */
     #[TentativeType]
-    public function key(): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public function key() {}
 
     /**
      * Gets the registered iterator instances
@@ -2491,7 +2686,8 @@ class MultipleIterator implements Iterator
      * @throws InvalidArgumentException if a key is NULL and MIT_KEYS_ASSOC is set.
      */
     #[TentativeType]
-    public function current(): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public function current() {}
 
     /**
      * Moves all attached iterator instances forward
@@ -2499,12 +2695,14 @@ class MultipleIterator implements Iterator
      * @return void
      */
     #[TentativeType]
-    public function next(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function next() {}
 
     /**
      * @return array
      * @since 7.4
      */
     #[TentativeType]
-    public function __debugInfo(): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public function __debugInfo() {}
 }

--- a/SimpleXML/SimpleXML.php
+++ b/SimpleXML/SimpleXML.php
@@ -55,7 +55,8 @@ class SimpleXMLElement implements Traversable, ArrayAccess, Countable, Iterator,
      * @since 5.0
      */
     #[TentativeType]
-    public function asXML(#[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $filename = null): string|bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'string|bool'], default: '')]
+    public function asXML(#[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $filename = null) {}
 
     /**
      * Alias of <b>SimpleXMLElement::asXML</b>
@@ -71,7 +72,8 @@ class SimpleXMLElement implements Traversable, ArrayAccess, Countable, Iterator,
      * successfully and false otherwise.
      */
     #[TentativeType]
-    public function saveXML(#[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $filename = null): string|bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'string|bool'], default: '')]
+    public function saveXML(#[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $filename = null) {}
 
     /**
      * Runs XPath query on XML data
@@ -83,7 +85,8 @@ class SimpleXMLElement implements Traversable, ArrayAccess, Countable, Iterator,
      * case of an error.
      */
     #[TentativeType]
-    public function xpath(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $expression): array|false|null {}
+    #[LanguageLevelTypeAware(['8.1' => 'array|false|null'], default: '')]
+    public function xpath(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $expression) {}
 
     /**
      * Creates a prefix/ns context for the next XPath query
@@ -100,10 +103,11 @@ class SimpleXMLElement implements Traversable, ArrayAccess, Countable, Iterator,
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function registerXPathNamespace(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $prefix,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $namespace
-    ): bool {}
+    ) {}
 
     /**
      * Identifies an element's attributes
@@ -123,10 +127,11 @@ class SimpleXMLElement implements Traversable, ArrayAccess, Countable, Iterator,
      * @since 5.0
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'static|null'], default: '')]
     public function attributes(
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $namespaceOrPrefix = null,
         #[LanguageLevelTypeAware(['8.0' => 'bool'], default: '')] $isPrefix = false
-    ): ?static {}
+    ) {}
 
     /**
      * Finds children of given node
@@ -146,10 +151,11 @@ class SimpleXMLElement implements Traversable, ArrayAccess, Countable, Iterator,
      */
     #[Pure]
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'static|null'], default: '')]
     public function children(
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $namespaceOrPrefix = null,
         #[LanguageLevelTypeAware(['8.0' => 'bool'], default: '')] $isPrefix = false
-    ): ?static {}
+    ) {}
 
     /**
      * Returns namespaces used in document
@@ -164,7 +170,8 @@ class SimpleXMLElement implements Traversable, ArrayAccess, Countable, Iterator,
      */
     #[Pure]
     #[TentativeType]
-    public function getNamespaces(#[LanguageLevelTypeAware(['8.0' => 'bool'], default: '')] $recursive = false): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public function getNamespaces(#[LanguageLevelTypeAware(['8.0' => 'bool'], default: '')] $recursive = false) {}
 
     /**
      * Returns namespaces declared in document
@@ -183,10 +190,11 @@ class SimpleXMLElement implements Traversable, ArrayAccess, Countable, Iterator,
      */
     #[Pure]
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'array|false'], default: '')]
     public function getDocNamespaces(
         #[LanguageLevelTypeAware(['8.0' => 'bool'], default: '')] $recursive = false,
         #[LanguageLevelTypeAware(['8.0' => 'bool'], default: '')] $fromRoot = true
-    ): array|false {}
+    ) {}
 
     /**
      * Gets the name of the XML element
@@ -197,7 +205,8 @@ class SimpleXMLElement implements Traversable, ArrayAccess, Countable, Iterator,
      */
     #[Pure]
     #[TentativeType]
-    public function getName(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function getName() {}
 
     /**
      * Adds a child element to the XML node
@@ -216,11 +225,12 @@ class SimpleXMLElement implements Traversable, ArrayAccess, Countable, Iterator,
      * @since 5.1
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'static|null'], default: '')]
     public function addChild(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $qualifiedName,
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $value = null,
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $namespace = null
-    ): ?static {}
+    ) {}
 
     /**
      * Adds an attribute to the SimpleXML element
@@ -238,12 +248,13 @@ class SimpleXMLElement implements Traversable, ArrayAccess, Countable, Iterator,
      * @since 5.1
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
     public function addAttribute(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $qualifiedName,
         #[PhpStormStubsElementAvailable(from: '5.3', to: '7.4')] $value = null,
         #[PhpStormStubsElementAvailable(from: '8.0')] string $value,
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $namespace = null
-    ): void {}
+    ) {}
 
     /**
      * Returns the string content
@@ -261,7 +272,8 @@ class SimpleXMLElement implements Traversable, ArrayAccess, Countable, Iterator,
      */
     #[Pure]
     #[TentativeType]
-    public function count(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function count() {}
 
     /**
      * Class provides access to children by position, and attributes by name
@@ -304,7 +316,8 @@ class SimpleXMLElement implements Traversable, ArrayAccess, Countable, Iterator,
      * @return void No value is returned.
      */
     #[TentativeType]
-    public function rewind(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function rewind() {}
 
     /**
      * Check whether the current element is valid
@@ -313,7 +326,8 @@ class SimpleXMLElement implements Traversable, ArrayAccess, Countable, Iterator,
      */
     #[Pure]
     #[TentativeType]
-    public function valid(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function valid() {}
 
     /**
      * Returns the current element
@@ -322,7 +336,8 @@ class SimpleXMLElement implements Traversable, ArrayAccess, Countable, Iterator,
      */
     #[Pure]
     #[TentativeType]
-    public function current(): SimpleXMLElement {}
+    #[LanguageLevelTypeAware(['8.1' => 'SimpleXMLElement'], default: '')]
+    public function current() {}
 
     /**
      * Return current key
@@ -339,7 +354,8 @@ class SimpleXMLElement implements Traversable, ArrayAccess, Countable, Iterator,
      * @return void No value is returned.
      */
     #[TentativeType]
-    public function next(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function next() {}
 
     /**
      * @return bool
@@ -347,14 +363,16 @@ class SimpleXMLElement implements Traversable, ArrayAccess, Countable, Iterator,
      */
     #[Pure]
     #[TentativeType]
-    public function hasChildren(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function hasChildren() {}
 
     /**
      * @since 8.0
      */
     #[Pure]
     #[TentativeType]
-    public function getChildren(): ?SimpleXMLElement {}
+    #[LanguageLevelTypeAware(['8.1' => 'SimpleXMLElement|null'], default: '')]
+    public function getChildren() {}
 
     /**
      * @since 8.3
@@ -394,7 +412,8 @@ class SimpleXMLIterator extends SimpleXMLElement implements RecursiveIterator, C
      */
     #[Pure]
     #[TentativeType]
-    public function current(): SimpleXMLElement {}
+    #[LanguageLevelTypeAware(['8.1' => 'SimpleXMLElement'], default: '')]
+    public function current() {}
 
     /**
      * Return current key

--- a/curl/curl.php
+++ b/curl/curl.php
@@ -39,7 +39,8 @@ class CURLFile
      */
     #[Pure]
     #[TentativeType]
-    public function getFilename(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function getFilename() {}
 
     /**
      * Get MIME type
@@ -49,7 +50,8 @@ class CURLFile
      */
     #[Pure]
     #[TentativeType]
-    public function getMimeType(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function getMimeType() {}
 
     /**
      * Get file name for POST
@@ -59,7 +61,8 @@ class CURLFile
      */
     #[Pure]
     #[TentativeType]
-    public function getPostFilename(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function getPostFilename() {}
 
     /**
      * Set MIME type
@@ -68,7 +71,8 @@ class CURLFile
      * @since 5.5
      */
     #[TentativeType]
-    public function setMimeType(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $mime_type): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function setMimeType(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $mime_type) {}
 
     /**
      * Set file name for POST
@@ -77,7 +81,8 @@ class CURLFile
      * @since 5.5
      */
     #[TentativeType]
-    public function setPostFilename(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $posted_filename): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function setPostFilename(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $posted_filename) {}
 
     /**
      * @link https://secure.php.net/manual/en/curlfile.wakeup.php

--- a/date/date_c.php
+++ b/date/date_c.php
@@ -98,10 +98,11 @@ interface DateTimeInterface
      * difference between the two dates.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'DateInterval'], default: '')]
     public function diff(
         DateTimeInterface $targetObject,
         #[LanguageLevelTypeAware(['8.0' => 'bool'], default: '')] $absolute = false
-    ): DateInterval;
+    );
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -116,7 +117,8 @@ interface DateTimeInterface
      */
     #[Pure(true)]
     #[TentativeType]
-    public function format(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $format): string;
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function format(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $format);
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -127,7 +129,7 @@ interface DateTimeInterface
      */
     #[LanguageLevelTypeAware(["8.0" => "int"], default: "int|false")]
     #[TentativeType]
-    public function getOffset(): int;
+    public function getOffset();
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -148,7 +150,8 @@ interface DateTimeInterface
      * or <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function getTimezone(): DateTimeZone|false;
+    #[LanguageLevelTypeAware(['8.1' => 'DateTimeZone|false'], default: '')]
+    public function getTimezone();
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -157,8 +160,9 @@ interface DateTimeInterface
      * @return void Initializes a DateTime object.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
     #[\JetBrains\PhpStorm\Deprecated(since: '8.5')]
-    public function __wakeup(): void;
+    public function __wakeup();
 
     #[PhpStormStubsElementAvailable(from: '8.2')]
     public function __serialize(): array;
@@ -230,8 +234,9 @@ class DateTimeImmutable implements DateTimeInterface
      * @link https://secure.php.net/manual/en/datetimeimmutable.add.php
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'DateTimeImmutable'], default: '')]
     #[\NoDiscard(message: "as DateTimeImmutable::add() does not modify the object itself")]
-    public function add(DateInterval $interval): DateTimeImmutable {}
+    public function add(DateInterval $interval) {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -243,12 +248,13 @@ class DateTimeImmutable implements DateTimeInterface
      * @return DateTimeImmutable|false
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'DateTimeImmutable|false'], default: '')]
     #[PhpStormStubsElementAvailable(from: '5.5', to: '7.4')]
     public static function createFromFormat(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $format,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $datetime,
         #[LanguageLevelTypeAware(['8.0' => 'DateTimeZone|null'], default: 'DateTimeZone')] $timezone = null
-    ): DateTimeImmutable|false {}
+    ) {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -261,12 +267,13 @@ class DateTimeImmutable implements DateTimeInterface
      * @throws ValueError when the datetime contains NULL-bytes.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'DateTimeImmutable|false'], default: '')]
     #[PhpStormStubsElementAvailable(from: '8.0')]
     public static function createFromFormat(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $format,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $datetime,
         #[LanguageLevelTypeAware(['8.0' => 'DateTimeZone|null'], default: 'DateTimeZone')] $timezone = null
-    ): DateTimeImmutable|false {}
+    ) {}
 
     /**
      * (PHP 5 &gt;=5.6.0)<br/>
@@ -287,7 +294,8 @@ class DateTimeImmutable implements DateTimeInterface
      */
     #[ArrayShape(["warning_count" => "int", "warnings" => "string[]", "error_count" => "int", "errors" => "string[]"])]
     #[TentativeType]
-    public static function getLastErrors(): array|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'array|false'], default: '')]
+    public static function getLastErrors() {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -330,7 +338,8 @@ class DateTimeImmutable implements DateTimeInterface
      * Returns a new instance of a {@link https://secure.php.net/manual/en/class.datetimeimmutable.php DateTimeImmutable} object.
      */
     #[TentativeType]
-    public static function __set_state(array $array): static {}
+    #[LanguageLevelTypeAware(['8.1' => 'static'], default: '')]
+    public static function __set_state(array $array) {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -343,12 +352,13 @@ class DateTimeImmutable implements DateTimeInterface
      * Returns the {@link https://secure.php.net/manual/en/class.datetimeimmutable.php DateTimeImmutable} object for method chaining or <b>FALSE</b> on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'DateTimeImmutable'], default: '')]
     #[\NoDiscard(message: "as DateTimeImmutable::setDate() does not modify the object itself")]
     public function setDate(
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $year,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $month,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $day
-    ): DateTimeImmutable {}
+    ) {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -361,12 +371,13 @@ class DateTimeImmutable implements DateTimeInterface
      * Returns the {@link https://secure.php.net/manual/en/class.datetimeimmutable.php DateTimeImmutable} object for method chaining or <b>FALSE</b> on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'DateTimeImmutable'], default: '')]
     #[\NoDiscard(message: "as DateTimeImmutable::setISODate() does not modify the object itself")]
     public function setISODate(
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $year,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $week,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $dayOfWeek = 1
-    ): DateTimeImmutable {}
+    ) {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -380,6 +391,7 @@ class DateTimeImmutable implements DateTimeInterface
      * Returns the {@link https://secure.php.net/manual/en/class.datetimeimmutable.php DateTimeImmutable} object for method chaining or <b>FALSE</b> on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'DateTimeImmutable'], default: '')]
     #[\NoDiscard(message: "as DateTimeImmutable::setTime() does not modify the object itself")]
     #[Pure]
     public function setTime(
@@ -387,7 +399,7 @@ class DateTimeImmutable implements DateTimeInterface
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $minute,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $second = 0,
         #[PhpStormStubsElementAvailable(from: '7.1')] #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $microsecond = 0
-    ): DateTimeImmutable {}
+    ) {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -398,8 +410,9 @@ class DateTimeImmutable implements DateTimeInterface
      * Returns the {@link https://secure.php.net/manual/en/class.datetimeimmutable.php DateTimeImmutable} object for method chaining or <b>FALSE</b> on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'DateTimeImmutable'], default: '')]
     #[\NoDiscard(message: "as DateTimeImmutable::setTimestamp() does not modify the object itself")]
-    public function setTimestamp(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $timestamp): DateTimeImmutable {}
+    public function setTimestamp(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $timestamp) {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -413,8 +426,9 @@ class DateTimeImmutable implements DateTimeInterface
      * Returns the {@link https://secure.php.net/manual/en/class.datetimeimmutable.php DateTimeImmutable} object for method chaining or <b>FALSE</b> on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'DateTimeImmutable'], default: '')]
     #[\NoDiscard(message: "as DateTimeImmutable::setTimezone() does not modify the object itself")]
-    public function setTimezone(DateTimeZone $timezone): DateTimeImmutable {}
+    public function setTimezone(DateTimeZone $timezone) {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -428,8 +442,9 @@ class DateTimeImmutable implements DateTimeInterface
      * Returns the {@link https://secure.php.net/manual/en/class.datetimeimmutable.php DateTimeImmutable} object for method chaining or <b>FALSE</b> on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'DateTimeImmutable'], default: '')]
     #[\NoDiscard(message: "as DateTimeImmutable::sub() does not modify the object itself")]
-    public function sub(DateInterval $interval): DateTimeImmutable {}
+    public function sub(DateInterval $interval) {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -442,10 +457,11 @@ class DateTimeImmutable implements DateTimeInterface
      * difference between the two dates.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'DateInterval'], default: '')]
     public function diff(
         #[LanguageLevelTypeAware(['8.0' => 'DateTimeInterface'], default: '')] $targetObject,
         #[LanguageLevelTypeAware(['8.0' => 'bool'], default: '')] $absolute = false
-    ): DateInterval {}
+    ) {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -459,7 +475,8 @@ class DateTimeImmutable implements DateTimeInterface
      */
     #[Pure(true)]
     #[TentativeType]
-    public function format(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $format): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function format(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $format) {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -469,7 +486,8 @@ class DateTimeImmutable implements DateTimeInterface
      * or <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function getOffset(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function getOffset() {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -478,7 +496,8 @@ class DateTimeImmutable implements DateTimeInterface
      * Returns the Unix timestamp representing the date.
      */
     #[TentativeType]
-    public function getTimestamp(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function getTimestamp() {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -489,7 +508,8 @@ class DateTimeImmutable implements DateTimeInterface
      * or <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function getTimezone(): DateTimeZone|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'DateTimeZone|false'], default: '')]
+    public function getTimezone() {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -498,8 +518,9 @@ class DateTimeImmutable implements DateTimeInterface
      * @return void Initializes a DateTime object.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
     #[Deprecated(since: '8.5')]
-    public function __wakeup(): void {}
+    public function __wakeup() {}
 
     /**
      * @param DateTimeInterface $object
@@ -518,7 +539,8 @@ class DateTimeImmutable implements DateTimeInterface
      * @since 8.4
      */
     #[TentativeType]
-    public static function createFromTimestamp(int|float $timestamp): static {}
+    #[LanguageLevelTypeAware(['8.1' => 'static'], default: '')]
+    public static function createFromTimestamp(int|float $timestamp) {}
 
     /**
      * @since 8.4
@@ -678,8 +700,9 @@ class DateTime implements DateTimeInterface
      * @link https://php.net/manual/en/datetime.wakeup.php
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
     #[Deprecated(since: '8.5')]
-    public function __wakeup(): void {}
+    public function __wakeup() {}
 
     /**
      * Returns date formatted according to given format.
@@ -689,7 +712,8 @@ class DateTime implements DateTimeInterface
      */
     #[Pure(true)]
     #[TentativeType]
-    public function format(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $format): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function format(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $format) {}
 
     /**
      * Alter the timestamp of a DateTime object by incrementing or decrementing
@@ -723,7 +747,8 @@ class DateTime implements DateTimeInterface
      * @link https://php.net/manual/en/datetime.add.php
      */
     #[TentativeType]
-    public function add(DateInterval $interval): DateTime {}
+    #[LanguageLevelTypeAware(['8.1' => 'DateTime'], default: '')]
+    public function add(DateInterval $interval) {}
 
     /**
      * @param DateTimeImmutable $object
@@ -742,7 +767,8 @@ class DateTime implements DateTimeInterface
      * @throws DateInvalidOperationException
      */
     #[TentativeType]
-    public function sub(DateInterval $interval): DateTime {}
+    #[LanguageLevelTypeAware(['8.1' => 'DateTime'], default: '')]
+    public function sub(DateInterval $interval) {}
 
     /**
      * Get the TimeZone associated with the DateTime
@@ -750,7 +776,8 @@ class DateTime implements DateTimeInterface
      * @link https://php.net/manual/en/datetime.gettimezone.php
      */
     #[TentativeType]
-    public function getTimezone(): DateTimeZone|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'DateTimeZone|false'], default: '')]
+    public function getTimezone() {}
 
     /**
      * Set the TimeZone associated with the DateTime
@@ -759,7 +786,8 @@ class DateTime implements DateTimeInterface
      * @link https://php.net/manual/en/datetime.settimezone.php
      */
     #[TentativeType]
-    public function setTimezone(#[LanguageLevelTypeAware(['8.0' => 'DateTimeZone'], default: '')] $timezone): DateTime {}
+    #[LanguageLevelTypeAware(['8.1' => 'DateTime'], default: '')]
+    public function setTimezone(#[LanguageLevelTypeAware(['8.0' => 'DateTimeZone'], default: '')] $timezone) {}
 
     /**
      * Returns the timezone offset
@@ -767,7 +795,8 @@ class DateTime implements DateTimeInterface
      * @link https://php.net/manual/en/datetime.getoffset.php
      */
     #[TentativeType]
-    public function getOffset(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function getOffset() {}
 
     /**
      * Sets the current time of the DateTime object to a different time.
@@ -779,12 +808,13 @@ class DateTime implements DateTimeInterface
      * @link https://php.net/manual/en/datetime.settime.php
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'DateTime'], default: '')]
     public function setTime(
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $hour,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $minute,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $second = 0,
         #[PhpStormStubsElementAvailable(from: '7.1')] #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $microsecond = 0
-    ): DateTime {}
+    ) {}
 
     /**
      * Sets the current date of the DateTime object to a different date.
@@ -795,11 +825,12 @@ class DateTime implements DateTimeInterface
      * @link https://php.net/manual/en/datetime.setdate.php
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'DateTime'], default: '')]
     public function setDate(
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $year,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $month,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $day
-    ): DateTime {}
+    ) {}
 
     /**
      * Set a date according to the ISO 8601 standard - using weeks and day offsets rather than specific dates.
@@ -810,11 +841,12 @@ class DateTime implements DateTimeInterface
      * @link https://php.net/manual/en/datetime.setisodate.php
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'DateTime'], default: '')]
     public function setISODate(
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $year,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $week,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $dayOfWeek = 1
-    ): DateTime {}
+    ) {}
 
     /**
      * Sets the date and time based on a Unix timestamp.
@@ -823,7 +855,8 @@ class DateTime implements DateTimeInterface
      * @link https://php.net/manual/en/datetime.settimestamp.php
      */
     #[TentativeType]
-    public function setTimestamp(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $timestamp): DateTime {}
+    #[LanguageLevelTypeAware(['8.1' => 'DateTime'], default: '')]
+    public function setTimestamp(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $timestamp) {}
 
     /**
      * Gets the Unix timestamp.
@@ -831,7 +864,8 @@ class DateTime implements DateTimeInterface
      * @link https://php.net/manual/en/datetime.gettimestamp.php
      */
     #[TentativeType]
-    public function getTimestamp(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function getTimestamp() {}
 
     /**
      * Returns the difference between two DateTime objects represented as a DateInterval.
@@ -841,10 +875,11 @@ class DateTime implements DateTimeInterface
      * @link https://php.net/manual/en/datetime.diff.php
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'DateInterval'], default: '')]
     public function diff(
         #[LanguageLevelTypeAware(['8.0' => 'DateTimeInterface'], default: '')] $targetObject,
         #[LanguageLevelTypeAware(['8.0' => 'bool'], default: '')] $absolute = false
-    ): DateInterval {}
+    ) {}
 
     /**
      * Parse a string into a new DateTime object according to the specified format
@@ -855,12 +890,13 @@ class DateTime implements DateTimeInterface
      * @link https://php.net/manual/en/datetime.createfromformat.php
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'DateTime|false'], default: '')]
     #[PhpStormStubsElementAvailable(from: '5.3', to: '7.4')]
     public static function createFromFormat(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $format,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $datetime,
         #[LanguageLevelTypeAware(['8.0' => 'DateTimeZone|null'], default: 'DateTimeZone')] $timezone = null
-    ): DateTime|false {}
+    ) {}
 
     /**
      * Parse a string into a new DateTime object according to the specified format
@@ -872,12 +908,13 @@ class DateTime implements DateTimeInterface
      * @throws ValueError when the datetime contains NULL-bytes.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'DateTime|false'], default: '')]
     #[PhpStormStubsElementAvailable(from: '8.0')]
     public static function createFromFormat(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $format,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $datetime,
         #[LanguageLevelTypeAware(['8.0' => 'DateTimeZone|null'], default: 'DateTimeZone')] $timezone = null
-    ): DateTime|false {}
+    ) {}
 
     /**
      * Returns an array of warnings and errors found while parsing a date/time string
@@ -886,7 +923,8 @@ class DateTime implements DateTimeInterface
      */
     #[ArrayShape(["warning_count" => "int", "warnings" => "string[]", "error_count" => "int", "errors" => "string[]"])]
     #[TentativeType]
-    public static function getLastErrors(): array|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'array|false'], default: '')]
+    public static function getLastErrors() {}
 
     /**
      * The __set_state handler
@@ -895,7 +933,8 @@ class DateTime implements DateTimeInterface
      * @return DateTime <p>Returns a new instance of a DateTime object.</p>
      */
     #[TentativeType]
-    public static function __set_state(array $array): static {}
+    #[LanguageLevelTypeAware(['8.1' => 'static'], default: '')]
+    public static function __set_state(array $array) {}
 
     /**
      * @param DateTimeInterface $object
@@ -914,7 +953,8 @@ class DateTime implements DateTimeInterface
      * @since 8.4
      */
     #[TentativeType]
-    public static function createFromTimestamp(int|float $timestamp): static {}
+    #[LanguageLevelTypeAware(['8.1' => 'static'], default: '')]
+    public static function createFromTimestamp(int|float $timestamp) {}
 
     /**
      * @since 8.4
@@ -961,7 +1001,8 @@ class DateTimeZone
      * @link https://php.net/manual/en/datetimezone.getname.php
      */
     #[TentativeType]
-    public function getName(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function getName() {}
 
     /**
      * Returns location information for a timezone
@@ -969,13 +1010,14 @@ class DateTimeZone
      * @link https://php.net/manual/en/datetimezone.getlocation.php
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'array|false'], default: '')]
     #[ArrayShape([
         'country_code' => 'string',
         'latitude' => 'double',
         'longitude' => 'double',
         'comments' => 'string',
     ])]
-    public function getLocation(): array|false {}
+    public function getLocation() {}
 
     /**
      * Returns the timezone offset from GMT
@@ -984,7 +1026,8 @@ class DateTimeZone
      * @link https://php.net/manual/en/datetimezone.getoffset.php
      */
     #[TentativeType]
-    public function getOffset(DateTimeInterface $datetime): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function getOffset(DateTimeInterface $datetime) {}
 
     /**
      * Returns all transitions for the timezone
@@ -994,12 +1037,13 @@ class DateTimeZone
      * @link https://php.net/manual/en/datetimezone.gettransitions.php
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'array|false'], default: '')]
     public function getTransitions(
         #[PhpStormStubsElementAvailable(from: '5.3', to: '5.6')] $timestampBegin = PHP_INT_MIN,
         #[PhpStormStubsElementAvailable(from: '5.3', to: '5.6')] $timestampEnd = 2147483647,
         #[PhpStormStubsElementAvailable(from: '7.0')] #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $timestampBegin = PHP_INT_MIN,
         #[PhpStormStubsElementAvailable(from: '7.0')] #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $timestampEnd = 2147483647
-    ): array|false {}
+    ) {}
 
     /**
      * Returns associative array containing dst, offset and the timezone name
@@ -1007,7 +1051,8 @@ class DateTimeZone
      * @link https://php.net/manual/en/datetimezone.listabbreviations.php
      */
     #[TentativeType]
-    public static function listAbbreviations(): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public static function listAbbreviations() {}
 
     /**
      * Returns a numerically indexed array with all timezone identifiers
@@ -1027,11 +1072,13 @@ class DateTimeZone
      * @link https://php.net/manual/en/datetime.wakeup.php
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
     #[Deprecated(since: '8.5')]
-    public function __wakeup(): void {}
+    public function __wakeup() {}
 
     #[TentativeType]
-    public static function __set_state(array $array): static {}
+    #[LanguageLevelTypeAware(['8.1' => 'static'], default: '')]
+    public static function __set_state(array $array) {}
 
     #[PhpStormStubsElementAvailable(from: '8.2')]
     public function __serialize(): array {}
@@ -1126,7 +1173,8 @@ class DateInterval
      * @link https://php.net/manual/en/dateinterval.format.php
      */
     #[TentativeType]
-    public function format(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $format): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function format(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $format) {}
 
     /**
      * Sets up a DateInterval from the relative parts of the string
@@ -1154,11 +1202,13 @@ class DateInterval
     public static function createFromDateString(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $datetime) {}
 
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
     #[Deprecated(since: '8.5')]
-    public function __wakeup(): void {}
+    public function __wakeup() {}
 
     #[TentativeType]
-    public static function __set_state(array $array): static {}
+    #[LanguageLevelTypeAware(['8.1' => 'static'], default: '')]
+    public static function __set_state(array $array) {}
 
     #[PhpStormStubsElementAvailable(from: '8.2')]
     public function __serialize(): array {}
@@ -1269,7 +1319,8 @@ class DatePeriod implements IteratorAggregate
      * @since 5.6
      */
     #[TentativeType]
-    public function getDateInterval(): DateInterval {}
+    #[LanguageLevelTypeAware(['8.1' => 'DateInterval'], default: '')]
+    public function getDateInterval() {}
 
     /**
      * Gets the end date
@@ -1279,7 +1330,8 @@ class DatePeriod implements IteratorAggregate
      * @return TEnd
      */
     #[TentativeType]
-    public function getEndDate(): ?DateTimeInterface {}
+    #[LanguageLevelTypeAware(['8.1' => 'DateTimeInterface|null'], default: '')]
+    public function getEndDate() {}
 
     /**
      * Gets the start date
@@ -1289,14 +1341,17 @@ class DatePeriod implements IteratorAggregate
      * @return TDate
      */
     #[TentativeType]
-    public function getStartDate(): DateTimeInterface {}
+    #[LanguageLevelTypeAware(['8.1' => 'DateTimeInterface'], default: '')]
+    public function getStartDate() {}
 
     #[TentativeType]
-    public static function __set_state(#[PhpStormStubsElementAvailable(from: '7.3')] array $array): DatePeriod {}
+    #[LanguageLevelTypeAware(['8.1' => 'DatePeriod'], default: '')]
+    public static function __set_state(#[PhpStormStubsElementAvailable(from: '7.3')] array $array) {}
 
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
     #[Deprecated(since: '8.5')]
-    public function __wakeup(): void {}
+    public function __wakeup() {}
 
     /**
      * Get the number of recurrences
@@ -1305,7 +1360,8 @@ class DatePeriod implements IteratorAggregate
      * @since 7.2
      */
     #[TentativeType]
-    public function getRecurrences(): ?int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int|null'], default: '')]
+    public function getRecurrences() {}
 
     /**
      * @return \Iterator<int, TDate>

--- a/dom/dom_c.php
+++ b/dom/dom_c.php
@@ -225,7 +225,8 @@ class DOMNode
      * @return bool true on success or false on failure.
      */
     #[TentativeType]
-    public function hasChildNodes(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function hasChildNodes() {}
 
     /**
      * Clones a node
@@ -247,7 +248,8 @@ class DOMNode
      * @return void
      */
     #[TentativeType]
-    public function normalize(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function normalize() {}
 
     /**
      * Checks if feature is supported for specified version
@@ -263,10 +265,11 @@ class DOMNode
      * @return bool true on success or false on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function isSupported(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $feature,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $version
-    ): bool {}
+    ) {}
 
     /**
      * Checks if node has attributes
@@ -274,7 +277,8 @@ class DOMNode
      * @return bool true on success or false on failure.
      */
     #[TentativeType]
-    public function hasAttributes(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function hasAttributes() {}
 
     /**
      * @return int
@@ -291,7 +295,8 @@ class DOMNode
      * @return bool true on success or false on failure.
      */
     #[TentativeType]
-    public function isSameNode(DOMNode $otherNode): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isSameNode(DOMNode $otherNode) {}
 
     /**
      * Gets the namespace prefix of the node based on the namespace URI
@@ -302,7 +307,8 @@ class DOMNode
      * @return string The prefix of the namespace.
      */
     #[TentativeType]
-    public function lookupPrefix(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $namespace): ?string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string|null'], default: '')]
+    public function lookupPrefix(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $namespace) {}
 
     /**
      * Checks if the specified namespaceURI is the default namespace or not
@@ -314,7 +320,8 @@ class DOMNode
      * namespace, false otherwise.
      */
     #[TentativeType]
-    public function isDefaultNamespace(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $namespace): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isDefaultNamespace(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $namespace) {}
 
     /**
      * Gets the namespace URI of the node based on the prefix
@@ -326,7 +333,8 @@ class DOMNode
      */
     #[PhpStormStubsElementAvailable(from: '8.0')]
     #[TentativeType]
-    public function lookupNamespaceURI(?string $prefix): ?string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string|null'], default: '')]
+    public function lookupNamespaceURI(?string $prefix) {}
 
     /**
      * Gets the namespace URI of the node based on the prefix
@@ -367,7 +375,8 @@ class DOMNode
      * @link https://secure.php.net/manual/en/domnode.getnodepath.php
      */
     #[TentativeType]
-    public function getNodePath(): ?string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string|null'], default: '')]
+    public function getNodePath() {}
 
     /**
      * Get line number for a node
@@ -375,7 +384,8 @@ class DOMNode
      * @return int Always returns the line number where the node was defined in.
      */
     #[TentativeType]
-    public function getLineNo(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function getLineNo() {}
 
     /**
      * Canonicalize nodes to a string
@@ -386,12 +396,13 @@ class DOMNode
      * @return string|false Canonicalized nodes as a string or FALSE on failure
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'string|false'], default: '')]
     public function C14N(
         #[LanguageLevelTypeAware(['8.0' => 'bool'], default: '')] $exclusive = false,
         #[LanguageLevelTypeAware(['8.0' => 'bool'], default: '')] $withComments = false,
         #[LanguageLevelTypeAware(['7.1' => 'array|null'], default: '')] $xpath = null,
         #[LanguageLevelTypeAware(['7.1' => 'array|null'], default: '')] $nsPrefixes = null
-    ): string|false {}
+    ) {}
 
     /**
      * Canonicalize nodes to a file.
@@ -404,13 +415,14 @@ class DOMNode
      * @return int|false Number of bytes written or FALSE on failure
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'int|false'], default: '')]
     public function C14NFile(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $uri,
         #[LanguageLevelTypeAware(['8.0' => 'bool'], default: '')] $exclusive = false,
         #[LanguageLevelTypeAware(['8.0' => 'bool'], default: '')] $withComments = false,
         #[LanguageLevelTypeAware(['7.1' => 'array|null'], default: '')] $xpath = null,
         #[LanguageLevelTypeAware(['7.1' => 'array|null'], default: '')] $nsPrefixes = null
-    ): int|false {}
+    ) {}
 
     /**
      * @since 8.3
@@ -520,10 +532,11 @@ class DOMImplementation
      * @removed 8.4
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'never'], default: '')]
     public function getFeature(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $feature,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $version
-    ): never {}
+    ) {}
 
     /**
      * Test if the DOM implementation implements a specific feature
@@ -538,10 +551,11 @@ class DOMImplementation
      * @return bool true on success or false on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function hasFeature(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $feature,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $version
-    ): bool {}
+    ) {}
 
     /**
      * Creates an empty DOMDocumentType object
@@ -664,7 +678,8 @@ class DOMDocumentFragment extends DOMNode implements DOMParentNode
      * @return bool true on success or false on failure.
      */
     #[TentativeType]
-    public function appendXML(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $data): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function appendXML(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $data) {}
 
     /**
      * {@inheritDoc}
@@ -894,7 +909,8 @@ class DOMDocument extends DOMNode implements DOMParentNode
      * @return DOMDocumentFragment|false The new DOMDocumentFragment or false if an error occurred.
      */
     #[TentativeType]
-    public function createDocumentFragment(): DOMDocumentFragment {}
+    #[LanguageLevelTypeAware(['8.1' => 'DOMDocumentFragment'], default: '')]
+    public function createDocumentFragment() {}
 
     /**
      * Create new text node
@@ -905,7 +921,8 @@ class DOMDocument extends DOMNode implements DOMParentNode
      * @return DOMText|false The new DOMText or false if an error occurred.
      */
     #[TentativeType]
-    public function createTextNode(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $data): DOMText {}
+    #[LanguageLevelTypeAware(['8.1' => 'DOMText'], default: '')]
+    public function createTextNode(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $data) {}
 
     /**
      * Create new comment node
@@ -916,7 +933,8 @@ class DOMDocument extends DOMNode implements DOMParentNode
      * @return DOMComment|false The new DOMComment or false if an error occurred.
      */
     #[TentativeType]
-    public function createComment(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $data): DOMComment {}
+    #[LanguageLevelTypeAware(['8.1' => 'DOMComment'], default: '')]
+    public function createComment(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $data) {}
 
     /**
      * Create new cdata node
@@ -980,7 +998,8 @@ class DOMDocument extends DOMNode implements DOMParentNode
      * elements.
      */
     #[TentativeType]
-    public function getElementsByTagName(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $qualifiedName): DOMNodeList {}
+    #[LanguageLevelTypeAware(['8.1' => 'DOMNodeList'], default: '')]
+    public function getElementsByTagName(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $qualifiedName) {}
 
     /**
      * Import node into current document
@@ -1058,10 +1077,11 @@ class DOMDocument extends DOMNode implements DOMParentNode
      * elements.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'DOMNodeList'], default: '')]
     public function getElementsByTagNameNS(
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $namespace,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $localName
-    ): DOMNodeList {}
+    ) {}
 
     /**
      * Searches for an element with a certain id
@@ -1073,7 +1093,8 @@ class DOMDocument extends DOMNode implements DOMParentNode
      * not found.
      */
     #[TentativeType]
-    public function getElementById(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $elementId): ?DOMElement {}
+    #[LanguageLevelTypeAware(['8.1' => 'DOMElement|null'], default: '')]
+    public function getElementById(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $elementId) {}
 
     #[TentativeType]
     #[LanguageLevelTypeAware(['8.3' => 'DOMNode|false'], default: '')]
@@ -1101,7 +1122,8 @@ class DOMDocument extends DOMNode implements DOMParentNode
      * @return void
      */
     #[TentativeType]
-    public function normalizeDocument(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function normalizeDocument() {}
 
     /**
      * @param DOMNode $node
@@ -1143,10 +1165,11 @@ class DOMDocument extends DOMNode implements DOMParentNode
      * @return int|false the number of bytes written or false if an error occurred.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'int|false'], default: '')]
     public function save(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $filename,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $options = null
-    ): int|false {}
+    ) {}
 
     /**
      * Load XML from a string
@@ -1182,10 +1205,11 @@ class DOMDocument extends DOMNode implements DOMParentNode
      * @return string|false the XML, or false if an error occurred.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'string|false'], default: '')]
     public function saveXML(
         #[LanguageLevelTypeAware(['7.1' => 'DOMNode|null'], default: '')] $node = null,
         #[PhpStormStubsElementAvailable(from: '7.0')] #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $options = 0
-    ): string|false {}
+    ) {}
 
     /**
      * Creates a new DOMDocument object
@@ -1205,7 +1229,8 @@ class DOMDocument extends DOMNode implements DOMParentNode
      * If the document have no DTD attached, this method will return false.
      */
     #[TentativeType]
-    public function validate(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function validate() {}
 
     /**
      * Substitutes XIncludes in a DOMDocument Object
@@ -1217,7 +1242,8 @@ class DOMDocument extends DOMNode implements DOMParentNode
      * @return int|false the number of XIncludes in the document.
      */
     #[TentativeType]
-    public function xinclude(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $options = 0): int|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'int|false'], default: '')]
+    public function xinclude(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $options = 0) {}
 
     /**
      * Load HTML from a string
@@ -1268,7 +1294,8 @@ class DOMDocument extends DOMNode implements DOMParentNode
      * @return string|false The HTML, or false if an error occurred.
      */
     #[TentativeType]
-    public function saveHTML(#[LanguageLevelTypeAware(['8.0' => 'DOMNode|null'], default: '')] $node = null): string|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'string|false'], default: '')]
+    public function saveHTML(#[LanguageLevelTypeAware(['8.0' => 'DOMNode|null'], default: '')] $node = null) {}
 
     /**
      * Dumps the internal document into a file using HTML formatting
@@ -1279,7 +1306,8 @@ class DOMDocument extends DOMNode implements DOMParentNode
      * @return int|false the number of bytes written or false if an error occurred.
      */
     #[TentativeType]
-    public function saveHTMLFile(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $filename): int|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'int|false'], default: '')]
+    public function saveHTMLFile(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $filename) {}
 
     /**
      * Validates a document based on a schema
@@ -1294,10 +1322,11 @@ class DOMDocument extends DOMNode implements DOMParentNode
      * @return bool true on success or false on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function schemaValidate(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $filename,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $flags = null
-    ): bool {}
+    ) {}
 
     /**
      * Validates a document based on a schema
@@ -1310,10 +1339,11 @@ class DOMDocument extends DOMNode implements DOMParentNode
      * @return bool true on success or false on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function schemaValidateSource(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $source,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $flags = 0
-    ): bool {}
+    ) {}
 
     /**
      * Performs relaxNG validation on the document
@@ -1324,7 +1354,8 @@ class DOMDocument extends DOMNode implements DOMParentNode
      * @return bool true on success or false on failure.
      */
     #[TentativeType]
-    public function relaxNGValidate(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $filename): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function relaxNGValidate(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $filename) {}
 
     /**
      * Performs relaxNG validation on the document
@@ -1335,7 +1366,8 @@ class DOMDocument extends DOMNode implements DOMParentNode
      * @return bool true on success or false on failure.
      */
     #[TentativeType]
-    public function relaxNGValidateSource(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $source): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function relaxNGValidateSource(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $source) {}
 
     /**
      * Register extended class used to create base node type
@@ -1395,7 +1427,8 @@ class DOMNodeList implements IteratorAggregate, Countable
      * @since 7.2
      */
     #[TentativeType]
-    public function count(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function count() {}
 
     /**
      * @return Iterator<int, TNode>
@@ -1432,7 +1465,8 @@ class DOMNamedNodeMap implements IteratorAggregate, Countable
      * null if no node is found.
      */
     #[TentativeType]
-    public function getNamedItem(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $qualifiedName): ?DOMNode {}
+    #[LanguageLevelTypeAware(['8.1' => 'DOMNode|null'], default: '')]
+    public function getNamedItem(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $qualifiedName) {}
 
     /**
      * @removed 8.0
@@ -1458,10 +1492,11 @@ class DOMNamedNodeMap implements IteratorAggregate, Countable
      * in this map).
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'DOMNode|null'], default: '')]
     public function item(
         #[PhpStormStubsElementAvailable(from: '5.3', to: '7.0')] $index = 0,
         #[PhpStormStubsElementAvailable(from: '7.1')] #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $index
-    ): ?DOMNode {}
+    ) {}
 
     /**
      * Retrieves a node specified by local name and namespace URI
@@ -1476,12 +1511,13 @@ class DOMNamedNodeMap implements IteratorAggregate, Countable
      * null if no node is found.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'DOMNode|null'], default: '')]
     public function getNamedItemNS(
         #[PhpStormStubsElementAvailable(from: '5.3', to: '7.4')] $namespaceURI = '',
         #[PhpStormStubsElementAvailable(from: '8.0')] ?string $namespace,
         #[PhpStormStubsElementAvailable(from: '5.3', to: '7.4')] $localName = '',
         #[PhpStormStubsElementAvailable(from: '8.0')] string $localName
-    ): ?DOMNode {}
+    ) {}
 
     /**
      * @removed 8.0
@@ -1501,7 +1537,8 @@ class DOMNamedNodeMap implements IteratorAggregate, Countable
      * @since 7.2
      */
     #[TentativeType]
-    public function count(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function count() {}
 
     /**
      * @return Iterator<string, TNode>
@@ -1580,10 +1617,11 @@ class DOMCharacterData extends DOMNode implements DOMChildNode
      * @return bool
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function insertData(
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $offset,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $data
-    ): bool {}
+    ) {}
 
     /**
      * Remove a range of characters from the node
@@ -1599,10 +1637,11 @@ class DOMCharacterData extends DOMNode implements DOMChildNode
      * @return bool
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function deleteData(
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $offset,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $count
-    ): bool {}
+    ) {}
 
     /**
      * Replace a substring within the DOMCharacterData node
@@ -1621,11 +1660,12 @@ class DOMCharacterData extends DOMNode implements DOMChildNode
      * @return bool
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function replaceData(
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $offset,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $count,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $data
-    ): bool {}
+    ) {}
 
     /**
      * {@inheritDoc}
@@ -1705,7 +1745,8 @@ class DOMAttr extends DOMNode
      * @return bool true on success or false on failure.
      */
     #[TentativeType]
-    public function isId(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isId() {}
 
     /**
      * Creates a new {@see DOMAttr} object
@@ -1817,7 +1858,8 @@ class DOMElement extends DOMNode implements DOMParentNode, DOMChildNode
      * given name is found.
      */
     #[TentativeType]
-    public function getAttribute(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $qualifiedName): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function getAttribute(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $qualifiedName) {}
 
     /**
      * Adds new attribute
@@ -1844,7 +1886,8 @@ class DOMElement extends DOMNode implements DOMParentNode, DOMChildNode
      * @return bool true on success or false on failure.
      */
     #[TentativeType]
-    public function removeAttribute(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $qualifiedName): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function removeAttribute(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $qualifiedName) {}
 
     /**
      * Returns attribute node
@@ -1887,7 +1930,8 @@ class DOMElement extends DOMNode implements DOMParentNode, DOMChildNode
      * DOMNodeList of all matched elements.
      */
     #[TentativeType]
-    public function getElementsByTagName(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $qualifiedName): DOMNodeList {}
+    #[LanguageLevelTypeAware(['8.1' => 'DOMNodeList'], default: '')]
+    public function getElementsByTagName(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $qualifiedName) {}
 
     /**
      * Returns value of attribute
@@ -1903,10 +1947,11 @@ class DOMElement extends DOMNode implements DOMParentNode, DOMChildNode
      * is found.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
     public function getAttributeNS(
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $namespace,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $localName
-    ): string {}
+    ) {}
 
     /**
      * Adds new attribute
@@ -1923,11 +1968,12 @@ class DOMElement extends DOMNode implements DOMParentNode, DOMChildNode
      * @return void
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
     public function setAttributeNS(
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $namespace,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $qualifiedName,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $value
-    ): void {}
+    ) {}
 
     /**
      * Removes attribute
@@ -1941,10 +1987,11 @@ class DOMElement extends DOMNode implements DOMParentNode, DOMChildNode
      * @return void
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
     public function removeAttributeNS(
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $namespace,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $localName
-    ): void {}
+    ) {}
 
     /**
      * Returns attribute node
@@ -1985,10 +2032,11 @@ class DOMElement extends DOMNode implements DOMParentNode, DOMChildNode
      * which they are encountered in a preorder traversal of this element tree.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'DOMNodeList'], default: '')]
     public function getElementsByTagNameNS(
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $namespace,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $localName
-    ): DOMNodeList {}
+    ) {}
 
     /**
      * Checks to see if attribute exists
@@ -1999,7 +2047,8 @@ class DOMElement extends DOMNode implements DOMParentNode, DOMChildNode
      * @return bool true on success or false on failure.
      */
     #[TentativeType]
-    public function hasAttribute(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $qualifiedName): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function hasAttribute(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $qualifiedName) {}
 
     /**
      * Checks to see if attribute exists
@@ -2013,10 +2062,11 @@ class DOMElement extends DOMNode implements DOMParentNode, DOMChildNode
      * @return bool true on success or false on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function hasAttributeNS(
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $namespace,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $localName
-    ): bool {}
+    ) {}
 
     /**
      * Declares the attribute specified by name to be of type ID
@@ -2031,10 +2081,11 @@ class DOMElement extends DOMNode implements DOMParentNode, DOMChildNode
      * @return void
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
     public function setIdAttribute(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $qualifiedName,
         #[LanguageLevelTypeAware(['8.0' => 'bool'], default: '')] $isId
-    ): void {}
+    ) {}
 
     /**
      * Declares the attribute specified by local name and namespace URI to be of type ID
@@ -2052,11 +2103,12 @@ class DOMElement extends DOMNode implements DOMParentNode, DOMChildNode
      * @return void
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
     public function setIdAttributeNS(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $namespace,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $qualifiedName,
         #[LanguageLevelTypeAware(['8.0' => 'bool'], default: '')] $isId
-    ): void {}
+    ) {}
 
     /**
      * Declares the attribute specified by node to be of type ID
@@ -2071,7 +2123,8 @@ class DOMElement extends DOMNode implements DOMParentNode, DOMChildNode
      * @return void
      */
     #[TentativeType]
-    public function setIdAttributeNode(DOMAttr $attr, #[LanguageLevelTypeAware(['8.0' => 'bool'], default: '')] $isId): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function setIdAttributeNode(DOMAttr $attr, #[LanguageLevelTypeAware(['8.0' => 'bool'], default: '')] $isId) {}
 
     /**
      * {@inheritDoc}
@@ -2175,10 +2228,12 @@ class DOMText extends DOMCharacterData
      * @return bool true on success or false on failure.
      */
     #[TentativeType]
-    public function isWhitespaceInElementContent(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isWhitespaceInElementContent() {}
 
     #[TentativeType]
-    public function isElementContentWhitespace(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isElementContentWhitespace() {}
 
     /**
      * @param $content
@@ -2513,10 +2568,11 @@ class DOMXPath
      * @return bool true on success or false on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function registerNamespace(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $prefix,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $namespace
-    ): bool {}
+    ) {}
 
     /**
      * Evaluates the given XPath expression
@@ -2537,11 +2593,12 @@ class DOMXPath
      * is malformed or the contextnode is invalid.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
     public function query(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] #[Language('XPath')] $expression,
         #[LanguageLevelTypeAware(['8.0' => 'DOMNode|null'], default: '')] $contextNode = null,
         #[LanguageLevelTypeAware(['8.0' => 'bool'], default: '')] $registerNodeNS = true
-    ): mixed {}
+    ) {}
 
     /**
      * Evaluates the given XPath expression and returns a typed result if possible.
@@ -2562,11 +2619,12 @@ class DOMXPath
      * containing all nodes matching the given XPath expression.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
     public function evaluate(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] #[Language('XPath')] $expression,
         #[LanguageLevelTypeAware(['8.0' => 'DOMNode|null'], default: '')] $contextNode = null,
         #[LanguageLevelTypeAware(['8.0' => 'bool'], default: '')] $registerNodeNS = true
-    ): mixed {}
+    ) {}
 
     /**
      * Register PHP functions as XPath functions
@@ -2581,7 +2639,8 @@ class DOMXPath
      * @return void
      */
     #[TentativeType]
-    public function registerPhpFunctions(#[LanguageLevelTypeAware(['8.0' => 'string|array|null'], default: '')] $restrict = null): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function registerPhpFunctions(#[LanguageLevelTypeAware(['8.0' => 'string|array|null'], default: '')] $restrict = null) {}
 
     /**
      * @since 8.4

--- a/fileinfo/fileinfo.php
+++ b/fileinfo/fileinfo.php
@@ -58,11 +58,12 @@ class finfo
      */
     #[Pure(true)]
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'string|false'], default: '')]
     public function file(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $filename,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $flags = FILEINFO_NONE,
         $context = null
-    ): string|false {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL fileinfo &gt;= 0.1.0)<br/>
@@ -81,11 +82,12 @@ class finfo
      */
     #[Pure(true)]
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'string|false'], default: '')]
     public function buffer(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $string,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $flags = FILEINFO_NONE,
         $context = null
-    ): string|false {}
+    ) {}
 }
 
 /**

--- a/intl/IntlChar.php
+++ b/intl/IntlChar.php
@@ -703,10 +703,11 @@ class IntlChar
      */
     #[Pure]
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool|null'], default: '')]
     public static function hasBinaryProperty(
         #[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $property
-    ): ?bool {}
+    ) {}
 
     /**
      * @link https://php.net/manual/en/intlchar.charage.php
@@ -717,7 +718,8 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
-    public static function charAge(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint): ?array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array|null'], default: '')]
+    public static function charAge(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint) {}
 
     /**
      * @link https://php.net/manual/en/intlchar.chardigitvalue.php
@@ -728,7 +730,8 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
-    public static function charDigitValue(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint): ?int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int|null'], default: '')]
+    public static function charDigitValue(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint) {}
 
     /**
      * Get bidirectional category value for a code point
@@ -766,7 +769,8 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
-    public static function charDirection(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint): ?int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int|null'], default: '')]
+    public static function charDirection(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint) {}
 
     /**
      * @link https://php.net/manual/en/intlchar.charfromname.php
@@ -785,10 +789,11 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'int|null'], default: '')]
     public static function charFromName(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $type = IntlChar::UNICODE_CHAR_NAME
-    ): ?int {}
+    ) {}
 
     /**
      * @link https://php.net/manual/en/intlchar.charmirror.php
@@ -799,7 +804,8 @@ class IntlChar
      * Or NULL if <em>codepoint</em> will be out of bound.
      */
     #[TentativeType]
-    public static function charMirror(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint): string|int|null {}
+    #[LanguageLevelTypeAware(['8.1' => 'string|int|null'], default: '')]
+    public static function charMirror(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint) {}
 
     /**
      * Retrieve the name of a Unicode character
@@ -817,10 +823,11 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'string|null'], default: '')]
     public static function charName(
         #[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $type = IntlChar::UNICODE_CHAR_NAME
-    ): ?string {}
+    ) {}
 
     /**
      * Get the general category value for a code point
@@ -864,7 +871,8 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
-    public static function charType(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint): ?int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int|null'], default: '')]
+    public static function charType(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint) {}
 
     /**
      * Return Unicode character by code point value
@@ -875,7 +883,8 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
-    public static function chr(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint): ?string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string|null'], default: '')]
+    public static function chr(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint) {}
 
     /**
      * Get the decimal digit value of a code point for a given radix
@@ -888,10 +897,11 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'int|false|null'], default: '')]
     public static function digit(
         #[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $base = 10
-    ): int|false|null {}
+    ) {}
 
     /**
      * Enumerate all assigned Unicode characters within a range
@@ -939,10 +949,11 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
     public static function enumCharTypes(
         #[PhpStormStubsElementAvailable(from: '7.0', to: '7.4')] $callback = null,
         #[PhpStormStubsElementAvailable(from: '8.0')] callable $callback
-    ): void {}
+    ) {}
 
     /**
      * Perform case folding on a code point
@@ -954,10 +965,11 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'string|int|null'], default: '')]
     public static function foldCase(
         #[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $options = IntlChar::FOLD_CASE_DEFAULT
-    ): string|int|null {}
+    ) {}
 
     /**
      * Get character representation for a given digit and radix
@@ -968,10 +980,11 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
     public static function forDigit(
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $digit,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $base = 10
-    ): int {}
+    ) {}
 
     /**
      * Get the paired bracket character for a code point
@@ -983,7 +996,8 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
-    public static function getBidiPairedBracket(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint): string|int|null {}
+    #[LanguageLevelTypeAware(['8.1' => 'string|int|null'], default: '')]
+    public static function getBidiPairedBracket(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint) {}
 
     /**
      * Get the Unicode allocation block containing a code point
@@ -994,7 +1008,8 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
-    public static function getBlockCode(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint): ?int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int|null'], default: '')]
+    public static function getBlockCode(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint) {}
 
     /**
      * Get the combining class of a code point
@@ -1005,7 +1020,8 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
-    public static function getCombiningClass(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint): ?int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int|null'], default: '')]
+    public static function getCombiningClass(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint) {}
 
     /**
      * Get the FC_NFKC_Closure property for a code point
@@ -1017,7 +1033,8 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
-    public static function getFC_NFKC_Closure(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint): string|false|null {}
+    #[LanguageLevelTypeAware(['8.1' => 'string|false|null'], default: '')]
+    public static function getFC_NFKC_Closure(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint) {}
 
     /**
      * Get the max value for a Unicode property
@@ -1027,7 +1044,8 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
-    public static function getIntPropertyMaxValue(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $property): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public static function getIntPropertyMaxValue(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $property) {}
 
     /**
      * Get the min value for a Unicode property
@@ -1037,7 +1055,8 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
-    public static function getIntPropertyMinValue(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $property): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public static function getIntPropertyMinValue(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $property) {}
 
     /**
      * Get the value for a Unicode property for a code point
@@ -1064,10 +1083,11 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'int|null'], default: '')]
     public static function getIntPropertyValue(
         #[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $property
-    ): ?int {}
+    ) {}
 
     /**
      * Get the numeric value for a Unicode code point
@@ -1077,7 +1097,8 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
-    public static function getNumericValue(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint): ?float {}
+    #[LanguageLevelTypeAware(['8.1' => 'float|null'], default: '')]
+    public static function getNumericValue(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint) {}
 
     /**
      * Get the property constant value for a given property name
@@ -1087,7 +1108,8 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
-    public static function getPropertyEnum(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $alias): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public static function getPropertyEnum(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $alias) {}
 
     /**
      * Get the Unicode name for a property
@@ -1109,10 +1131,11 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'string|false'], default: '')]
     public static function getPropertyName(
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $property,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $type = IntlChar::LONG_PROPERTY_NAME
-    ): string|false {}
+    ) {}
 
     /**
      * Get the property value for a given value name
@@ -1124,10 +1147,11 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
     public static function getPropertyValueEnum(
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $property,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name
-    ): int {}
+    ) {}
 
     /**
      * Get the Unicode name for a property value
@@ -1158,11 +1182,12 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'string|false'], default: '')]
     public static function getPropertyValueName(
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $property,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $value,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $type = IntlChar::LONG_PROPERTY_NAME
-    ): string|false {}
+    ) {}
 
     /**
      * Get the Unicode version
@@ -1171,7 +1196,8 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
-    public static function getUnicodeVersion(): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public static function getUnicodeVersion() {}
 
     /**
      * Check if code point is an alphanumeric character
@@ -1181,7 +1207,8 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
-    public static function isalnum(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint): ?bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool|null'], default: '')]
+    public static function isalnum(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint) {}
 
     /**
      * Check if code point is a letter character
@@ -1191,7 +1218,8 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
-    public static function isalpha(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint): ?bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool|null'], default: '')]
+    public static function isalpha(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint) {}
 
     /**
      * Check if code point is a base character
@@ -1201,7 +1229,8 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
-    public static function isbase(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint): ?bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool|null'], default: '')]
+    public static function isbase(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint) {}
 
     /**
      * Check if code point is a "blank" or "horizontal space" character
@@ -1211,7 +1240,8 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
-    public static function isblank(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint): ?bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool|null'], default: '')]
+    public static function isblank(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint) {}
 
     /**
      * Check if code point is a control character
@@ -1221,7 +1251,8 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
-    public static function iscntrl(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint): ?bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool|null'], default: '')]
+    public static function iscntrl(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint) {}
 
     /**
      * Check whether the code point is defined
@@ -1231,7 +1262,8 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
-    public static function isdefined(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint): ?bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool|null'], default: '')]
+    public static function isdefined(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint) {}
 
     /**
      * Check if code point is a digit character
@@ -1241,7 +1273,8 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
-    public static function isdigit(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint): ?bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool|null'], default: '')]
+    public static function isdigit(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint) {}
 
     /**
      * Check if code point is a graphic character
@@ -1251,7 +1284,8 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
-    public static function isgraph(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint): ?bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool|null'], default: '')]
+    public static function isgraph(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint) {}
 
     /**
      * Check if code point is an ignorable character
@@ -1261,7 +1295,8 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
-    public static function isIDIgnorable(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint): ?bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool|null'], default: '')]
+    public static function isIDIgnorable(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint) {}
 
     /**
      * Check if code point is permissible in an identifier
@@ -1271,7 +1306,8 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
-    public static function isIDPart(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint): ?bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool|null'], default: '')]
+    public static function isIDPart(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint) {}
 
     /**
      * Check if code point is permissible as the first character in an identifier
@@ -1281,7 +1317,8 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
-    public static function isIDStart(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint): ?bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool|null'], default: '')]
+    public static function isIDStart(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint) {}
 
     /**
      * Check if code point is an ISO control code
@@ -1291,7 +1328,8 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
-    public static function isISOControl(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint): ?bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool|null'], default: '')]
+    public static function isISOControl(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint) {}
 
     /**
      * Check if code point is permissible in a Java identifier
@@ -1301,7 +1339,8 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
-    public static function isJavaIDPart(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint): ?bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool|null'], default: '')]
+    public static function isJavaIDPart(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint) {}
 
     /**
      * Check if code point is permissible as the first character in a Java identifier
@@ -1311,7 +1350,8 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
-    public static function isJavaIDStart(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint): ?bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool|null'], default: '')]
+    public static function isJavaIDStart(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint) {}
 
     /**
      * Check if code point is a space character according to Java
@@ -1321,7 +1361,8 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
-    public static function isJavaSpaceChar(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint): ?bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool|null'], default: '')]
+    public static function isJavaSpaceChar(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint) {}
 
     /**
      * Check if code point is a lowercase letter
@@ -1332,7 +1373,8 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
-    public static function islower(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint): ?bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool|null'], default: '')]
+    public static function islower(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint) {}
 
     /**
      * Check if code point has the Bidi_Mirrored property
@@ -1342,7 +1384,8 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
-    public static function isMirrored(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint): ?bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool|null'], default: '')]
+    public static function isMirrored(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint) {}
 
     /**
      * Check if code point is a printable character
@@ -1352,7 +1395,8 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
-    public static function isprint(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint): ?bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool|null'], default: '')]
+    public static function isprint(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint) {}
 
     /**
      * Check if code point is punctuation character
@@ -1363,7 +1407,8 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
-    public static function ispunct(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint): ?bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool|null'], default: '')]
+    public static function ispunct(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint) {}
 
     /**
      * Check if code point is a space character
@@ -1373,7 +1418,8 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
-    public static function isspace(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint): ?bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool|null'], default: '')]
+    public static function isspace(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint) {}
 
     /**
      * Check if code point is a titlecase letter
@@ -1383,7 +1429,8 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
-    public static function istitle(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint): ?bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool|null'], default: '')]
+    public static function istitle(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint) {}
 
     /**
      * Check if code point has the Alphabetic Unicode property
@@ -1393,7 +1440,8 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
-    public static function isUAlphabetic(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint): ?bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool|null'], default: '')]
+    public static function isUAlphabetic(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint) {}
 
     /**
      * Check if code point has the Lowercase Unicode property
@@ -1403,7 +1451,8 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
-    public static function isULowercase(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint): ?bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool|null'], default: '')]
+    public static function isULowercase(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint) {}
 
     /**
      * Check if code point has the general category "Lu" (uppercase letter)
@@ -1414,7 +1463,8 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
-    public static function isupper(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint): ?bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool|null'], default: '')]
+    public static function isupper(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint) {}
 
     /**
      * Check if code point has the Uppercase Unicode property
@@ -1424,7 +1474,8 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
-    public static function isUUppercase(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint): ?bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool|null'], default: '')]
+    public static function isUUppercase(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint) {}
 
     /**
      * Check if code point has the White_Space Unicode property
@@ -1434,7 +1485,8 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
-    public static function isUWhiteSpace(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint): ?bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool|null'], default: '')]
+    public static function isUWhiteSpace(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint) {}
 
     /**
      * Check if code point is a whitespace character according to ICU
@@ -1444,7 +1496,8 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
-    public static function isWhitespace(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint): ?bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool|null'], default: '')]
+    public static function isWhitespace(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint) {}
 
     /**
      * Check if code point is a hexadecimal digit
@@ -1453,7 +1506,8 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
-    public static function isxdigit(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint): ?bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool|null'], default: '')]
+    public static function isxdigit(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint) {}
 
     /**
      * Return Unicode code point value of character
@@ -1463,7 +1517,8 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
-    public static function ord(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $character): ?int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int|null'], default: '')]
+    public static function ord(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $character) {}
 
     /**
      * Make Unicode character lowercase
@@ -1475,7 +1530,8 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
-    public static function tolower(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint): string|int|null {}
+    #[LanguageLevelTypeAware(['8.1' => 'string|int|null'], default: '')]
+    public static function tolower(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint) {}
 
     /**
      * Make Unicode character titlecase
@@ -1487,7 +1543,8 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
-    public static function totitle(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint): string|int|null {}
+    #[LanguageLevelTypeAware(['8.1' => 'string|int|null'], default: '')]
+    public static function totitle(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint) {}
 
     /**
      * Make Unicode character uppercase
@@ -1499,5 +1556,6 @@ class IntlChar
      * @since 7.0
      */
     #[TentativeType]
-    public static function toupper(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint): string|int|null {}
+    #[LanguageLevelTypeAware(['8.1' => 'string|int|null'], default: '')]
+    public static function toupper(#[LanguageLevelTypeAware(['8.0' => 'int|string'], default: '')] $codepoint) {}
 }

--- a/intl/intl.php
+++ b/intl/intl.php
@@ -264,7 +264,8 @@ class Collator
      * on error.
      */
     #[TentativeType]
-    public static function create(#[LanguageAware(['8.0' => 'string'], default: '')] $locale): ?Collator {}
+    #[LanguageAware(['8.1' => 'Collator|null'], default: '')]
+    public static function create(#[LanguageAware(['8.0' => 'string'], default: '')] $locale) {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -297,10 +298,11 @@ class Collator
      */
     #[Pure]
     #[TentativeType]
+    #[LanguageAware(['8.1' => 'int|false'], default: '')]
     public function compare(
         #[LanguageAware(['8.0' => 'string'], default: '')] $string1,
         #[LanguageAware(['8.0' => 'string'], default: '')] $string2
-    ): int|false {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -319,10 +321,11 @@ class Collator
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
+    #[LanguageAware(['8.1' => 'bool'], default: '')]
     public function sort(
         array &$array,
         #[LanguageAware(['8.0' => 'int'], default: '')] #[EV([Collator::SORT_REGULAR])] $flags = 0
-    ): bool {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -332,10 +335,11 @@ class Collator
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
+    #[LanguageAware(['8.1' => 'bool'], default: '')]
     public function sortWithSortKeys(
         array &$array,
         #[ElementAvailable(from: '5.3', to: '5.6')] $flags = []
-    ): bool {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -350,10 +354,11 @@ class Collator
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
+    #[LanguageAware(['8.1' => 'bool'], default: '')]
     public function asort(
         array &$array,
         #[LanguageAware(['8.0' => 'int'], default: '')] #[EV([Collator::SORT_REGULAR])] $flags = 0
-    ): bool {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -366,7 +371,8 @@ class Collator
      */
     #[Pure]
     #[TentativeType]
-    public function getAttribute(#[LanguageAware(['8.0' => 'int'], default: '')] $attribute): int|false {}
+    #[LanguageAware(['8.1' => 'int|false'], default: '')]
+    public function getAttribute(#[LanguageAware(['8.0' => 'int'], default: '')] $attribute) {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -379,10 +385,11 @@ class Collator
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
+    #[LanguageAware(['8.1' => 'bool'], default: '')]
     public function setAttribute(
         #[LanguageAware(['8.0' => 'int'], default: '')] $attribute,
         #[LanguageAware(['8.0' => 'int'], default: '')] $value
-    ): bool {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -392,7 +399,8 @@ class Collator
      */
     #[Pure]
     #[TentativeType]
-    public function getStrength(): int {}
+    #[LanguageAware(['8.1' => 'int'], default: '')]
+    public function getStrength() {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -417,7 +425,8 @@ class Collator
      */
     #[Pure]
     #[TentativeType]
-    public function getErrorCode(): int|false {}
+    #[LanguageAware(['8.1' => 'int|false'], default: '')]
+    public function getErrorCode() {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -435,9 +444,10 @@ class Collator
      */
     #[Pure]
     #[TentativeType]
+    #[LanguageAware(['8.1' => 'string|false'], default: '')]
     public function getLocale(
         #[LanguageAware(['8.0' => 'int'], default: '')] #[EV([Locale::VALID_LOCALE, Locale::ACTUAL_LOCALE])] $type
-    ): string|false {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -447,7 +457,8 @@ class Collator
      */
     #[Pure]
     #[TentativeType]
-    public function getErrorMessage(): string|false {}
+    #[LanguageAware(['8.1' => 'string|false'], default: '')]
+    public function getErrorMessage() {}
 
     /**
      * (PHP 5 &gt;= 5.3.2, PECL intl &gt;= 1.0.3)<br/>
@@ -460,10 +471,11 @@ class Collator
      */
     #[Pure]
     #[TentativeType]
+    #[LanguageAware(['8.1' => 'string|false'], default: '')]
     public function getSortKey(
         #[LanguageAware(['8.0' => 'string'], default: '')] $string,
         #[ElementAvailable(from: '5.3', to: '5.6')] $arg2
-    ): string|false {}
+    ) {}
 }
 
 class NumberFormatter
@@ -1005,6 +1017,7 @@ class NumberFormatter
      * @return NumberFormatter|false <b>NumberFormatter</b> object or <b>FALSE</b> on error.
      */
     #[TentativeType]
+    #[LanguageAware(['8.1' => 'NumberFormatter|null'], default: '')]
     public static function create(
         #[LanguageAware(['8.0' => 'string'], default: '')] $locale,
         #[LanguageAware(['8.0' => 'int'], default: '')] #[EV([NumberFormatter::DECIMAL, NumberFormatter::PATTERN_DECIMAL,
@@ -1013,7 +1026,7 @@ class NumberFormatter
             NumberFormatter::DURATION, NumberFormatter::PATTERN_RULEBASED, NumberFormatter::CURRENCY_ACCOUNTING,
             NumberFormatter::DEFAULT_STYLE, NumberFormatter::IGNORE])] $style,
         #[LanguageAware(['8.0' => 'string|null'], default: '')] $pattern = null
-    ): ?NumberFormatter {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1031,10 +1044,11 @@ class NumberFormatter
      */
     #[Pure]
     #[TentativeType]
+    #[LanguageAware(['8.1' => 'string|false'], default: '')]
     public function format(
         #[LanguageAware(['8.0' => 'int|float'], default: '')] $num,
         #[LanguageAware(['8.0' => 'int'], default: '')] $type = 0
-    ): string|false {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1053,11 +1067,12 @@ class NumberFormatter
      * @return mixed The value of the parsed number or <b>FALSE</b> on error.
      */
     #[TentativeType]
+    #[LanguageAware(['8.1' => 'int|float|false'], default: '')]
     public function parse(
         #[LanguageAware(['8.0' => 'string'], default: '')] $string,
         #[LanguageAware(['8.0' => 'int'], default: '')] $type = NumberFormatter::TYPE_DOUBLE,
         &$offset = null
-    ): int|float|false {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1073,10 +1088,11 @@ class NumberFormatter
      */
     #[Pure]
     #[TentativeType]
+    #[LanguageAware(['8.1' => 'string|false'], default: '')]
     public function formatCurrency(
         #[LanguageAware(['8.0' => 'float'], default: '')] $amount,
         #[LanguageAware(['8.0' => 'string'], default: '')] $currency
-    ): string|false {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1094,7 +1110,8 @@ class NumberFormatter
      * @return float|false The parsed numeric value or <b>FALSE</b> on error.
      */
     #[TentativeType]
-    public function parseCurrency(#[LanguageAware(['8.0' => 'string'], default: '')] $string, &$currency, &$offset = null): float|false {}
+    #[LanguageAware(['8.1' => 'float|false'], default: '')]
+    public function parseCurrency(#[LanguageAware(['8.0' => 'string'], default: '')] $string, &$currency, &$offset = null) {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1110,10 +1127,11 @@ class NumberFormatter
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
+    #[LanguageAware(['8.1' => 'bool'], default: '')]
     public function setAttribute(
         #[LanguageAware(['8.0' => 'int'], default: '')] $attribute,
         #[LanguageAware(['8.0' => 'int|float'], default: '')] $value
-    ): bool {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1127,7 +1145,8 @@ class NumberFormatter
      */
     #[Pure]
     #[TentativeType]
-    public function getAttribute(#[LanguageAware(['8.0' => 'int'], default: '')] $attribute): int|float|false {}
+    #[LanguageAware(['8.1' => 'int|float|false'], default: '')]
+    public function getAttribute(#[LanguageAware(['8.0' => 'int'], default: '')] $attribute) {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1144,10 +1163,11 @@ class NumberFormatter
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
+    #[LanguageAware(['8.1' => 'bool'], default: '')]
     public function setTextAttribute(
         #[LanguageAware(['8.0' => 'int'], default: '')] $attribute,
         #[LanguageAware(['8.0' => 'string'], default: '')] $value
-    ): bool {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1161,7 +1181,8 @@ class NumberFormatter
      */
     #[Pure]
     #[TentativeType]
-    public function getTextAttribute(#[LanguageAware(['8.0' => 'int'], default: '')] $attribute): string|false {}
+    #[LanguageAware(['8.1' => 'string|false'], default: '')]
+    public function getTextAttribute(#[LanguageAware(['8.0' => 'int'], default: '')] $attribute) {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1177,10 +1198,11 @@ class NumberFormatter
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
+    #[LanguageAware(['8.1' => 'bool'], default: '')]
     public function setSymbol(
         #[LanguageAware(['8.0' => 'int'], default: '')] $symbol,
         #[LanguageAware(['8.0' => 'string'], default: '')] $value
-    ): bool {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1194,7 +1216,8 @@ class NumberFormatter
      */
     #[Pure]
     #[TentativeType]
-    public function getSymbol(#[LanguageAware(['8.0' => 'int'], default: '')] $symbol): string|false {}
+    #[LanguageAware(['8.1' => 'string|false'], default: '')]
+    public function getSymbol(#[LanguageAware(['8.0' => 'int'], default: '')] $symbol) {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1208,7 +1231,8 @@ class NumberFormatter
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function setPattern(#[LanguageAware(['8.0' => 'string'], default: '')] $pattern): bool {}
+    #[LanguageAware(['8.1' => 'bool'], default: '')]
+    public function setPattern(#[LanguageAware(['8.0' => 'string'], default: '')] $pattern) {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1218,7 +1242,8 @@ class NumberFormatter
      */
     #[Pure]
     #[TentativeType]
-    public function getPattern(): string|false {}
+    #[LanguageAware(['8.1' => 'string|false'], default: '')]
+    public function getPattern() {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1234,9 +1259,10 @@ class NumberFormatter
      */
     #[Pure]
     #[TentativeType]
+    #[LanguageAware(['8.1' => 'string|false'], default: '')]
     public function getLocale(
         #[LanguageAware(['8.0' => 'int'], default: '')] #[EV([Locale::VALID_LOCALE, Locale::ACTUAL_LOCALE])] $type = 0
-    ): string|false {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1246,7 +1272,8 @@ class NumberFormatter
      */
     #[Pure]
     #[TentativeType]
-    public function getErrorCode(): int {}
+    #[LanguageAware(['8.1' => 'int'], default: '')]
+    public function getErrorCode() {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1256,7 +1283,8 @@ class NumberFormatter
      */
     #[Pure]
     #[TentativeType]
-    public function getErrorMessage(): string {}
+    #[LanguageAware(['8.1' => 'string'], default: '')]
+    public function getErrorMessage() {}
 }
 
 class Normalizer
@@ -1316,12 +1344,13 @@ class Normalizer
      * @return string|false The normalized string or <b>FALSE</b> if an error occurred.
      */
     #[TentativeType]
+    #[LanguageAware(['8.1' => 'string|false'], default: '')]
     public static function normalize(
         #[LanguageAware(['8.0' => 'string'], default: '')] $string,
         #[ElementAvailable(from: '5.3', to: '5.6')] $form,
         #[ElementAvailable(from: '7.0')] #[LanguageAware(['8.0' => 'int'], default: '')] $form = Normalizer::FORM_C,
         #[ElementAvailable(from: '5.3', to: '5.6')] $arg3
-    ): string|false {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1334,12 +1363,13 @@ class Normalizer
      * @return bool <b>TRUE</b> if normalized, <b>FALSE</b> otherwise or if there an error
      */
     #[TentativeType]
+    #[LanguageAware(['8.1' => 'bool'], default: '')]
     public static function isNormalized(
         #[LanguageAware(['8.0' => 'string'], default: '')] $string,
         #[ElementAvailable(from: '5.3', to: '5.6')] $form,
         #[ElementAvailable(from: '7.0')] #[LanguageAware(['8.0' => 'int'], default: '')] $form = Normalizer::FORM_C,
         #[ElementAvailable(from: '5.3', to: '5.6')] $arg3
-    ): bool {}
+    ) {}
 
     /**
      * @param string $string <p>The input string to normalize</p>
@@ -1350,10 +1380,11 @@ class Normalizer
      * @since 7.3
      */
     #[TentativeType]
+    #[LanguageAware(['8.1' => 'string|null'], default: '')]
     public static function getRawDecomposition(
         string $string,
         #[ElementAvailable(from: '8.0')] int $form = 16
-    ): ?string {}
+    ) {}
 }
 
 class Locale
@@ -1427,7 +1458,8 @@ class Locale
      * @return string The current runtime locale
      */
     #[TentativeType]
-    public static function getDefault(): string {}
+    #[LanguageAware(['8.1' => 'string'], default: '')]
+    public static function getDefault() {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1452,7 +1484,8 @@ class Locale
      * @return string|null The language code associated with the language or <b>NULL</b> in case of error.
      */
     #[TentativeType]
-    public static function getPrimaryLanguage(#[LanguageAware(['8.0' => 'string'], default: '')] $locale): ?string {}
+    #[LanguageAware(['8.1' => 'string|null'], default: '')]
+    public static function getPrimaryLanguage(#[LanguageAware(['8.0' => 'string'], default: '')] $locale) {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1464,7 +1497,8 @@ class Locale
      * @return string|null The script subtag for the locale or <b>NULL</b> if not present
      */
     #[TentativeType]
-    public static function getScript(#[LanguageAware(['8.0' => 'string'], default: '')] $locale): ?string {}
+    #[LanguageAware(['8.1' => 'string|null'], default: '')]
+    public static function getScript(#[LanguageAware(['8.0' => 'string'], default: '')] $locale) {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1476,7 +1510,8 @@ class Locale
      * @return string|null The region subtag for the locale or <b>NULL</b> if not present
      */
     #[TentativeType]
-    public static function getRegion(#[LanguageAware(['8.0' => 'string'], default: '')] $locale): ?string {}
+    #[LanguageAware(['8.1' => 'string|null'], default: '')]
+    public static function getRegion(#[LanguageAware(['8.0' => 'string'], default: '')] $locale) {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1488,7 +1523,8 @@ class Locale
      * @return array|false|null Associative array containing the keyword-value pairs for this locale
      */
     #[TentativeType]
-    public static function getKeywords(#[LanguageAware(['8.0' => 'string'], default: '')] $locale): array|false|null {}
+    #[LanguageAware(['8.1' => 'array|false|null'], default: '')]
+    public static function getKeywords(#[LanguageAware(['8.0' => 'string'], default: '')] $locale) {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1504,11 +1540,12 @@ class Locale
      * $in_locale.
      */
     #[TentativeType]
+    #[LanguageAware(['8.1' => 'string|false'], default: '')]
     public static function getDisplayScript(
         #[LanguageAware(['8.0' => 'string'], default: '')] $locale,
         #[ElementAvailable(from: '5.3', to: '5.6')] $displayLocale,
         #[ElementAvailable(from: '7.0')] #[LanguageAware(['8.0' => 'string|null'], default: '')] $displayLocale = null
-    ): string|false {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1524,11 +1561,12 @@ class Locale
      * $in_locale.
      */
     #[TentativeType]
+    #[LanguageAware(['8.1' => 'string|false'], default: '')]
     public static function getDisplayRegion(
         #[LanguageAware(['8.0' => 'string'], default: '')] $locale,
         #[ElementAvailable(from: '5.3', to: '5.6')] $displayLocale,
         #[ElementAvailable(from: '7.0')] #[LanguageAware(['8.0' => 'string|null'], default: '')] $displayLocale = null
-    ): string|false {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1541,11 +1579,12 @@ class Locale
      * @return string|false Display name of the locale in the format appropriate for $in_locale.
      */
     #[TentativeType]
+    #[LanguageAware(['8.1' => 'string|false'], default: '')]
     public static function getDisplayName(
         #[LanguageAware(['8.0' => 'string'], default: '')] $locale,
         #[ElementAvailable(from: '5.3', to: '5.6')] $displayLocale,
         #[ElementAvailable(from: '7.0')] #[LanguageAware(['8.0' => 'string|null'], default: '')] $displayLocale = null
-    ): string|false {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1561,11 +1600,12 @@ class Locale
      * $in_locale.
      */
     #[TentativeType]
+    #[LanguageAware(['8.1' => 'string|false'], default: '')]
     public static function getDisplayLanguage(
         #[LanguageAware(['8.0' => 'string'], default: '')] $locale,
         #[ElementAvailable(from: '5.3', to: '5.6')] $displayLocale,
         #[ElementAvailable(from: '7.0')] #[LanguageAware(['8.0' => 'string|null'], default: '')] $displayLocale = null
-    ): string|false {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1581,11 +1621,12 @@ class Locale
      * $in_locale.
      */
     #[TentativeType]
+    #[LanguageAware(['8.1' => 'string|false'], default: '')]
     public static function getDisplayVariant(
         #[LanguageAware(['8.0' => 'string'], default: '')] $locale,
         #[ElementAvailable(from: '5.3', to: '5.6')] $displayLocale,
         #[ElementAvailable(from: '7.0')] #[LanguageAware(['8.0' => 'string|null'], default: '')] $displayLocale = null
-    ): string|false {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1612,7 +1653,8 @@ class Locale
      * @return string|false The corresponding locale identifier.
      */
     #[TentativeType]
-    public static function composeLocale(array $subtags): string|false {}
+    #[LanguageAware(['8.1' => 'string|false'], default: '')]
+    public static function composeLocale(array $subtags) {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1631,7 +1673,8 @@ class Locale
      * variant2=&gt;varZ
      */
     #[TentativeType]
-    public static function parseLocale(#[LanguageAware(['8.0' => 'string'], default: '')] $locale): ?array {}
+    #[LanguageAware(['8.1' => 'array|null'], default: '')]
+    public static function parseLocale(#[LanguageAware(['8.0' => 'string'], default: '')] $locale) {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1644,7 +1687,8 @@ class Locale
      * or <b>NULL</b> if not present
      */
     #[TentativeType]
-    public static function getAllVariants(#[LanguageAware(['8.0' => 'string'], default: '')] $locale): ?array {}
+    #[LanguageAware(['8.1' => 'array|null'], default: '')]
+    public static function getAllVariants(#[LanguageAware(['8.0' => 'string'], default: '')] $locale) {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1663,12 +1707,13 @@ class Locale
      * @return bool|null <b>TRUE</b> if $locale matches $langtag <b>FALSE</b> otherwise.
      */
     #[TentativeType]
+    #[LanguageAware(['8.1' => 'bool|null'], default: '')]
     public static function filterMatches(
         #[LanguageAware(['8.0' => 'string'], default: '')] $languageTag,
         #[LanguageAware(['8.0' => 'string'], default: '')] $locale,
         #[ElementAvailable(from: '5.3', to: '5.6')] $canonicalize,
         #[ElementAvailable(from: '7.0')] #[LanguageAware(['8.0' => 'bool'], default: '')] $canonicalize = false
-    ): ?bool {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1691,6 +1736,7 @@ class Locale
      * @return string|null The closest matching language tag or default value.
      */
     #[TentativeType]
+    #[LanguageAware(['8.1' => 'string|null'], default: '')]
     public static function lookup(
         array $languageTag,
         #[LanguageAware(['8.0' => 'string'], default: '')] $locale,
@@ -1698,7 +1744,7 @@ class Locale
         #[ElementAvailable(from: '5.3', to: '5.6')] $defaultLocale,
         #[ElementAvailable(from: '7.0')] #[LanguageAware(['8.0' => 'bool'], default: '')] $canonicalize = false,
         #[ElementAvailable(from: '7.0')] #[LanguageAware(['8.0' => 'string|null'], default: '')] $defaultLocale = null
-    ): ?string {}
+    ) {}
 
     /**
      * @link https://php.net/manual/en/locale.canonicalize.php
@@ -1706,7 +1752,8 @@ class Locale
      * @return string|null
      */
     #[TentativeType]
-    public static function canonicalize(#[LanguageAware(['8.0' => 'string'], default: '')] $locale): ?string {}
+    #[LanguageAware(['8.1' => 'string|null'], default: '')]
+    public static function canonicalize(#[LanguageAware(['8.0' => 'string'], default: '')] $locale) {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1718,7 +1765,8 @@ class Locale
      * @return string|false The corresponding locale identifier.
      */
     #[TentativeType]
-    public static function acceptFromHttp(#[LanguageAware(['8.0' => 'string'], default: '')] $header): string|false {}
+    #[LanguageAware(['8.1' => 'string|false'], default: '')]
+    public static function acceptFromHttp(#[LanguageAware(['8.0' => 'string'], default: '')] $header) {}
 
     /**
      * @since 8.5
@@ -1775,10 +1823,11 @@ class MessageFormatter
      * @return MessageFormatter|null The formatter object
      */
     #[TentativeType]
+    #[LanguageAware(['8.1' => 'MessageFormatter|null'], default: '')]
     public static function create(
         #[LanguageAware(['8.0' => 'string'], default: '')] $locale,
         #[LanguageAware(['8.0' => 'string'], default: '')] $pattern
-    ): ?MessageFormatter {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1791,7 +1840,8 @@ class MessageFormatter
      */
     #[Pure]
     #[TentativeType]
-    public function format(array $values): string|false {}
+    #[LanguageAware(['8.1' => 'string|false'], default: '')]
+    public function format(array $values) {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1812,11 +1862,12 @@ class MessageFormatter
      * @return string|false The formatted pattern string or <b>FALSE</b> if an error occurred
      */
     #[TentativeType]
+    #[LanguageAware(['8.1' => 'string|false'], default: '')]
     public static function formatMessage(
         #[LanguageAware(['8.0' => 'string'], default: '')] $locale,
         #[LanguageAware(['8.0' => 'string'], default: '')] $pattern,
         array $values
-    ): string|false {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1829,7 +1880,8 @@ class MessageFormatter
      */
     #[Pure]
     #[TentativeType]
-    public function parse(#[LanguageAware(['8.0' => 'string'], default: '')] $string): array|false {}
+    #[LanguageAware(['8.1' => 'array|false'], default: '')]
+    public function parse(#[LanguageAware(['8.0' => 'string'], default: '')] $string) {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1847,11 +1899,12 @@ class MessageFormatter
      * @return array|false An array containing items extracted, or <b>FALSE</b> on error
      */
     #[TentativeType]
+    #[LanguageAware(['8.1' => 'array|false'], default: '')]
     public static function parseMessage(
         #[LanguageAware(['8.0' => 'string'], default: '')] $locale,
         #[LanguageAware(['8.0' => 'string'], default: '')] $pattern,
         #[LanguageAware(['8.0' => 'string'], default: '')] $message
-    ): array|false {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1866,7 +1919,8 @@ class MessageFormatter
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function setPattern(#[LanguageAware(['8.0' => 'string'], default: '')] $pattern): bool {}
+    #[LanguageAware(['8.1' => 'bool'], default: '')]
+    public function setPattern(#[LanguageAware(['8.0' => 'string'], default: '')] $pattern) {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1876,7 +1930,8 @@ class MessageFormatter
      */
     #[Pure]
     #[TentativeType]
-    public function getPattern(): string|false {}
+    #[LanguageAware(['8.1' => 'string|false'], default: '')]
+    public function getPattern() {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1886,7 +1941,8 @@ class MessageFormatter
      */
     #[Pure]
     #[TentativeType]
-    public function getLocale(): string {}
+    #[LanguageAware(['8.1' => 'string'], default: '')]
+    public function getLocale() {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1896,7 +1952,8 @@ class MessageFormatter
      */
     #[Pure]
     #[TentativeType]
-    public function getErrorCode(): int {}
+    #[LanguageAware(['8.1' => 'int'], default: '')]
+    public function getErrorCode() {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -1906,7 +1963,8 @@ class MessageFormatter
      */
     #[Pure]
     #[TentativeType]
-    public function getErrorMessage(): string {}
+    #[LanguageAware(['8.1' => 'string'], default: '')]
+    public function getErrorMessage() {}
 }
 
 class IntlDateFormatter
@@ -2014,6 +2072,7 @@ class IntlDateFormatter
      * @return IntlDateFormatter|null
      */
     #[TentativeType]
+    #[LanguageAware(['8.1' => 'IntlDateFormatter|null'], default: '')]
     public static function create(
         #[LanguageAware(['8.0' => 'string|null'], default: '')] $locale,
         #[ElementAvailable(from: '5.3', to: '8.0')] #[LanguageAware(['8.0' => 'int'], default: '')] $dateType,
@@ -2023,7 +2082,7 @@ class IntlDateFormatter
         #[LanguageAware(['8.5' => 'IntlTimeZone|DateTimeZone|string|null'], default: '')] $timezone = null,
         #[LanguageAware(['8.0' => 'IntlCalendar|int|null'], default: '')] $calendar = null,
         #[LanguageAware(['8.0' => 'string|null'], default: '')] $pattern = null
-    ): ?IntlDateFormatter {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -2033,7 +2092,8 @@ class IntlDateFormatter
      */
     #[Pure]
     #[TentativeType]
-    public function getDateType(): int|false {}
+    #[LanguageAware(['8.1' => 'int|false'], default: '')]
+    public function getDateType() {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -2043,7 +2103,8 @@ class IntlDateFormatter
      */
     #[Pure]
     #[TentativeType]
-    public function getTimeType(): int|false {}
+    #[LanguageAware(['8.1' => 'int|false'], default: '')]
+    public function getTimeType() {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -2053,7 +2114,8 @@ class IntlDateFormatter
      */
     #[Pure]
     #[TentativeType]
-    public function getCalendar(): int|false {}
+    #[LanguageAware(['8.1' => 'int|false'], default: '')]
+    public function getCalendar() {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -2066,7 +2128,8 @@ class IntlDateFormatter
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function setCalendar(#[LanguageAware(['8.0' => 'IntlCalendar|int|null'], default: '')] $calendar): bool {}
+    #[LanguageAware(['8.1' => 'bool'], default: '')]
+    public function setCalendar(#[LanguageAware(['8.0' => 'IntlCalendar|int|null'], default: '')] $calendar) {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -2076,7 +2139,8 @@ class IntlDateFormatter
      */
     #[Pure]
     #[TentativeType]
-    public function getTimeZoneId(): string|false {}
+    #[LanguageAware(['8.1' => 'string|false'], default: '')]
+    public function getTimeZoneId() {}
 
     /**
      * (PHP 5 &gt;= 5.5.0, PECL intl &gt;= 3.0.0)<br/>
@@ -2086,7 +2150,8 @@ class IntlDateFormatter
      */
     #[Pure]
     #[TentativeType]
-    public function getCalendarObject(): IntlCalendar|false|null {}
+    #[LanguageAware(['8.1' => 'IntlCalendar|false|null'], default: '')]
+    public function getCalendarObject() {}
 
     /**
      * (PHP 5 &gt;= 5.5.0, PECL intl &gt;= 3.0.0)<br/>
@@ -2096,7 +2161,8 @@ class IntlDateFormatter
      */
     #[Pure]
     #[TentativeType]
-    public function getTimeZone(): IntlTimeZone|false {}
+    #[LanguageAware(['8.1' => 'IntlTimeZone|false'], default: '')]
+    public function getTimeZone() {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -2167,7 +2233,8 @@ class IntlDateFormatter
      * Bad formatstrings are usually the cause of the failure.
      */
     #[TentativeType]
-    public function setPattern(#[LanguageAware(['8.0' => 'string'], default: '')] $pattern): bool {}
+    #[LanguageAware(['8.1' => 'bool'], default: '')]
+    public function setPattern(#[LanguageAware(['8.0' => 'string'], default: '')] $pattern) {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -2177,7 +2244,8 @@ class IntlDateFormatter
      */
     #[Pure]
     #[TentativeType]
-    public function getPattern(): string|false {}
+    #[LanguageAware(['8.1' => 'string|false'], default: '')]
+    public function getPattern() {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -2188,9 +2256,10 @@ class IntlDateFormatter
      */
     #[Pure]
     #[TentativeType]
+    #[LanguageAware(['8.1' => 'string|false'], default: '')]
     public function getLocale(
         #[ElementAvailable(from: '8.0')] #[LanguageAware(['8.0' => 'int'], default: '')] $type = 0
-    ): string|false {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -2202,7 +2271,8 @@ class IntlDateFormatter
      * @return void
      */
     #[TentativeType]
-    public function setLenient(#[LanguageAware(['8.0' => 'bool'], default: '')] $lenient): void {}
+    #[LanguageAware(['8.1' => 'void'], default: '')]
+    public function setLenient(#[LanguageAware(['8.0' => 'bool'], default: '')] $lenient) {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -2212,7 +2282,8 @@ class IntlDateFormatter
      */
     #[Pure]
     #[TentativeType]
-    public function isLenient(): bool {}
+    #[LanguageAware(['8.1' => 'bool'], default: '')]
+    public function isLenient() {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -2227,11 +2298,12 @@ class IntlDateFormatter
      * @return string|false The formatted string or, if an error occurred, <b>FALSE</b>.
      */
     #[TentativeType]
+    #[LanguageAware(['8.1' => 'string|false'], default: '')]
     public function format(
         #[ElementAvailable(from: '5.3', to: '7.4')] $datetime = null,
         #[ElementAvailable(from: '8.0')] $datetime,
         #[ElementAvailable(from: '5.3', to: '7.4')] $array = null
-    ): string|false {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.5.0, PECL intl &gt;= 3.0.0)<br/>
@@ -2258,7 +2330,8 @@ class IntlDateFormatter
      * @return string|false A string with result or <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public static function formatObject($datetime, $format = null, #[LanguageAware(['8.0' => 'string|null'], default: '')] $locale = null): string|false {}
+    #[LanguageAware(['8.1' => 'string|false'], default: '')]
+    public static function formatObject($datetime, $format = null, #[LanguageAware(['8.0' => 'string|null'], default: '')] $locale = null) {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -2277,7 +2350,8 @@ class IntlDateFormatter
      * @return int|float|false timestamp parsed value
      */
     #[TentativeType]
-    public function parse(#[LanguageAware(['8.0' => 'string'], default: '')] $string, &$offset = null): int|float|false {}
+    #[LanguageAware(['8.1' => 'int|float|false'], default: '')]
+    public function parse(#[LanguageAware(['8.0' => 'string'], default: '')] $string, &$offset = null) {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -2295,7 +2369,8 @@ class IntlDateFormatter
      * @return array|false Localtime compatible array of integers : contains 24 hour clock value in tm_hour field
      */
     #[TentativeType]
-    public function localtime(#[LanguageAware(['8.0' => 'string'], default: '')] $string, &$offset = null): array|false {}
+    #[LanguageAware(['8.1' => 'array|false'], default: '')]
+    public function localtime(#[LanguageAware(['8.0' => 'string'], default: '')] $string, &$offset = null) {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -2305,7 +2380,8 @@ class IntlDateFormatter
      */
     #[Pure]
     #[TentativeType]
-    public function getErrorCode(): int {}
+    #[LanguageAware(['8.1' => 'int'], default: '')]
+    public function getErrorCode() {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL intl &gt;= 1.0.0)<br/>
@@ -2315,7 +2391,8 @@ class IntlDateFormatter
      */
     #[Pure]
     #[TentativeType]
-    public function getErrorMessage(): string {}
+    #[LanguageAware(['8.1' => 'string'], default: '')]
+    public function getErrorMessage() {}
 
     /**
      * @since 8.4
@@ -2354,11 +2431,12 @@ class ResourceBundle implements IteratorAggregate, Countable
      * @return ResourceBundle|null <b>ResourceBundle</b> object or <b>null</b> on error.
      */
     #[TentativeType]
+    #[LanguageAware(['8.1' => 'ResourceBundle|null'], default: '')]
     public static function create(
         #[LanguageAware(['8.0' => 'string|null'], default: '')] $locale,
         #[LanguageAware(['8.0' => 'string|null'], default: '')] $bundle,
         #[LanguageAware(['8.0' => 'bool'], default: '')] $fallback = true
-    ): ?ResourceBundle {}
+    ) {}
 
     /**
      * (PHP &gt;= 5.3.2, PECL intl &gt;= 2.0.0)<br/>
@@ -2385,7 +2463,8 @@ class ResourceBundle implements IteratorAggregate, Countable
      */
     #[Pure]
     #[TentativeType]
-    public function count(): int {}
+    #[LanguageAware(['8.1' => 'int'], default: '')]
+    public function count() {}
 
     /**
      * (PHP &gt;= 5.3.2, PECL intl &gt;= 2.0.0)<br/>
@@ -2398,7 +2477,8 @@ class ResourceBundle implements IteratorAggregate, Countable
      * @return array|false the list of locales supported by the bundle.
      */
     #[TentativeType]
-    public static function getLocales(#[LanguageAware(['8.0' => 'string'], default: '')] $bundle): array|false {}
+    #[LanguageAware(['8.1' => 'array|false'], default: '')]
+    public static function getLocales(#[LanguageAware(['8.0' => 'string'], default: '')] $bundle) {}
 
     /**
      * (PHP &gt;= 5.3.2, PECL intl &gt;= 2.0.0)<br/>
@@ -2408,7 +2488,8 @@ class ResourceBundle implements IteratorAggregate, Countable
      */
     #[Pure]
     #[TentativeType]
-    public function getErrorCode(): int {}
+    #[LanguageAware(['8.1' => 'int'], default: '')]
+    public function getErrorCode() {}
 
     /**
      * (PHP &gt;= 5.3.2, PECL intl &gt;= 2.0.0)<br/>
@@ -2418,7 +2499,8 @@ class ResourceBundle implements IteratorAggregate, Countable
      */
     #[Pure]
     #[TentativeType]
-    public function getErrorMessage(): string {}
+    #[LanguageAware(['8.1' => 'string'], default: '')]
+    public function getErrorMessage() {}
 
     /**
      * @return Iterator
@@ -2473,10 +2555,11 @@ class Transliterator
      * or <b>NULL</b> on failure.
      */
     #[TentativeType]
+    #[LanguageAware(['8.1' => 'Transliterator|null'], default: '')]
     public static function create(
         #[LanguageAware(['8.0' => 'string'], default: '')] $id,
         #[LanguageAware(['8.0' => 'int'], default: '')] #[EV([Transliterator::FORWARD, Transliterator::REVERSE])] $direction = 0
-    ): ?Transliterator {}
+    ) {}
 
     /**
      * (PHP &gt;= 5.4.0, PECL intl &gt;= 2.0.0)<br/>
@@ -2495,10 +2578,11 @@ class Transliterator
      * or <b>NULL</b> on failure.
      */
     #[TentativeType]
+    #[LanguageAware(['8.1' => 'Transliterator|null'], default: '')]
     public static function createFromRules(
         #[LanguageAware(['8.0' => 'string'], default: '')] $rules,
         #[LanguageAware(['8.0' => 'int'], default: '')] #[EV([Transliterator::FORWARD, Transliterator::REVERSE])] $direction = 0
-    ): ?Transliterator {}
+    ) {}
 
     /**
      * (PHP &gt;= 5.4.0, PECL intl &gt;= 2.0.0)<br/>
@@ -2509,7 +2593,8 @@ class Transliterator
      */
     #[Pure]
     #[TentativeType]
-    public function createInverse(): ?Transliterator {}
+    #[LanguageAware(['8.1' => 'Transliterator|null'], default: '')]
+    public function createInverse() {}
 
     /**
      * (PHP &gt;= 5.4.0, PECL intl &gt;= 2.0.0)<br/>
@@ -2519,7 +2604,8 @@ class Transliterator
      * or <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public static function listIDs(): array|false {}
+    #[LanguageAware(['8.1' => 'array|false'], default: '')]
+    public static function listIDs() {}
 
     /**
      * (PHP &gt;= 5.4.0, PECL intl &gt;= 2.0.0)<br/>
@@ -2542,11 +2628,12 @@ class Transliterator
      */
     #[Pure]
     #[TentativeType]
+    #[LanguageAware(['8.1' => 'string|false'], default: '')]
     public function transliterate(
         #[LanguageAware(['8.0' => 'string'], default: '')] $string,
         #[LanguageAware(['8.0' => 'int'], default: '')] $start = 0,
         #[LanguageAware(['8.0' => 'int'], default: '')] $end = -1
-    ): string|false {}
+    ) {}
 
     /**
      * (PHP &gt;= 5.4.0, PECL intl &gt;= 2.0.0)<br/>
@@ -2633,7 +2720,8 @@ class Spoofchecker
      * @return bool
      */
     #[TentativeType]
-    public function isSuspicious(#[LanguageAware(['8.0' => 'string'], default: '')] $string, &$errorCode = null): bool {}
+    #[LanguageAware(['8.1' => 'bool'], default: '')]
+    public function isSuspicious(#[LanguageAware(['8.0' => 'string'], default: '')] $string, &$errorCode = null) {}
 
     /**
      * (PHP &gt;= 5.4.0, PECL intl &gt;= 2.0.0)<br/>
@@ -2648,11 +2736,12 @@ class Spoofchecker
      * @return bool
      */
     #[TentativeType]
+    #[LanguageAware(['8.1' => 'bool'], default: '')]
     public function areConfusable(
         #[LanguageAware(['8.0' => 'string'], default: '')] $string1,
         #[LanguageAware(['8.0' => 'string'], default: '')] $string2,
         &$errorCode = null
-    ): bool {}
+    ) {}
 
     /**
      * (PHP &gt;= 5.4.0, PECL intl &gt;= 2.0.0)<br/>
@@ -2663,7 +2752,8 @@ class Spoofchecker
      * @return void
      */
     #[TentativeType]
-    public function setAllowedLocales(#[LanguageAware(['8.0' => 'string'], default: '')] $locales): void {}
+    #[LanguageAware(['8.1' => 'void'], default: '')]
+    public function setAllowedLocales(#[LanguageAware(['8.0' => 'string'], default: '')] $locales) {}
 
     /**
      * (PHP &gt;= 5.4.0, PECL intl &gt;= 2.0.0)<br/>
@@ -2674,13 +2764,15 @@ class Spoofchecker
      * @return void
      */
     #[TentativeType]
-    public function setChecks(#[LanguageAware(['8.0' => 'int'], default: '')] $checks): void {}
+    #[LanguageAware(['8.1' => 'void'], default: '')]
+    public function setChecks(#[LanguageAware(['8.0' => 'int'], default: '')] $checks) {}
 
     /**
      * @param int $level
      */
     #[TentativeType]
-    public function setRestrictionLevel(#[LanguageAware(['8.0' => 'int'], default: '')] $level): void {}
+    #[LanguageAware(['8.1' => 'void'], default: '')]
+    public function setRestrictionLevel(#[LanguageAware(['8.0' => 'int'], default: '')] $level) {}
 
     /**
      * @since 8.4
@@ -2708,14 +2800,16 @@ class IntlGregorianCalendar extends IntlCalendar
      * @param float $timestamp
      */
     #[TentativeType]
-    public function setGregorianChange(#[LanguageAware(['8.0' => 'float'], default: '')] $timestamp): bool {}
+    #[LanguageAware(['8.1' => 'bool'], default: '')]
+    public function setGregorianChange(#[LanguageAware(['8.0' => 'float'], default: '')] $timestamp) {}
 
     /**
      * @return float
      */
     #[Pure]
     #[TentativeType]
-    public function getGregorianChange(): float {}
+    #[LanguageAware(['8.1' => 'float'], default: '')]
+    public function getGregorianChange() {}
 
     /**
      * @param int $year
@@ -2723,7 +2817,8 @@ class IntlGregorianCalendar extends IntlCalendar
      */
     #[Pure]
     #[TentativeType]
-    public function isLeapYear(#[LanguageAware(['8.0' => 'int'], default: '')] $year): bool {}
+    #[LanguageAware(['8.1' => 'bool'], default: '')]
+    public function isLeapYear(#[LanguageAware(['8.0' => 'int'], default: '')] $year) {}
 
     /**
      * @since 8.3
@@ -2798,10 +2893,11 @@ class IntlCalendar
      * @return bool Returns TRUE on success or FALSE on failure.
      */
     #[TentativeType]
+    #[LanguageAware(['8.1' => 'bool'], default: '')]
     public function add(
         #[LanguageAware(['8.0' => 'int'], default: '')] $field,
         #[LanguageAware(['8.0' => 'int'], default: '')] $value
-    ): bool {}
+    ) {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
@@ -2816,7 +2912,8 @@ class IntlCalendar
      */
     #[Pure]
     #[TentativeType]
-    public function after(IntlCalendar $other): bool {}
+    #[LanguageAware(['8.1' => 'bool'], default: '')]
+    public function after(IntlCalendar $other) {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
@@ -2831,7 +2928,8 @@ class IntlCalendar
      */
     #[Pure]
     #[TentativeType]
-    public function before(IntlCalendar $other): bool {}
+    #[LanguageAware(['8.1' => 'bool'], default: '')]
+    public function before(IntlCalendar $other) {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
@@ -2901,10 +2999,11 @@ class IntlCalendar
      * failure.
      */
     #[TentativeType]
+    #[LanguageAware(['8.1' => 'IntlCalendar|null'], default: '')]
     public static function createInstance(
         #[LanguageAware(['8.5' => 'IntlTimeZone|DateTimeZone|string|null'], default: '')] $timezone = null,
         #[LanguageAware(['8.0' => 'string|null'], default: '')] $locale = null
-    ): ?IntlCalendar {}
+    ) {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
@@ -2921,7 +3020,8 @@ class IntlCalendar
      */
     #[Pure]
     #[TentativeType]
-    public function equals(#[LanguageAware(['8.0' => 'IntlCalendar'], default: '')] $other): bool {}
+    #[LanguageAware(['8.1' => 'bool'], default: '')]
+    public function equals(#[LanguageAware(['8.0' => 'IntlCalendar'], default: '')] $other) {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
@@ -2947,10 +3047,11 @@ class IntlCalendar
      */
     #[Pure]
     #[TentativeType]
+    #[LanguageAware(['8.1' => 'int|false'], default: '')]
     public function fieldDifference(
         #[LanguageAware(['8.0' => 'float'], default: '')] $timestamp,
         #[LanguageAware(['8.0' => 'int'], default: '')] $field
-    ): int|false {}
+    ) {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a2)<br/>
@@ -2967,10 +3068,11 @@ class IntlCalendar
      * inside the {@link https://secure.php.net/manual/en/class.datetime.php DateTime} constructor is propagated.
      */
     #[TentativeType]
+    #[LanguageAware(['8.1' => 'IntlCalendar|null'], default: '')]
     public static function fromDateTime(
         #[LanguageAware(['8.0' => 'DateTime|string'], default: '')] $datetime,
         #[LanguageAware(['8.0' => 'string|null'], default: '')] #[ElementAvailable(from: '8.0')] $locale
-    ): ?IntlCalendar {}
+    ) {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
@@ -2985,7 +3087,8 @@ class IntlCalendar
      */
     #[Pure]
     #[TentativeType]
-    public function get(#[LanguageAware(['8.0' => 'int'], default: '')] $field): int|false {}
+    #[LanguageAware(['8.1' => 'int|false'], default: '')]
+    public function get(#[LanguageAware(['8.0' => 'int'], default: '')] $field) {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
@@ -3002,7 +3105,8 @@ class IntlCalendar
      */
     #[Pure]
     #[TentativeType]
-    public function getActualMaximum(#[LanguageAware(['8.0' => 'int'], default: '')] $field): int|false {}
+    #[LanguageAware(['8.1' => 'int|false'], default: '')]
+    public function getActualMaximum(#[LanguageAware(['8.0' => 'int'], default: '')] $field) {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
@@ -3019,7 +3123,8 @@ class IntlCalendar
      */
     #[Pure]
     #[TentativeType]
-    public function getActualMinimum(#[LanguageAware(['8.0' => 'int'], default: '')] $field): int|false {}
+    #[LanguageAware(['8.1' => 'int|false'], default: '')]
+    public function getActualMinimum(#[LanguageAware(['8.0' => 'int'], default: '')] $field) {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
@@ -3028,7 +3133,8 @@ class IntlCalendar
      * @return string[] An array of strings, one for which locale.
      */
     #[TentativeType]
-    public static function getAvailableLocales(): array {}
+    #[LanguageAware(['8.1' => 'array'], default: '')]
+    public static function getAvailableLocales() {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
@@ -3047,7 +3153,8 @@ class IntlCalendar
      */
     #[Pure]
     #[TentativeType]
-    public function getDayOfWeekType(#[LanguageAware(['8.0' => 'int'], default: '')] $dayOfWeek): int|false {}
+    #[LanguageAware(['8.1' => 'int|false'], default: '')]
+    public function getDayOfWeekType(#[LanguageAware(['8.0' => 'int'], default: '')] $dayOfWeek) {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
@@ -3057,7 +3164,8 @@ class IntlCalendar
      */
     #[Pure]
     #[TentativeType]
-    public function getErrorCode(): int|false {}
+    #[LanguageAware(['8.1' => 'int|false'], default: '')]
+    public function getErrorCode() {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
@@ -3067,7 +3175,8 @@ class IntlCalendar
      */
     #[Pure]
     #[TentativeType]
-    public function getErrorMessage(): string|false {}
+    #[LanguageAware(['8.1' => 'string|false'], default: '')]
+    public function getErrorMessage() {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
@@ -3080,7 +3189,8 @@ class IntlCalendar
      */
     #[Pure]
     #[TentativeType]
-    public function getFirstDayOfWeek(): int|false {}
+    #[LanguageAware(['8.1' => 'int|false'], default: '')]
+    public function getFirstDayOfWeek() {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
@@ -3096,7 +3206,8 @@ class IntlCalendar
      */
     #[Pure]
     #[TentativeType]
-    public function getGreatestMinimum(#[LanguageAware(['8.0' => 'int'], default: '')] $field): int|false {}
+    #[LanguageAware(['8.1' => 'int|false'], default: '')]
+    public function getGreatestMinimum(#[LanguageAware(['8.0' => 'int'], default: '')] $field) {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
@@ -3115,11 +3226,12 @@ class IntlCalendar
      * @return Iterator|false An iterator that yields strings with the locale keyword values or <b>FALSE</b> on failure.
      */
     #[TentativeType]
+    #[LanguageAware(['8.1' => 'IntlIterator|false'], default: '')]
     public static function getKeywordValuesForLocale(
         #[LanguageAware(['8.0' => 'string'], default: '')] $keyword,
         #[LanguageAware(['8.0' => 'string'], default: '')] $locale,
         #[LanguageAware(['8.0' => 'bool'], default: '')] $onlyCommon
-    ): IntlIterator|false {}
+    ) {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
@@ -3136,7 +3248,8 @@ class IntlCalendar
      */
     #[Pure]
     #[TentativeType]
-    public function getLeastMaximum(#[LanguageAware(['8.0' => 'int'], default: '')] $field): int|false {}
+    #[LanguageAware(['8.1' => 'int|false'], default: '')]
+    public function getLeastMaximum(#[LanguageAware(['8.0' => 'int'], default: '')] $field) {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
@@ -3154,7 +3267,8 @@ class IntlCalendar
      */
     #[Pure]
     #[TentativeType]
-    public function getLocale(#[LanguageAware(['8.0' => 'int'], default: '')] $type): string|false {}
+    #[LanguageAware(['8.1' => 'string|false'], default: '')]
+    public function getLocale(#[LanguageAware(['8.0' => 'int'], default: '')] $type) {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
@@ -3169,7 +3283,8 @@ class IntlCalendar
      */
     #[Pure]
     #[TentativeType]
-    public function getMaximum(#[LanguageAware(['8.0' => 'int'], default: '')] $field): int|false {}
+    #[LanguageAware(['8.1' => 'int|false'], default: '')]
+    public function getMaximum(#[LanguageAware(['8.0' => 'int'], default: '')] $field) {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
@@ -3180,7 +3295,8 @@ class IntlCalendar
      */
     #[Pure]
     #[TentativeType]
-    public function getMinimalDaysInFirstWeek(): int|false {}
+    #[LanguageAware(['8.1' => 'int|false'], default: '')]
+    public function getMinimalDaysInFirstWeek() {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
@@ -3196,7 +3312,8 @@ class IntlCalendar
      */
     #[Pure]
     #[TentativeType]
-    public function getMinimum(#[LanguageAware(['8.0' => 'int'], default: '')] $field): int|false {}
+    #[LanguageAware(['8.1' => 'int|false'], default: '')]
+    public function getMinimum(#[LanguageAware(['8.0' => 'int'], default: '')] $field) {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
@@ -3204,7 +3321,8 @@ class IntlCalendar
      * @return float A float representing a number of milliseconds since the epoch, not counting leap seconds.
      */
     #[TentativeType]
-    public static function getNow(): float {}
+    #[LanguageAware(['8.1' => 'float'], default: '')]
+    public static function getNow() {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
@@ -3216,7 +3334,8 @@ class IntlCalendar
      */
     #[Pure]
     #[TentativeType]
-    public function getRepeatedWallTimeOption(): int {}
+    #[LanguageAware(['8.1' => 'int'], default: '')]
+    public function getRepeatedWallTimeOption() {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
@@ -3229,7 +3348,8 @@ class IntlCalendar
      */
     #[Pure]
     #[TentativeType]
-    public function getSkippedWallTimeOption(): int {}
+    #[LanguageAware(['8.1' => 'int'], default: '')]
+    public function getSkippedWallTimeOption() {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
@@ -3240,7 +3360,8 @@ class IntlCalendar
      */
     #[Pure]
     #[TentativeType]
-    public function getTime(): float|false {}
+    #[LanguageAware(['8.1' => 'float|false'], default: '')]
+    public function getTime() {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
@@ -3252,7 +3373,8 @@ class IntlCalendar
      */
     #[Pure]
     #[TentativeType]
-    public function getTimeZone(): IntlTimeZone|false {}
+    #[LanguageAware(['8.1' => 'IntlTimeZone|false'], default: '')]
+    public function getTimeZone() {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
@@ -3264,7 +3386,8 @@ class IntlCalendar
      */
     #[Pure]
     #[TentativeType]
-    public function getType(): string {}
+    #[LanguageAware(['8.1' => 'string'], default: '')]
+    public function getType() {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
@@ -3281,7 +3404,8 @@ class IntlCalendar
      */
     #[Pure]
     #[TentativeType]
-    public function getWeekendTransition(#[LanguageAware(['8.0' => 'int'], default: '')] $dayOfWeek): int|false {}
+    #[LanguageAware(['8.1' => 'int|false'], default: '')]
+    public function getWeekendTransition(#[LanguageAware(['8.0' => 'int'], default: '')] $dayOfWeek) {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
@@ -3295,7 +3419,8 @@ class IntlCalendar
      */
     #[Pure]
     #[TentativeType]
-    public function inDaylightTime(): bool {}
+    #[LanguageAware(['8.1' => 'bool'], default: '')]
+    public function inDaylightTime() {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
@@ -3307,7 +3432,8 @@ class IntlCalendar
      */
     #[Pure]
     #[TentativeType]
-    public function isEquivalentTo(IntlCalendar $other): bool {}
+    #[LanguageAware(['8.1' => 'bool'], default: '')]
+    public function isEquivalentTo(IntlCalendar $other) {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
@@ -3318,7 +3444,8 @@ class IntlCalendar
      */
     #[Pure]
     #[TentativeType]
-    public function isLenient(): bool {}
+    #[LanguageAware(['8.1' => 'bool'], default: '')]
+    public function isLenient() {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
@@ -3340,7 +3467,8 @@ class IntlCalendar
      */
     #[Pure]
     #[TentativeType]
-    public function isWeekend(#[LanguageAware(['8.0' => 'float|null'], default: '')] $timestamp = null): bool {}
+    #[LanguageAware(['8.1' => 'bool'], default: '')]
+    public function isWeekend(#[LanguageAware(['8.0' => 'float|null'], default: '')] $timestamp = null) {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
@@ -3360,7 +3488,8 @@ class IntlCalendar
      * @return bool Returns <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function roll(#[LanguageAware(['8.0' => 'int'], default: '')] $field, $value): bool {}
+    #[LanguageAware(['8.1' => 'bool'], default: '')]
+    public function roll(#[LanguageAware(['8.0' => 'int'], default: '')] $field, $value) {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
@@ -3375,7 +3504,8 @@ class IntlCalendar
      * @return bool Assuming there are no argument errors, returns <b>TRUE</b> iif the field is set.
      */
     #[TentativeType]
-    public function PS_UNRESERVE_PREFIX_isSet(#[LanguageAware(['8.0' => 'int'], default: '')] $field): bool {}
+    #[LanguageAware(['8.1' => 'bool'], default: '')]
+    public function PS_UNRESERVE_PREFIX_isSet(#[LanguageAware(['8.0' => 'int'], default: '')] $field) {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
@@ -3505,7 +3635,8 @@ class IntlCalendar
      * Returns <b>TRUE</b> on success and <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function setTime(#[LanguageAware(['8.0' => 'float'], default: '')] $timestamp): bool {}
+    #[LanguageAware(['8.1' => 'bool'], default: '')]
+    public function setTime(#[LanguageAware(['8.0' => 'float'], default: '')] $timestamp) {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
@@ -3547,7 +3678,8 @@ class IntlCalendar
      * @return bool Returns <b>TRUE</b> on success and <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function setTimeZone(#[LanguageAware(['8.5' => 'IntlTimeZone|DateTimeZone|string|null'], default: '')] $timezone): bool {}
+    #[LanguageAware(['8.1' => 'bool'], default: '')]
+    public function setTimeZone(#[LanguageAware(['8.5' => 'IntlTimeZone|DateTimeZone|string|null'], default: '')] $timezone) {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a2)<br/>
@@ -3561,7 +3693,8 @@ class IntlCalendar
      */
     #[Pure]
     #[TentativeType]
-    public function toDateTime(): DateTime|false {}
+    #[LanguageAware(['8.1' => 'DateTime|false'], default: '')]
+    public function toDateTime() {}
 
     /**
      * @link https://www.php.net/manual/en/intlcalendar.setminimaldaysinfirstweek.php
@@ -3589,19 +3722,24 @@ class IntlCalendar
 class IntlIterator implements Iterator
 {
     #[TentativeType]
-    public function current(): mixed {}
+    #[LanguageAware(['8.1' => 'mixed'], default: '')]
+    public function current() {}
 
     #[TentativeType]
-    public function key(): mixed {}
+    #[LanguageAware(['8.1' => 'mixed'], default: '')]
+    public function key() {}
 
     #[TentativeType]
-    public function next(): void {}
+    #[LanguageAware(['8.1' => 'void'], default: '')]
+    public function next() {}
 
     #[TentativeType]
-    public function rewind(): void {}
+    #[LanguageAware(['8.1' => 'void'], default: '')]
+    public function rewind() {}
 
     #[TentativeType]
-    public function valid(): bool {}
+    #[LanguageAware(['8.1' => 'bool'], default: '')]
+    public function valid() {}
 }
 
 /**
@@ -3639,7 +3777,8 @@ class IntlTimeZone
      * @return int|false number of IDs or <b>FALSE</b> on failure
      */
     #[TentativeType]
-    public static function countEquivalentIDs(#[LanguageAware(['8.0' => 'string'], default: '')] $timezoneId): int|false {}
+    #[LanguageAware(['8.1' => 'int|false'], default: '')]
+    public static function countEquivalentIDs(#[LanguageAware(['8.0' => 'string'], default: '')] $timezoneId) {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
@@ -3648,7 +3787,8 @@ class IntlTimeZone
      * @return IntlTimeZone
      */
     #[TentativeType]
-    public static function createDefault(): IntlTimeZone {}
+    #[LanguageAware(['8.1' => 'IntlTimeZone'], default: '')]
+    public static function createDefault() {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
@@ -3658,7 +3798,8 @@ class IntlTimeZone
      * @return IntlIterator|false an iterator or <b>FALSE</b> on failure
      */
     #[TentativeType]
-    public static function createEnumeration(#[LanguageAware(['8.5' => 'string|int|null'], default: '')] $countryOrRawOffset): IntlIterator|false {}
+    #[LanguageAware(['8.1' => 'IntlIterator|false'], default: '')]
+    public static function createEnumeration(#[LanguageAware(['8.5' => 'string|int|null'], default: '')] $countryOrRawOffset) {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
@@ -3668,7 +3809,8 @@ class IntlTimeZone
      * @return IntlTimeZone|null a timezone object or <b>NULL</b> on failure
      */
     #[TentativeType]
-    public static function createTimeZone(#[LanguageAware(['8.0' => 'string'], default: '')] $timezoneId): ?IntlTimeZone {}
+    #[LanguageAware(['8.1' => 'IntlTimeZone|null'], default: '')]
+    public static function createTimeZone(#[LanguageAware(['8.0' => 'string'], default: '')] $timezoneId) {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -3680,11 +3822,12 @@ class IntlTimeZone
      * @return IntlIterator|false an iterator or <b>FALSE</b> on failure
      */
     #[TentativeType]
+    #[LanguageAware(['8.1' => 'IntlIterator|false'], default: '')]
     public static function createTimeZoneIDEnumeration(
         #[LanguageAware(['8.0' => 'int'], default: '')] $type,
         #[LanguageAware(['8.0' => 'string|null'], default: '')] $region = null,
         #[LanguageAware(['8.0' => 'int|null'], default: '')] $rawOffset = null
-    ): IntlIterator|false {}
+    ) {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
@@ -3694,7 +3837,8 @@ class IntlTimeZone
      * @return IntlTimeZone|null a timezone object or <b>NULL</b> on failure
      */
     #[TentativeType]
-    public static function fromDateTimeZone(#[LanguageAware(['8.0' => 'DateTimeZone'], default: '')] $timezone): ?IntlTimeZone {}
+    #[LanguageAware(['8.1' => 'IntlTimeZone|null'], default: '')]
+    public static function fromDateTimeZone(#[LanguageAware(['8.0' => 'DateTimeZone'], default: '')] $timezone) {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
@@ -3705,7 +3849,8 @@ class IntlTimeZone
      * @return string|false the timezone ID or <b>FALSE</b> on failure
      */
     #[TentativeType]
-    public static function getCanonicalID(#[LanguageAware(['8.0' => 'string'], default: '')] $timezoneId, &$isSystemId): string|false {}
+    #[LanguageAware(['8.1' => 'string|false'], default: '')]
+    public static function getCanonicalID(#[LanguageAware(['8.0' => 'string'], default: '')] $timezoneId, &$isSystemId) {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
@@ -3717,11 +3862,12 @@ class IntlTimeZone
      */
     #[Pure]
     #[TentativeType]
+    #[LanguageAware(['8.1' => 'string|false'], default: '')]
     public function getDisplayName(
         #[LanguageAware(['8.0' => 'bool'], default: '')] $dst = false,
         #[LanguageAware(['8.0' => 'int'], default: '')] $style = 2,
         #[LanguageAware(['8.0' => 'string|null'], default: '')] $locale
-    ): string|false {}
+    ) {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
@@ -3731,7 +3877,8 @@ class IntlTimeZone
      */
     #[Pure]
     #[TentativeType]
-    public function getDSTSavings(): int {}
+    #[LanguageAware(['8.1' => 'int'], default: '')]
+    public function getDSTSavings() {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
@@ -3742,10 +3889,11 @@ class IntlTimeZone
      * @return string|false the time zone ID or <b>FALSE</b> on failure
      */
     #[TentativeType]
+    #[LanguageAware(['8.1' => 'string|false'], default: '')]
     public static function getEquivalentID(
         #[LanguageAware(['8.0' => 'string'], default: '')] $timezoneId,
         #[LanguageAware(['8.0' => 'int'], default: '')] $offset
-    ): string|false {}
+    ) {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
@@ -3755,7 +3903,8 @@ class IntlTimeZone
      */
     #[Pure]
     #[TentativeType]
-    public function getErrorCode(): int|false {}
+    #[LanguageAware(['8.1' => 'int|false'], default: '')]
+    public function getErrorCode() {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
@@ -3765,7 +3914,8 @@ class IntlTimeZone
      */
     #[Pure]
     #[TentativeType]
-    public function getErrorMessage(): string|false {}
+    #[LanguageAware(['8.1' => 'string|false'], default: '')]
+    public function getErrorMessage() {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
@@ -3774,7 +3924,8 @@ class IntlTimeZone
      * @return IntlTimeZone
      */
     #[TentativeType]
-    public static function getGMT(): IntlTimeZone {}
+    #[LanguageAware(['8.1' => 'IntlTimeZone'], default: '')]
+    public static function getGMT() {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
@@ -3783,7 +3934,8 @@ class IntlTimeZone
      */
     #[Pure]
     #[TentativeType]
-    public function getID(): string|false {}
+    #[LanguageAware(['8.1' => 'string|false'], default: '')]
+    public function getID() {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
@@ -3806,12 +3958,13 @@ class IntlTimeZone
      * @return bool boolean indication of success
      */
     #[TentativeType]
+    #[LanguageAware(['8.1' => 'bool'], default: '')]
     public function getOffset(
         #[LanguageAware(['8.0' => 'float'], default: '')] $timestamp,
         #[LanguageAware(['8.0' => 'bool'], default: '')] $local,
         &$rawOffset,
         &$dstOffset
-    ): bool {}
+    ) {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
@@ -3821,7 +3974,8 @@ class IntlTimeZone
      */
     #[Pure]
     #[TentativeType]
-    public function getRawOffset(): int {}
+    #[LanguageAware(['8.1' => 'int'], default: '')]
+    public function getRawOffset() {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -3831,7 +3985,8 @@ class IntlTimeZone
      * @return string|false region or <b>FALSE</b> on failure
      */
     #[TentativeType]
-    public static function getRegion(#[LanguageAware(['8.0' => 'string'], default: '')] $timezoneId): string|false {}
+    #[LanguageAware(['8.1' => 'string|false'], default: '')]
+    public static function getRegion(#[LanguageAware(['8.0' => 'string'], default: '')] $timezoneId) {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
@@ -3840,7 +3995,8 @@ class IntlTimeZone
      * @return string|false
      */
     #[TentativeType]
-    public static function getTZDataVersion(): string|false {}
+    #[LanguageAware(['8.1' => 'string|false'], default: '')]
+    public static function getTZDataVersion() {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -3849,7 +4005,8 @@ class IntlTimeZone
      * @return IntlTimeZone
      */
     #[TentativeType]
-    public static function getUnknown(): IntlTimeZone {}
+    #[LanguageAware(['8.1' => 'IntlTimeZone'], default: '')]
+    public static function getUnknown() {}
 
     /**
      * (PHP 7 &gt;=7.1.0)<br/>
@@ -3861,7 +4018,8 @@ class IntlTimeZone
      * @since 7.1
      */
     #[TentativeType]
-    public static function getWindowsID(string $timezoneId): string|false {}
+    #[LanguageAware(['8.1' => 'string|false'], default: '')]
+    public static function getWindowsID(string $timezoneId) {}
 
     /**
      * @link https://www.php.net/manual/en/intltimezone.getidforwindowsid.php
@@ -3871,7 +4029,8 @@ class IntlTimeZone
      * @since 7.1
      */
     #[TentativeType]
-    public static function getIDForWindowsID(string $timezoneId, ?string $region = null): string|false {}
+    #[LanguageAware(['8.1' => 'string|false'], default: '')]
+    public static function getIDForWindowsID(string $timezoneId, ?string $region = null) {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
@@ -3882,7 +4041,8 @@ class IntlTimeZone
      */
     #[Pure]
     #[TentativeType]
-    public function hasSameRules(IntlTimeZone $other): bool {}
+    #[LanguageAware(['8.1' => 'bool'], default: '')]
+    public function hasSameRules(IntlTimeZone $other) {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
@@ -3892,7 +4052,8 @@ class IntlTimeZone
      */
     #[Pure]
     #[TentativeType]
-    public function toDateTimeZone(): DateTimeZone|false {}
+    #[LanguageAware(['8.1' => 'DateTimeZone|false'], default: '')]
+    public function toDateTimeZone() {}
 
     /**
      * (PHP 5 &gt;=5.5.0 PECL intl &gt;= 3.0.0a1)<br/>
@@ -3901,7 +4062,8 @@ class IntlTimeZone
      * @return bool
      */
     #[TentativeType]
-    public function useDaylightTime(): bool {}
+    #[LanguageAware(['8.1' => 'bool'], default: '')]
+    public function useDaylightTime() {}
 
     /**
      * @since 8.4
@@ -7280,7 +7442,8 @@ class IntlBreakIterator implements IteratorAggregate
      * @return IntlBreakIterator|null
      */
     #[TentativeType]
-    public static function createCharacterInstance(#[LanguageAware(['8.0' => 'string|null'], default: '')] $locale = null): ?IntlBreakIterator {}
+    #[LanguageAware(['8.1' => 'IntlBreakIterator|null'], default: '')]
+    public static function createCharacterInstance(#[LanguageAware(['8.0' => 'string|null'], default: '')] $locale = null) {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -7289,7 +7452,8 @@ class IntlBreakIterator implements IteratorAggregate
      * @return IntlCodePointBreakIterator
      */
     #[TentativeType]
-    public static function createCodePointInstance(): IntlCodePointBreakIterator {}
+    #[LanguageAware(['8.1' => 'IntlCodePointBreakIterator'], default: '')]
+    public static function createCodePointInstance() {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -7299,7 +7463,8 @@ class IntlBreakIterator implements IteratorAggregate
      * @return IntlBreakIterator|null
      */
     #[TentativeType]
-    public static function createLineInstance(#[LanguageAware(['8.0' => 'string|null'], default: '')] $locale): ?IntlBreakIterator {}
+    #[LanguageAware(['8.1' => 'IntlBreakIterator|null'], default: '')]
+    public static function createLineInstance(#[LanguageAware(['8.0' => 'string|null'], default: '')] $locale) {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -7309,7 +7474,8 @@ class IntlBreakIterator implements IteratorAggregate
      * @return IntlBreakIterator|null
      */
     #[TentativeType]
-    public static function createSentenceInstance(#[LanguageAware(['8.0' => 'string|null'], default: '')] $locale): ?IntlBreakIterator {}
+    #[LanguageAware(['8.1' => 'IntlBreakIterator|null'], default: '')]
+    public static function createSentenceInstance(#[LanguageAware(['8.0' => 'string|null'], default: '')] $locale) {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -7319,7 +7485,8 @@ class IntlBreakIterator implements IteratorAggregate
      * @return IntlBreakIterator|null
      */
     #[TentativeType]
-    public static function createTitleInstance(#[LanguageAware(['8.0' => 'string|null'], default: '')] $locale): ?IntlBreakIterator {}
+    #[LanguageAware(['8.1' => 'IntlBreakIterator|null'], default: '')]
+    public static function createTitleInstance(#[LanguageAware(['8.0' => 'string|null'], default: '')] $locale) {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -7329,7 +7496,8 @@ class IntlBreakIterator implements IteratorAggregate
      * @return IntlBreakIterator|null
      */
     #[TentativeType]
-    public static function createWordInstance(#[LanguageAware(['8.0' => 'string|null'], default: '')] $locale): ?IntlBreakIterator {}
+    #[LanguageAware(['8.1' => 'IntlBreakIterator|null'], default: '')]
+    public static function createWordInstance(#[LanguageAware(['8.0' => 'string|null'], default: '')] $locale) {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -7339,7 +7507,8 @@ class IntlBreakIterator implements IteratorAggregate
      */
     #[Pure]
     #[TentativeType]
-    public function current(): int {}
+    #[LanguageAware(['8.1' => 'int'], default: '')]
+    public function current() {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -7347,7 +7516,8 @@ class IntlBreakIterator implements IteratorAggregate
      * @link https://secure.php.net/manual/en/intlbreakiterator.first.php
      */
     #[TentativeType]
-    public function first(): int {}
+    #[LanguageAware(['8.1' => 'int'], default: '')]
+    public function first() {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -7356,7 +7526,8 @@ class IntlBreakIterator implements IteratorAggregate
      * @param int $offset
      */
     #[TentativeType]
-    public function following(#[LanguageAware(['8.0' => 'int'], default: '')] $offset): int {}
+    #[LanguageAware(['8.1' => 'int'], default: '')]
+    public function following(#[LanguageAware(['8.0' => 'int'], default: '')] $offset) {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -7366,7 +7537,8 @@ class IntlBreakIterator implements IteratorAggregate
      */
     #[Pure]
     #[TentativeType]
-    public function getErrorCode(): int {}
+    #[LanguageAware(['8.1' => 'int'], default: '')]
+    public function getErrorCode() {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -7376,7 +7548,8 @@ class IntlBreakIterator implements IteratorAggregate
      */
     #[Pure]
     #[TentativeType]
-    public function getErrorMessage(): string {}
+    #[LanguageAware(['8.1' => 'string'], default: '')]
+    public function getErrorMessage() {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -7386,7 +7559,8 @@ class IntlBreakIterator implements IteratorAggregate
      */
     #[Pure]
     #[TentativeType]
-    public function getLocale(#[LanguageAware(['8.0' => 'int'], default: '')] $type): string|false {}
+    #[LanguageAware(['8.1' => 'string|false'], default: '')]
+    public function getLocale(#[LanguageAware(['8.0' => 'int'], default: '')] $type) {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -7412,9 +7586,10 @@ class IntlBreakIterator implements IteratorAggregate
      */
     #[Pure]
     #[TentativeType]
+    #[LanguageAware(['8.1' => 'IntlPartsIterator'], default: '')]
     public function getPartsIterator(
         #[LanguageAware(['8.0' => 'string'], default: '')] #[EV([IntlPartsIterator::KEY_SEQUENTIAL, IntlPartsIterator::KEY_LEFT, IntlPartsIterator::KEY_RIGHT])] $type = IntlPartsIterator::KEY_SEQUENTIAL
-    ): IntlPartsIterator {}
+    ) {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -7423,7 +7598,8 @@ class IntlBreakIterator implements IteratorAggregate
      */
     #[Pure]
     #[TentativeType]
-    public function getText(): ?string {}
+    #[LanguageAware(['8.1' => 'string|null'], default: '')]
+    public function getText() {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -7433,7 +7609,8 @@ class IntlBreakIterator implements IteratorAggregate
      */
     #[Pure]
     #[TentativeType]
-    public function isBoundary(#[LanguageAware(['8.0' => 'int'], default: '')] $offset): bool {}
+    #[LanguageAware(['8.1' => 'bool'], default: '')]
+    public function isBoundary(#[LanguageAware(['8.0' => 'int'], default: '')] $offset) {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -7442,7 +7619,8 @@ class IntlBreakIterator implements IteratorAggregate
      * @return int
      */
     #[TentativeType]
-    public function last(): int {}
+    #[LanguageAware(['8.1' => 'int'], default: '')]
+    public function last() {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -7451,7 +7629,8 @@ class IntlBreakIterator implements IteratorAggregate
      * @return int
      */
     #[TentativeType]
-    public function next(#[LanguageAware(['8.0' => 'int|null'], default: '')] $offset = null): int {}
+    #[LanguageAware(['8.1' => 'int'], default: '')]
+    public function next(#[LanguageAware(['8.0' => 'int|null'], default: '')] $offset = null) {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -7459,7 +7638,8 @@ class IntlBreakIterator implements IteratorAggregate
      * @param int $offset
      */
     #[TentativeType]
-    public function preceding(#[LanguageAware(['8.0' => 'int'], default: '')] $offset): int {}
+    #[LanguageAware(['8.1' => 'int'], default: '')]
+    public function preceding(#[LanguageAware(['8.0' => 'int'], default: '')] $offset) {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -7468,7 +7648,8 @@ class IntlBreakIterator implements IteratorAggregate
      * @return int
      */
     #[TentativeType]
-    public function previous(): int {}
+    #[LanguageAware(['8.1' => 'int'], default: '')]
+    public function previous() {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -7511,7 +7692,8 @@ class IntlRuleBasedBreakIterator extends IntlBreakIterator implements Traversabl
      */
     #[Pure]
     #[TentativeType]
-    public function getBinaryRules(): string|false {}
+    #[LanguageAware(['8.1' => 'string|false'], default: '')]
+    public function getBinaryRules() {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -7521,7 +7703,8 @@ class IntlRuleBasedBreakIterator extends IntlBreakIterator implements Traversabl
      */
     #[Pure]
     #[TentativeType]
-    public function getRules(): string|false {}
+    #[LanguageAware(['8.1' => 'string|false'], default: '')]
+    public function getRules() {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -7531,7 +7714,8 @@ class IntlRuleBasedBreakIterator extends IntlBreakIterator implements Traversabl
      */
     #[Pure]
     #[TentativeType]
-    public function getRuleStatus(): int {}
+    #[LanguageAware(['8.1' => 'int'], default: '')]
+    public function getRuleStatus() {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -7541,7 +7725,8 @@ class IntlRuleBasedBreakIterator extends IntlBreakIterator implements Traversabl
      */
     #[Pure]
     #[TentativeType]
-    public function getRuleStatusVec(): array|false {}
+    #[LanguageAware(['8.1' => 'array|false'], default: '')]
+    public function getRuleStatusVec() {}
 }
 
 /**
@@ -7559,13 +7744,15 @@ class IntlPartsIterator extends IntlIterator implements Iterator
      */
     #[Pure]
     #[TentativeType]
-    public function getBreakIterator(): IntlBreakIterator {}
+    #[LanguageAware(['8.1' => 'IntlBreakIterator'], default: '')]
+    public function getBreakIterator() {}
 
     /**
      * @since 8.1
      */
     #[TentativeType]
-    public function getRuleStatus(): int {}
+    #[LanguageAware(['8.1' => 'int'], default: '')]
+    public function getRuleStatus() {}
 }
 
 class IntlCodePointBreakIterator extends IntlBreakIterator implements Traversable
@@ -7578,7 +7765,8 @@ class IntlCodePointBreakIterator extends IntlBreakIterator implements Traversabl
      */
     #[Pure]
     #[TentativeType]
-    public function getLastCodePoint(): int {}
+    #[LanguageAware(['8.1' => 'int'], default: '')]
+    public function getLastCodePoint() {}
 }
 
 class UConverter
@@ -7650,10 +7838,11 @@ class UConverter
      */
     #[Pure]
     #[TentativeType]
+    #[LanguageAware(['8.1' => 'string|false'], default: '')]
     public function convert(
         #[LanguageAware(['8.0' => 'string'], default: '')] $str,
         #[LanguageAware(['8.0' => 'bool'], default: '')] $reverse = false
-    ): string|false {}
+    ) {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -7666,12 +7855,13 @@ class UConverter
      * @return array|string|int|null
      */
     #[TentativeType]
+    #[LanguageAware(['8.1' => 'array|string|int|null'], default: '')]
     public function fromUCallback(
         #[LanguageAware(['8.0' => 'int'], default: '')] $reason,
         #[LanguageAware(['8.0' => 'array'], default: '')] $source,
         #[LanguageAware(['8.0' => 'int'], default: '')] $codePoint,
         &$error
-    ): array|string|int|null {}
+    ) {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -7681,10 +7871,11 @@ class UConverter
      * @return array|false|null
      */
     #[TentativeType]
+    #[LanguageAware(['8.1' => 'array|false|null'], default: '')]
     public static function getAliases(
         #[ElementAvailable(from: '5.5', to: '5.6')] $name = '',
         #[ElementAvailable(from: '7.0')] #[LanguageAware(['8.0' => 'string'], default: '')] $name
-    ): array|false|null {}
+    ) {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -7693,7 +7884,8 @@ class UConverter
      * @return array
      */
     #[TentativeType]
-    public static function getAvailable(): array {}
+    #[LanguageAware(['8.1' => 'array'], default: '')]
+    public static function getAvailable() {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -7703,7 +7895,8 @@ class UConverter
      */
     #[Pure]
     #[TentativeType]
-    public function getDestinationEncoding(): string|false|null {}
+    #[LanguageAware(['8.1' => 'string|false|null'], default: '')]
+    public function getDestinationEncoding() {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -7713,7 +7906,8 @@ class UConverter
      */
     #[Pure]
     #[TentativeType]
-    public function getDestinationType(): int|false|null {}
+    #[LanguageAware(['8.1' => 'int|false|null'], default: '')]
+    public function getDestinationType() {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -7723,7 +7917,8 @@ class UConverter
      */
     #[Pure]
     #[TentativeType]
-    public function getErrorCode(): int {}
+    #[LanguageAware(['8.1' => 'int'], default: '')]
+    public function getErrorCode() {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -7733,7 +7928,8 @@ class UConverter
      */
     #[Pure]
     #[TentativeType]
-    public function getErrorMessage(): ?string {}
+    #[LanguageAware(['8.1' => 'string|null'], default: '')]
+    public function getErrorMessage() {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -7743,7 +7939,8 @@ class UConverter
      */
     #[Pure]
     #[TentativeType]
-    public function getSourceEncoding(): string|false|null {}
+    #[LanguageAware(['8.1' => 'string|false|null'], default: '')]
+    public function getSourceEncoding() {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -7753,7 +7950,8 @@ class UConverter
      */
     #[Pure]
     #[TentativeType]
-    public function getSourceType(): int|false|null {}
+    #[LanguageAware(['8.1' => 'int|false|null'], default: '')]
+    public function getSourceType() {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -7763,7 +7961,8 @@ class UConverter
      */
     #[Pure]
     #[TentativeType]
-    public static function getStandards(): ?array {}
+    #[LanguageAware(['8.1' => 'array|null'], default: '')]
+    public static function getStandards() {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -7773,7 +7972,8 @@ class UConverter
      */
     #[Pure]
     #[TentativeType]
-    public function getSubstChars(): string|false|null {}
+    #[LanguageAware(['8.1' => 'string|false|null'], default: '')]
+    public function getSubstChars() {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -7784,10 +7984,11 @@ class UConverter
      */
     #[Pure]
     #[TentativeType]
+    #[LanguageAware(['8.1' => 'string'], default: '')]
     public static function reasonText(
         #[ElementAvailable(from: '5.3', to: '7.4')] $reason = 0,
         #[ElementAvailable(from: '8.0')] int $reason
-    ): string {}
+    ) {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -7797,7 +7998,8 @@ class UConverter
      * @return bool
      */
     #[TentativeType]
-    public function setDestinationEncoding(#[LanguageAware(['8.0' => 'string'], default: '')] $encoding): bool {}
+    #[LanguageAware(['8.1' => 'bool'], default: '')]
+    public function setDestinationEncoding(#[LanguageAware(['8.0' => 'string'], default: '')] $encoding) {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -7807,7 +8009,8 @@ class UConverter
      * @return bool
      */
     #[TentativeType]
-    public function setSourceEncoding(#[LanguageAware(['8.0' => 'string'], default: '')] $encoding): bool {}
+    #[LanguageAware(['8.1' => 'bool'], default: '')]
+    public function setSourceEncoding(#[LanguageAware(['8.0' => 'string'], default: '')] $encoding) {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -7817,7 +8020,8 @@ class UConverter
      * @return bool
      */
     #[TentativeType]
-    public function setSubstChars(#[LanguageAware(['8.0' => 'string'], default: '')] $chars): bool {}
+    #[LanguageAware(['8.1' => 'bool'], default: '')]
+    public function setSubstChars(#[LanguageAware(['8.0' => 'string'], default: '')] $chars) {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -7830,12 +8034,13 @@ class UConverter
      * @return array|string|int|null
      */
     #[TentativeType]
+    #[LanguageAware(['8.1' => 'array|string|int|null'], default: '')]
     public function toUCallback(
         #[LanguageAware(['8.0' => 'int'], default: '')] $reason,
         #[LanguageAware(['8.0' => 'string'], default: '')] $source,
         #[LanguageAware(['8.0' => 'string'], default: '')] $codeUnits,
         &$error
-    ): array|string|int|null {}
+    ) {}
 
     /**
      * (PHP 5 &gt;=5.5.0)<br/>
@@ -7848,11 +8053,12 @@ class UConverter
      * @return string|false
      */
     #[TentativeType]
+    #[LanguageAware(['8.1' => 'string|false'], default: '')]
     public static function transcode(
         #[LanguageAware(['8.0' => 'string'], default: '')] $str,
         #[LanguageAware(['8.0' => 'string'], default: '')] $toEncoding,
         #[LanguageAware(['8.0' => 'string'], default: '')] $fromEncoding,
         #[LanguageAware(['7.1' => 'array|null'], default: '')] $options = null
-    ): string|false {}
+    ) {}
 }
 // End of intl v.1.1.0

--- a/json/json.php
+++ b/json/json.php
@@ -4,6 +4,7 @@
 use JetBrains\PhpStorm\Internal\TentativeType;
 use JetBrains\PhpStorm\Language;
 use JetBrains\PhpStorm\Pure;
+use JetBrains\PhpStorm\Internal\LanguageLevelTypeAware;
 
 /**
  * Objects implementing JsonSerializable
@@ -22,7 +23,8 @@ interface JsonSerializable
      * @since 5.4
      */
     #[TentativeType]
-    public function jsonSerialize(): mixed;
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
+    public function jsonSerialize();
 }
 
 class JsonIncrementalParser

--- a/mysqli/mysqli.php
+++ b/mysqli/mysqli.php
@@ -222,7 +222,8 @@ class mysqli
      * @return bool true on success or false on failure.
      */
     #[TentativeType]
-    public function autocommit(#[LanguageLevelTypeAware(['8.0' => 'bool'], default: '')] $enable): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function autocommit(#[LanguageLevelTypeAware(['8.0' => 'bool'], default: '')] $enable) {}
 
     /**
      * Starts a transaction
@@ -233,10 +234,11 @@ class mysqli
      * @since 5.5
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function begin_transaction(
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $flags = 0,
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $name = null
-    ): bool {}
+    ) {}
 
     /**
      * Changes the user of the specified database connection
@@ -258,11 +260,12 @@ class mysqli
      * @return bool true on success or false on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function change_user(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $username,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $password,
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $database
-    ): bool {}
+    ) {}
 
     /**
      * Returns the current character set of the database connection
@@ -270,7 +273,8 @@ class mysqli
      * @return string The current character set of the connection
      */
     #[TentativeType]
-    public function character_set_name(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function character_set_name() {}
 
     /**
      * @removed 5.4
@@ -295,10 +299,11 @@ class mysqli
      * @return bool true on success or false on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function commit(
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $flags = 0,
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $name = null
-    ): bool {}
+    ) {}
 
     /**
      * @link https://php.net/manual/en/function.mysqli-connect.php
@@ -311,6 +316,7 @@ class mysqli
      * @return bool
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function connect(
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $hostname = null,
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $username = null,
@@ -318,7 +324,7 @@ class mysqli
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $database = null,
         #[LanguageLevelTypeAware(['8.0' => 'int|null'], default: '')] $port = null,
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $socket = null
-    ): bool {}
+    ) {}
 
     /**
      * Dump debugging information into the log
@@ -326,7 +332,8 @@ class mysqli
      * @return bool true on success or false on failure.
      */
     #[TentativeType]
-    public function dump_debug_info(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function dump_debug_info() {}
 
     /**
      * Performs debugging operations
@@ -360,7 +367,8 @@ class mysqli
      * <p>Character set status (?)</p>
      */
     #[TentativeType]
-    public function get_charset(): ?object {}
+    #[LanguageLevelTypeAware(['8.1' => 'object|null'], default: '')]
+    public function get_charset() {}
 
     /**
      * <p>Prepares the SQL query, binds parameters, and executes it. The
@@ -407,7 +415,8 @@ class mysqli
      * @deprecated 8.1
      */
     #[TentativeType]
-    public function get_client_info(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function get_client_info() {}
 
     /**
      * Returns statistics about the client connection
@@ -415,7 +424,8 @@ class mysqli
      * @return array an array with connection stats.
      */
     #[TentativeType]
-    public function get_connection_stats(): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public function get_connection_stats() {}
 
     /**
      * Returns the version of the MySQL server
@@ -423,7 +433,8 @@ class mysqli
      * @return string A character string representing the server version.
      */
     #[TentativeType]
-    public function get_server_info(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function get_server_info() {}
 
     /**
      * Get result of SHOW WARNINGS
@@ -431,7 +442,8 @@ class mysqli
      * @return mysqli_warning|false
      */
     #[TentativeType]
-    public function get_warnings(): mysqli_warning|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'mysqli_warning|false'], default: '')]
+    public function get_warnings() {}
 
     /**
      * Initializes MySQLi object
@@ -449,7 +461,8 @@ class mysqli
      */
     #[Deprecated("The function is deprecated", since: "8.4")]
     #[TentativeType]
-    public function kill(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $process_id): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function kill(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $process_id) {}
 
     /**
      * Performs one or more queries on the database
@@ -469,7 +482,8 @@ class mysqli
      * <b>mysqli_next_result</b> first.
      */
     #[TentativeType]
-    public function multi_query(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $query): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function multi_query(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $query) {}
 
     /**
      * @link https://php.net/manual/en/mysqli.construct.php
@@ -490,7 +504,8 @@ class mysqli
      * @return bool true on success or false on failure.
      */
     #[TentativeType]
-    public function more_results(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function more_results() {}
 
     /**
      * Prepare next result from multi_query
@@ -498,7 +513,8 @@ class mysqli
      * @return bool true on success or false on failure.
      */
     #[TentativeType]
-    public function next_result(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function next_result() {}
 
     /**
      * Set options
@@ -550,7 +566,8 @@ class mysqli
      * @return bool true on success or false on failure.
      */
     #[TentativeType]
-    public function options(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $option, $value): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function options(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $option, $value) {}
 
     /**
      * Pings a server connection, or tries to reconnect if the connection has gone down
@@ -559,7 +576,8 @@ class mysqli
      */
     #[Deprecated("The function is deprecated", since: "8.4")]
     #[TentativeType]
-    public function ping(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function ping() {}
 
     /**
      * Prepares an SQL statement for execution
@@ -591,7 +609,8 @@ class mysqli
      * @return mysqli_stmt|false <b>mysqli_prepare</b> returns a statement object or false if an error occurred.
      */
     #[TentativeType]
-    public function prepare(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $query): mysqli_stmt|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'mysqli_stmt|false'], default: '')]
+    public function prepare(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $query) {}
 
     /**
      * Performs a query on the database
@@ -636,10 +655,11 @@ class mysqli
      * return true.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'mysqli_result|bool'], default: '')]
     public function query(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $query,
         #[PhpStormStubsElementAvailable(from: '7.1')] int $result_mode = MYSQLI_STORE_RESULT
-    ): mysqli_result|bool {}
+    ) {}
 
     /**
      * Opens a connection to a mysql server
@@ -718,6 +738,7 @@ class mysqli
      * @return bool true on success or false on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function real_connect(
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $hostname = null,
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $username = null,
@@ -726,7 +747,7 @@ class mysqli
         #[LanguageLevelTypeAware(['8.0' => 'int|null'], default: '')] $port = null,
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $socket = null,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $flags = 0
-    ): bool {}
+    ) {}
 
     /**
      * Escapes special characters in a string for use in an SQL statement, taking into account the current charset of the connection
@@ -741,7 +762,8 @@ class mysqli
      * @return string an escaped string.
      */
     #[TentativeType]
-    public function real_escape_string(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $string): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function real_escape_string(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $string) {}
 
     /**
      * Poll connections
@@ -761,13 +783,14 @@ class mysqli
      * @return int|false number of ready connections in success, false otherwise.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'int|false'], default: '')]
     public static function poll(
         #[LanguageLevelTypeAware(['7.1' => 'array|null'], default: '')] &$read,
         #[LanguageLevelTypeAware(['7.1' => 'array|null'], default: '')] &$error,
         #[LanguageLevelTypeAware(['8.0' => 'array'], default: '')] &$reject,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $seconds,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $microseconds = 0
-    ): int|false {}
+    ) {}
 
     /**
      * Get result from async query
@@ -775,7 +798,8 @@ class mysqli
      * @return mysqli_result|bool false on failure, mysqli_result for queries which produce a result set, true otherwise
      */
     #[TentativeType]
-    public function reap_async_query(): mysqli_result|bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'mysqli_result|bool'], default: '')]
+    public function reap_async_query() {}
 
     /**
      * Escapes special characters in a string for use in an SQL statement, taking into account the current charset of the connection
@@ -785,7 +809,8 @@ class mysqli
      * @link https://secure.php.net/manual/en/mysqli.real-escape-string.php
      */
     #[TentativeType]
-    public function escape_string(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $string): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function escape_string(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $string) {}
 
     /**
      * Execute an SQL query
@@ -802,7 +827,8 @@ class mysqli
      * @return bool true on success or false on failure.
      */
     #[TentativeType]
-    public function real_query(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $query): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function real_query(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $query) {}
 
     /**
      * Removes the named savepoint from the set of savepoints of the current transaction
@@ -812,7 +838,8 @@ class mysqli
      * @since 5.5
      */
     #[TentativeType]
-    public function release_savepoint(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function release_savepoint(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name) {}
 
     /**
      * Rolls back current transaction
@@ -823,10 +850,11 @@ class mysqli
      * @since 5.5 Added flags and name parameters.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function rollback(
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $flags = 0,
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $name = null
-    ): bool {}
+    ) {}
 
     /**
      * Set a named transaction savepoint
@@ -836,7 +864,8 @@ class mysqli
      * @since 5.5
      */
     #[TentativeType]
-    public function savepoint(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function savepoint(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name) {}
 
     /**
      * Selects the default database for database queries
@@ -847,7 +876,8 @@ class mysqli
      * @return bool true on success or false on failure.
      */
     #[TentativeType]
-    public function select_db(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $database): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function select_db(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $database) {}
 
     /**
      * Sets the client character set
@@ -858,7 +888,8 @@ class mysqli
      * @return bool true on success or false on failure
      */
     #[TentativeType]
-    public function set_charset(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $charset): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function set_charset(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $charset) {}
 
     /**
      * @link https://php.net/manual/en/function.mysqli-set-opt
@@ -866,7 +897,8 @@ class mysqli
      * @param string|int $value
      */
     #[TentativeType]
-    public function set_opt(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $option, $value): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function set_opt(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $option, $value) {}
 
     /**
      * Used for establishing secure connections using SSL
@@ -904,7 +936,8 @@ class mysqli
      * @return string|false A string describing the server status. false if an error occurred.
      */
     #[TentativeType]
-    public function stat(): string|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'string|false'], default: '')]
+    public function stat() {}
 
     /**
      * Initializes a statement and returns an object for use with mysqli_stmt_prepare
@@ -912,7 +945,8 @@ class mysqli
      * @return mysqli_stmt an object.
      */
     #[TentativeType]
-    public function stmt_init(): mysqli_stmt|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'mysqli_stmt|false'], default: '')]
+    public function stmt_init() {}
 
     /**
      * Transfers a result set from the last query
@@ -935,9 +969,10 @@ class mysqli
      * statement should have produced a non-empty result set.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'mysqli_result|false'], default: '')]
     public function store_result(
         #[Deprecated(since: '8.4'), LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $mode = 0
-    ): mysqli_result|false {}
+    ) {}
 
     /**
      * Returns whether thread safety is given or not
@@ -945,7 +980,8 @@ class mysqli
      * @return bool true if the client library is thread-safe, otherwise false.
      */
     #[TentativeType]
-    public function thread_safe(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function thread_safe() {}
 
     /**
      * Initiate a result set retrieval
@@ -953,7 +989,8 @@ class mysqli
      * @return mysqli_result|false an unbuffered result object or false if an error occurred.
      */
     #[TentativeType]
-    public function use_result(): mysqli_result|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'mysqli_result|false'], default: '')]
+    public function use_result() {}
 
     /**
      * @link https://php.net/manual/en/mysqli.refresh
@@ -963,7 +1000,8 @@ class mysqli
      */
     #[Deprecated("The function is deprecated", since: "8.4")]
     #[TentativeType]
-    public function refresh(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $flags): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function refresh(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $flags) {}
 }
 
 /**
@@ -1065,7 +1103,8 @@ class mysqli_result implements IteratorAggregate
      * @link https://php.net/manual/en/mysqli-result.free.php
      */
     #[TentativeType]
-    public function close(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function close() {}
 
     /**
      * Frees the memory associated with a result
@@ -1073,7 +1112,8 @@ class mysqli_result implements IteratorAggregate
      * @return void
      */
     #[TentativeType]
-    public function free(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function free() {}
 
     /**
      * Adjusts the result pointer to an arbitrary row in the result
@@ -1085,7 +1125,8 @@ class mysqli_result implements IteratorAggregate
      * @return bool true on success or false on failure.
      */
     #[TentativeType]
-    public function data_seek(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $offset): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function data_seek(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $offset) {}
 
     /**
      * Returns the next field in the result set
@@ -1155,7 +1196,8 @@ class mysqli_result implements IteratorAggregate
      * </table>
      */
     #[TentativeType]
-    public function fetch_field(): object|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'object|false'], default: '')]
+    public function fetch_field() {}
 
     /**
      * Returns an array of objects representing the fields in a result set
@@ -1216,7 +1258,8 @@ class mysqli_result implements IteratorAggregate
      * </table>
      */
     #[TentativeType]
-    public function fetch_fields(): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public function fetch_fields() {}
 
     /**
      * Fetch meta-data for a single field
@@ -1283,7 +1326,8 @@ class mysqli_result implements IteratorAggregate
      * </table>
      */
     #[TentativeType]
-    public function fetch_field_direct(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $index): object|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'object|false'], default: '')]
+    public function fetch_field_direct(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $index) {}
 
     /**
      * Fetches all result rows as an associative array, a numeric array, or both
@@ -1297,7 +1341,8 @@ class mysqli_result implements IteratorAggregate
      * @return array an array of associative or numeric arrays holding result rows.
      */
     #[TentativeType]
-    public function fetch_all(#[PhpStormStubsElementAvailable(from: '7.0')] int $mode = MYSQLI_NUM): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public function fetch_all(#[PhpStormStubsElementAvailable(from: '7.0')] int $mode = MYSQLI_NUM) {}
 
     /**
      * Fetch the next row of a result set as an associative, a numeric array, or both
@@ -1320,7 +1365,8 @@ class mysqli_result implements IteratorAggregate
      * are no more rows in the result set, or false on failure.
      */
     #[TentativeType]
-    public function fetch_array(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $mode = MYSQLI_BOTH): array|false|null {}
+    #[LanguageLevelTypeAware(['8.1' => 'array|false|null'], default: '')]
+    public function fetch_array(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $mode = MYSQLI_BOTH) {}
 
     /**
      * Fetch the next row of a result set as an associative array
@@ -1330,7 +1376,8 @@ class mysqli_result implements IteratorAggregate
      * are no more rows in the result set, or false on failure.
      */
     #[TentativeType]
-    public function fetch_assoc(): array|false|null {}
+    #[LanguageLevelTypeAware(['8.1' => 'array|false|null'], default: '')]
+    public function fetch_assoc() {}
 
     /**
      * @template T of object
@@ -1350,7 +1397,8 @@ class mysqli_result implements IteratorAggregate
      * are no more rows in the result set, or false on failure.
      */
     #[TentativeType]
-    public function fetch_object(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $class = 'stdClass', array $constructor_args = []): object|false|null {}
+    #[LanguageLevelTypeAware(['8.1' => 'object|false|null'], default: '')]
+    public function fetch_object(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $class = 'stdClass', array $constructor_args = []) {}
 
     /**
      * Fetch the next row of a result set as an enumerated array
@@ -1360,7 +1408,8 @@ class mysqli_result implements IteratorAggregate
      * are no more rows in the result set, or false on failure.
      */
     #[TentativeType]
-    public function fetch_row(): array|false|null {}
+    #[LanguageLevelTypeAware(['8.1' => 'array|false|null'], default: '')]
+    public function fetch_row() {}
 
     /**
      * Fetch a single column from the next row of a result set
@@ -1393,7 +1442,8 @@ class mysqli_result implements IteratorAggregate
      * @link https://php.net/manual/en/mysqli-result.free.php
      */
     #[TentativeType]
-    public function free_result(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function free_result() {}
 
     /**
      * @return Iterator
@@ -1485,7 +1535,8 @@ class mysqli_stmt
      * @return int Returns the value of the attribute.
      */
     #[TentativeType]
-    public function attr_get(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $attribute): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function attr_get(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $attribute) {}
 
     /**
      * Used to modify the behavior of a prepared statement
@@ -1540,10 +1591,11 @@ class mysqli_stmt
      * @return bool
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function attr_set(
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $attribute,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $value
-    ): bool {}
+    ) {}
 
     /**
      * Binds variables to a prepared statement as parameters
@@ -1583,7 +1635,8 @@ class mysqli_stmt
      * @return bool true on success or false on failure.
      */
     #[TentativeType]
-    public function bind_param(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $types, mixed & $var1, mixed & ...$_): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function bind_param(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $types, mixed & $var1, mixed & ...$_) {}
 
     /**
      * Binds variables to a prepared statement for result storage
@@ -1593,7 +1646,8 @@ class mysqli_stmt
      * @return bool true on success or false on failure.
      */
     #[TentativeType]
-    public function bind_result(mixed &$var1, mixed &...$_): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function bind_result(mixed &$var1, mixed &...$_) {}
 
     /**
      * Closes a prepared statement
@@ -1614,7 +1668,8 @@ class mysqli_stmt
      * @return void
      */
     #[TentativeType]
-    public function data_seek(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $offset): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function data_seek(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $offset) {}
 
     /**
      * Executes a prepared statement
@@ -1624,7 +1679,8 @@ class mysqli_stmt
      * @return bool true on success or false on failure.
      */
     #[TentativeType]
-    public function execute(#[PhpStormStubsElementAvailable('8.1')] ?array $params = null): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function execute(#[PhpStormStubsElementAvailable('8.1')] ?array $params = null) {}
 
     /**
      * Fetch results from a prepared statement into the bound variables
@@ -1632,7 +1688,8 @@ class mysqli_stmt
      * @return bool|null
      */
     #[TentativeType]
-    public function fetch(): ?bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool|null'], default: '')]
+    public function fetch() {}
 
     /**
      * Get result of SHOW WARNINGS
@@ -1640,7 +1697,8 @@ class mysqli_stmt
      * @return object|false
      */
     #[TentativeType]
-    public function get_warnings(): mysqli_warning|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'mysqli_warning|false'], default: '')]
+    public function get_warnings() {}
 
     /**
      * Returns result set metadata from a prepared statement
@@ -1648,7 +1706,8 @@ class mysqli_stmt
      * @return mysqli_result|false a result object or false if an error occurred.
      */
     #[TentativeType]
-    public function result_metadata(): mysqli_result|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'mysqli_result|false'], default: '')]
+    public function result_metadata() {}
 
     /**
      * Check if there are more query results from a multiple query
@@ -1656,7 +1715,8 @@ class mysqli_stmt
      * @return bool
      */
     #[TentativeType]
-    public function more_results(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function more_results() {}
 
     /**
      * Reads the next result from a multiple query
@@ -1664,7 +1724,8 @@ class mysqli_stmt
      * @return bool
      */
     #[TentativeType]
-    public function next_result(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function next_result() {}
 
     /**
      * Return the number of rows in statements result set
@@ -1672,7 +1733,8 @@ class mysqli_stmt
      * @return string|int An integer representing the number of rows in result set.
      */
     #[TentativeType]
-    public function num_rows(): string|int {}
+    #[LanguageLevelTypeAware(['8.1' => 'string|int'], default: '')]
+    public function num_rows() {}
 
     /**
      * Send data in blocks
@@ -1687,10 +1749,11 @@ class mysqli_stmt
      * @return bool true on success or false on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function send_long_data(
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $param_num,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $data
-    ): bool {}
+    ) {}
 
     /**
      * No documentation available
@@ -1705,7 +1768,8 @@ class mysqli_stmt
      * @return void
      */
     #[TentativeType]
-    public function free_result(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function free_result() {}
 
     /**
      * Resets a prepared statement
@@ -1713,7 +1777,8 @@ class mysqli_stmt
      * @return bool true on success or false on failure.
      */
     #[TentativeType]
-    public function reset(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function reset() {}
 
     /**
      * Prepare an SQL statement for execution
@@ -1742,7 +1807,8 @@ class mysqli_stmt
      * @return bool true on success or false on failure.
      */
     #[TentativeType]
-    public function prepare(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $query): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function prepare(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $query) {}
 
     /**
      * Stores a result set in an internal buffer
@@ -1750,7 +1816,8 @@ class mysqli_stmt
      * @return bool true on success or false on failure.
      */
     #[TentativeType]
-    public function store_result(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function store_result() {}
 
     /**
      * Gets a result set from a prepared statement as a mysqli_result object
@@ -1758,7 +1825,8 @@ class mysqli_stmt
      * @return mysqli_result|false Returns a resultset or FALSE on failure
      */
     #[TentativeType]
-    public function get_result(): mysqli_result|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'mysqli_result|false'], default: '')]
+    public function get_result() {}
 }
 
 /**

--- a/rdkafka/RdKafka.php
+++ b/rdkafka/RdKafka.php
@@ -6,6 +6,7 @@ use RdKafka\Metadata;
 use RdKafka\Topic;
 use RdKafka\TopicConf;
 use RdKafka\TopicPartition;
+use JetBrains\PhpStorm\Internal\LanguageLevelTypeAware;
 
 abstract class RdKafka
 {
@@ -39,7 +40,8 @@ abstract class RdKafka
     public function getMetadata($all_topics, $only_topic = null, $timeout_ms = 0) {}
 
     #[TentativeType]
-    public function getControllerId(int $timeout_ms): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function getControllerId(int $timeout_ms) {}
 
     /**
      * @return int
@@ -108,14 +110,18 @@ abstract class RdKafka
     public function outqLen() {}
 
     #[TentativeType]
-    public function pausePartitions(array $topic_partitions): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public function pausePartitions(array $topic_partitions) {}
 
     #[TentativeType]
-    public function resumePartitions(array $topic_partitions): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public function resumePartitions(array $topic_partitions) {}
 
     #[TentativeType]
-    public function oauthbearerSetToken(string $token_value, int|float|string $lifetime_ms, string $principal_name, array $extensions = []): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function oauthbearerSetToken(string $token_value, int|float|string $lifetime_ms, string $principal_name, array $extensions = []) {}
 
     #[TentativeType]
-    public function oauthbearerSetTokenFailure(string $error): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function oauthbearerSetTokenFailure(string $error) {}
 }

--- a/rdkafka/RdKafka/Conf.php
+++ b/rdkafka/RdKafka/Conf.php
@@ -3,6 +3,7 @@
 namespace RdKafka;
 
 use JetBrains\PhpStorm\Internal\TentativeType;
+use JetBrains\PhpStorm\Internal\LanguageLevelTypeAware;
 
 /**
  * Configuration reference: https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
@@ -81,5 +82,6 @@ class Conf
     public function setLogCb($callback) {}
 
     #[TentativeType]
-    public function setOauthbearerTokenRefreshCb(callable $callback): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function setOauthbearerTokenRefreshCb(callable $callback) {}
 }

--- a/rdkafka/RdKafka/KafkaConsumer.php
+++ b/rdkafka/RdKafka/KafkaConsumer.php
@@ -3,6 +3,7 @@
 namespace RdKafka;
 
 use JetBrains\PhpStorm\Internal\TentativeType;
+use JetBrains\PhpStorm\Internal\LanguageLevelTypeAware;
 
 class KafkaConsumer
 {
@@ -35,10 +36,12 @@ class KafkaConsumer
     public function assign($topic_partitions = null) {}
 
     #[TentativeType]
-    public function incrementalAssign(array $topic_partitions): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function incrementalAssign(array $topic_partitions) {}
 
     #[TentativeType]
-    public function incrementalUnassign(array $topic_partitions): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function incrementalUnassign(array $topic_partitions) {}
 
     /**
      * @param null|Message|TopicPartition[] $message_or_offsets
@@ -141,22 +144,28 @@ class KafkaConsumer
     public function newTopic($topic_name, $topic_conf = null) {}
 
     #[TentativeType]
-    public function getControllerId(int $timeout_ms): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function getControllerId(int $timeout_ms) {}
 
     #[TentativeType]
-    public function pausePartitions(array $topic_partitions): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public function pausePartitions(array $topic_partitions) {}
 
     #[TentativeType]
-    public function resumePartitions(array $topic_partitions): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public function resumePartitions(array $topic_partitions) {}
 
     #[TentativeType]
-    public function poll(int $timeout_ms): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function poll(int $timeout_ms) {}
 
     #[TentativeType]
-    public function oauthbearerSetToken(string $token_value, int $lifetime_ms, string $principal_name, array $extensions = []): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function oauthbearerSetToken(string $token_value, int $lifetime_ms, string $principal_name, array $extensions = []) {}
 
     #[TentativeType]
-    public function oauthbearerSetTokenFailure(string $error): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function oauthbearerSetTokenFailure(string $error) {}
 
     /**
      * @return void

--- a/rdkafka/RdKafka/TopicPartition.php
+++ b/rdkafka/RdKafka/TopicPartition.php
@@ -3,6 +3,7 @@
 namespace RdKafka;
 
 use JetBrains\PhpStorm\Internal\TentativeType;
+use JetBrains\PhpStorm\Internal\LanguageLevelTypeAware;
 
 class TopicPartition
 {
@@ -50,5 +51,6 @@ class TopicPartition
     public function setTopic($topic_name) {}
 
     #[TentativeType]
-    public function getErr(): ?int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int|null'], default: '')]
+    public function getErr() {}
 }

--- a/session/SessionHandler.php
+++ b/session/SessionHandler.php
@@ -24,7 +24,8 @@ interface SessionHandlerInterface
      * @since 5.4
      */
     #[TentativeType]
-    public function close(): bool;
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function close();
 
     /**
      * Destroy a session
@@ -37,7 +38,8 @@ interface SessionHandlerInterface
      * @since 5.4
      */
     #[TentativeType]
-    public function destroy(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $id): bool;
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function destroy(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $id);
 
     /**
      * Cleanup old sessions
@@ -54,7 +56,7 @@ interface SessionHandlerInterface
      */
     #[LanguageLevelTypeAware(['7.1' => 'int|false'], default: 'bool')]
     #[TentativeType]
-    public function gc(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $max_lifetime): int|false;
+    public function gc(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $max_lifetime);
 
     /**
      * Initialize session
@@ -68,10 +70,11 @@ interface SessionHandlerInterface
      * @since 5.4
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function open(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $path,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name
-    ): bool;
+    );
 
     /**
      * Read session data
@@ -85,7 +88,8 @@ interface SessionHandlerInterface
      * @since 5.4
      */
     #[TentativeType]
-    public function read(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $id): string|false;
+    #[LanguageLevelTypeAware(['8.1' => 'string|false'], default: '')]
+    public function read(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $id);
 
     /**
      * Write session data
@@ -105,10 +109,11 @@ interface SessionHandlerInterface
      * @since 5.4
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function write(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $id,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $data
-    ): bool;
+    );
 }
 
 /**
@@ -126,7 +131,8 @@ interface SessionIdInterface
      * </p>
      */
     #[TentativeType]
-    public function create_sid(): string;
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function create_sid();
 }
 
 /**
@@ -147,7 +153,8 @@ interface SessionUpdateTimestampHandlerInterface
      * </p>
      */
     #[TentativeType]
-    public function validateId(string $id): bool;
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function validateId(string $id);
 
     /**
      * Update timestamp of a session
@@ -163,7 +170,8 @@ interface SessionUpdateTimestampHandlerInterface
      * @return bool
      */
     #[TentativeType]
-    public function updateTimestamp(string $id, string $data): bool;
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function updateTimestamp(string $id, string $data);
 }
 
 /**
@@ -193,7 +201,8 @@ class SessionHandler implements SessionHandlerInterface, SessionIdInterface
      * @since 5.4
      */
     #[TentativeType]
-    public function close(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function close() {}
 
     /**
      * Return a new session ID
@@ -202,7 +211,8 @@ class SessionHandler implements SessionHandlerInterface, SessionIdInterface
      * @since 5.5
      */
     #[TentativeType]
-    public function create_sid(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function create_sid() {}
 
     /**
      * Destroy a session
@@ -215,7 +225,8 @@ class SessionHandler implements SessionHandlerInterface, SessionIdInterface
      * @since 5.4
      */
     #[TentativeType]
-    public function destroy(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $id): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function destroy(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $id) {}
 
     /**
      * Cleanup old sessions
@@ -231,7 +242,8 @@ class SessionHandler implements SessionHandlerInterface, SessionIdInterface
      * @since 5.4
      */
     #[TentativeType]
-    public function gc(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $max_lifetime): int|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'int|false'], default: '')]
+    public function gc(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $max_lifetime) {}
 
     /**
      * Initialize session
@@ -245,10 +257,11 @@ class SessionHandler implements SessionHandlerInterface, SessionIdInterface
      * @since 5.4
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function open(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $path,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name
-    ): bool {}
+    ) {}
 
     /**
      * Read session data
@@ -262,7 +275,8 @@ class SessionHandler implements SessionHandlerInterface, SessionIdInterface
      * @since 5.4
      */
     #[TentativeType]
-    public function read(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $id): string|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'string|false'], default: '')]
+    public function read(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $id) {}
 
     /**
      * Write session data
@@ -282,8 +296,9 @@ class SessionHandler implements SessionHandlerInterface, SessionIdInterface
      * @since 5.4
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function write(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $id,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $data
-    ): bool {}
+    ) {}
 }

--- a/soap/soap.php
+++ b/soap/soap.php
@@ -279,10 +279,11 @@ class SoapClient
      */
     #[Deprecated]
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
     public function __call(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name,
         array $args
-    ): mixed {}
+    ) {}
 
     /**
      * Calls a SOAP function
@@ -331,13 +332,14 @@ class SoapClient
      * @since 5.0
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
     public function __soapCall(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name,
         array $args,
         #[LanguageLevelTypeAware(['8.0' => 'array|null'], default: '')] $options = null,
         $inputHeaders = null,
         &$outputHeaders = null
-    ): mixed {}
+    ) {}
 
     /**
      * Returns last SOAP request
@@ -346,7 +348,8 @@ class SoapClient
      * @since 5.0
      */
     #[TentativeType]
-    public function __getLastRequest(): ?string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string|null'], default: '')]
+    public function __getLastRequest() {}
 
     /**
      * Returns last SOAP response
@@ -355,7 +358,8 @@ class SoapClient
      * @since 5.0
      */
     #[TentativeType]
-    public function __getLastResponse(): ?string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string|null'], default: '')]
+    public function __getLastResponse() {}
 
     /**
      * Returns the SOAP headers from the last request
@@ -364,7 +368,8 @@ class SoapClient
      * @since 5.0
      */
     #[TentativeType]
-    public function __getLastRequestHeaders(): ?string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string|null'], default: '')]
+    public function __getLastRequestHeaders() {}
 
     /**
      * Returns the SOAP headers from the last response
@@ -373,7 +378,8 @@ class SoapClient
      * @since 5.0
      */
     #[TentativeType]
-    public function __getLastResponseHeaders(): ?string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string|null'], default: '')]
+    public function __getLastResponseHeaders() {}
 
     /**
      * Returns list of available SOAP functions
@@ -383,7 +389,8 @@ class SoapClient
      * @since 5.0
      */
     #[TentativeType]
-    public function __getFunctions(): ?array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array|null'], default: '')]
+    public function __getFunctions() {}
 
     /**
      * Returns a list of SOAP types
@@ -392,7 +399,8 @@ class SoapClient
      * @since 5.0
      */
     #[TentativeType]
-    public function __getTypes(): ?array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array|null'], default: '')]
+    public function __getTypes() {}
 
     /**
      * Returns a list of all cookies
@@ -401,7 +409,8 @@ class SoapClient
      * @since 5.4
      */
     #[TentativeType]
-    public function __getCookies(): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public function __getCookies() {}
 
     /**
      * Performs a SOAP request
@@ -426,6 +435,7 @@ class SoapClient
      * @since 5.0
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'string|null'], default: '')]
     public function __doRequest(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $request,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $location,
@@ -433,7 +443,7 @@ class SoapClient
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $version,
         #[LanguageLevelTypeAware(["8.0" => 'bool'], default: 'int')] $oneWay = false,
         #[PhpStormStubsElementAvailable(from: '8.5')] ?string $uriParserClass = null
-    ): ?string {}
+    ) {}
 
     /**
      * The __setCookie purpose
@@ -448,10 +458,11 @@ class SoapClient
      * @since 5.0
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
     public function __setCookie(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name,
         #[LanguageLevelTypeAware(["8.0" => "string|null"], default: "string")] $value = null
-    ): void {}
+    ) {}
 
     /**
      * Sets the location of the Web service to use
@@ -463,7 +474,8 @@ class SoapClient
      * @since 5.0
      */
     #[TentativeType]
-    public function __setLocation(#[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $location = null): ?string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string|null'], default: '')]
+    public function __setLocation(#[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $location = null) {}
 
     /**
      * Sets SOAP headers for subsequent calls
@@ -477,10 +489,11 @@ class SoapClient
      * @since 5.0
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function __setSoapHeaders(
         #[PhpStormStubsElementAvailable(from: '5.3', to: '5.6')] $headers = null,
         #[PhpStormStubsElementAvailable(from: '7.0')] $headers = null
-    ): bool {}
+    ) {}
 }
 
 /**
@@ -699,7 +712,8 @@ class SoapServer
      * @since 5.1
      */
     #[TentativeType]
-    public function setPersistence(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $mode): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function setPersistence(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $mode) {}
 
     /**
      * Sets the class which handles SOAP requests
@@ -712,10 +726,11 @@ class SoapServer
      * @since 5.0
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
     public function setClass(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $class,
         #[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] ...$args
-    ): void {}
+    ) {}
 
     /**
      * Sets the object which will be used to handle SOAP requests
@@ -726,7 +741,8 @@ class SoapServer
      * @return void No value is returned.
      */
     #[TentativeType]
-    public function setObject(#[LanguageLevelTypeAware(['8.0' => 'object'], default: '')] $object): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function setObject(#[LanguageLevelTypeAware(['8.0' => 'object'], default: '')] $object) {}
 
     /**
      * Adds one or more functions to handle SOAP requests
@@ -751,7 +767,8 @@ class SoapServer
      * @since 5.0
      */
     #[TentativeType]
-    public function addFunction($functions): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function addFunction($functions) {}
 
     /**
      * Returns list of defined functions
@@ -760,7 +777,8 @@ class SoapServer
      * @since 5.0
      */
     #[TentativeType]
-    public function getFunctions(): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public function getFunctions() {}
 
     /**
      * Handles a SOAP request
@@ -773,7 +791,8 @@ class SoapServer
      * @since 5.0
      */
     #[TentativeType]
-    public function handle(#[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $request = null): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function handle(#[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $request = null) {}
 
     /**
      * Issue SoapServer fault indicating an error
@@ -798,6 +817,7 @@ class SoapServer
      * @since 5.0
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
     public function fault(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $code,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $string,
@@ -805,7 +825,7 @@ class SoapServer
         #[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $details = null,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name = '',
         #[PhpStormStubsElementAvailable('8.5')] string $lang = ''
-    ): void {}
+    ) {}
 
     /**
      * Add a SOAP header to the response
@@ -817,7 +837,8 @@ class SoapServer
      * @since 5.0
      */
     #[TentativeType]
-    public function addSoapHeader(SoapHeader $header): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function addSoapHeader(SoapHeader $header) {}
 
     /**
      * @since 8.4

--- a/sqlite3/sqlite3.php
+++ b/sqlite3/sqlite3.php
@@ -149,13 +149,14 @@ class SQLite3
      * @return void No value is returned.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
     public function open(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $filename,
         #[PhpStormStubsElementAvailable(from: '5.3', to: '5.6')] $flags = 6,
         #[PhpStormStubsElementAvailable(from: '5.3', to: '5.6')] $encryptionKey = '',
         #[PhpStormStubsElementAvailable(from: '7.0')] #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $flags = SQLITE3_OPEN_READWRITE|SQLITE3_OPEN_CREATE,
         #[PhpStormStubsElementAvailable(from: '7.0')] #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $encryptionKey = ''
-    ): void {}
+    ) {}
 
     /**
      * Closes the database connection
@@ -163,7 +164,8 @@ class SQLite3
      * @return bool <b>TRUE</b> on success, <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function close(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function close() {}
 
     /**
      * Executes a result-less query against a given database
@@ -175,7 +177,8 @@ class SQLite3
      * @return bool <b>TRUE</b> if the query succeeded, <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function exec(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $query): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function exec(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $query) {}
 
     /**
      * Returns the SQLite3 library version as a string constant and as a number
@@ -185,7 +188,8 @@ class SQLite3
      */
     #[ArrayShape(["versionString" => "string", "versionNumber" => "int"])]
     #[TentativeType]
-    public static function version(): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public static function version() {}
 
     /**
      * Returns the row ID of the most recent INSERT into the database
@@ -193,7 +197,8 @@ class SQLite3
      * @return int the row ID of the most recent INSERT into the database
      */
     #[TentativeType]
-    public function lastInsertRowID(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function lastInsertRowID() {}
 
     /**
      * Returns the numeric result code of the most recent failed SQLite request
@@ -202,7 +207,8 @@ class SQLite3
      * recent failed SQLite request.
      */
     #[TentativeType]
-    public function lastErrorCode(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function lastErrorCode() {}
 
     /**
      * Returns English text describing the most recent failed SQLite request
@@ -210,7 +216,8 @@ class SQLite3
      * @return string an English string describing the most recent failed SQLite request.
      */
     #[TentativeType]
-    public function lastErrorMsg(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function lastErrorMsg() {}
 
     /**
      * Sets the busy connection handler
@@ -223,7 +230,8 @@ class SQLite3
      * @since 5.3
      */
     #[TentativeType]
-    public function busyTimeout(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $milliseconds): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function busyTimeout(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $milliseconds) {}
 
     /**
      * Attempts to load an SQLite extension library
@@ -235,7 +243,8 @@ class SQLite3
      * @return bool <b>TRUE</b> if the extension is successfully loaded, <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function loadExtension(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function loadExtension(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name) {}
 
     /**
      * Returns the number of database rows that were changed (or inserted or
@@ -246,7 +255,8 @@ class SQLite3
      * statement.
      */
     #[TentativeType]
-    public function changes(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function changes() {}
 
     /**
      * Returns a string that has been properly escaped
@@ -258,7 +268,8 @@ class SQLite3
      * statement.
      */
     #[TentativeType]
-    public static function escapeString(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $string): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public static function escapeString(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $string) {}
 
     /**
      * Prepares an SQL statement for execution
@@ -269,7 +280,8 @@ class SQLite3
      * @return SQLite3Stmt|false an <b>SQLite3Stmt</b> object on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function prepare(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $query): SQLite3Stmt|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'SQLite3Stmt|false'], default: '')]
+    public function prepare(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $query) {}
 
     /**
      * Executes an SQL query
@@ -280,7 +292,8 @@ class SQLite3
      * @return SQLite3Result|false an <b>SQLite3Result</b> object, or <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function query(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $query): SQLite3Result|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'SQLite3Result|false'], default: '')]
+    public function query(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $query) {}
 
     /**
      * Executes a query and returns a single result
@@ -306,10 +319,11 @@ class SQLite3
      * Invalid or failing queries will return <b>FALSE</b>.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'mixed'], default: '')]
     public function querySingle(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $query,
         #[LanguageLevelTypeAware(['8.0' => 'bool'], default: '')] $entireRow = false
-    ): mixed {}
+    ) {}
 
     /**
      * Registers a PHP function for use as an SQL scalar function
@@ -333,12 +347,13 @@ class SQLite3
      * @return bool <b>TRUE</b> upon successful creation of the function, <b>FALSE</b> on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function createFunction(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name,
         #[LanguageLevelTypeAware(['8.0' => 'callable'], default: '')] $callback,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $argCount = -1,
         #[PhpStormStubsElementAvailable(from: '7.1')] int $flags = 0
-    ): bool {}
+    ) {}
 
     /**
      * Registers a PHP function for use as an SQL aggregate function
@@ -363,12 +378,13 @@ class SQLite3
      * failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function createAggregate(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name,
         #[LanguageLevelTypeAware(['8.0' => 'callable'], default: '')] $stepCallback,
         #[LanguageLevelTypeAware(['8.0' => 'callable'], default: '')] $finalCallback,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $argCount = -1
-    ): bool {}
+    ) {}
 
     /**
      * Registers a PHP function for use as an SQL collating function
@@ -387,7 +403,8 @@ class SQLite3
      * @since 5.3
      */
     #[TentativeType]
-    public function createCollation(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name, callable $callback): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function createCollation(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name, callable $callback) {}
 
     /**
      * Opens a stream resource to read a BLOB
@@ -415,10 +432,11 @@ class SQLite3
      * @return bool Returns the old value; true if exceptions were enabled, false otherwise.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function enableExceptions(
         #[PhpStormStubsElementAvailable(from: '5.3', to: '5.6')] $enable = false,
         #[PhpStormStubsElementAvailable(from: '7.0')] #[LanguageLevelTypeAware(['8.0' => 'bool'], default: '')] $enable = false
-    ): bool {}
+    ) {}
 
     /**
      * Instantiates an SQLite3 object and opens an SQLite 3 database
@@ -452,17 +470,19 @@ class SQLite3
      * @since 7.4
      */
     #[TentativeType]
-    public function lastExtendedErrorCode(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function lastExtendedErrorCode() {}
 
     /**
      * @param bool $enable
      * @since 7.4
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function enableExtendedResultCodes(
         #[PhpStormStubsElementAvailable(from: '7.4', to: '7.4')] bool $enable = true,
         #[PhpStormStubsElementAvailable(from: '8.0')] bool $enable = true
-    ): bool {}
+    ) {}
 
     /**
      * @param SQLite3 $destination
@@ -472,7 +492,8 @@ class SQLite3
      * @since 7.4
      */
     #[TentativeType]
-    public function backup(SQLite3 $destination, string $sourceDatabase = 'main', string $destinationDatabase = 'main'): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function backup(SQLite3 $destination, string $sourceDatabase = 'main', string $destinationDatabase = 'main') {}
 
     /**
      * @param null|callable $callback
@@ -480,7 +501,8 @@ class SQLite3
      * @since 8.0
      */
     #[TentativeType]
-    public function setAuthorizer(?callable $callback): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function setAuthorizer(?callable $callback) {}
 }
 
 /**
@@ -504,7 +526,8 @@ class SQLite3Stmt
      * @return int the number of parameters within the prepared statement.
      */
     #[TentativeType]
-    public function paramCount(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function paramCount() {}
 
     /**
      * Closes the prepared statement
@@ -521,7 +544,8 @@ class SQLite3Stmt
      * @return bool <b>TRUE</b> if the statement is successfully reset, <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function reset(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function reset() {}
 
     /**
      * Clears all current bound parameters
@@ -530,7 +554,8 @@ class SQLite3Stmt
      * failure.
      */
     #[TentativeType]
-    public function clear(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function clear() {}
 
     /**
      * Executes a prepared statement and returns a result set object
@@ -539,7 +564,8 @@ class SQLite3Stmt
      * statement, <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function execute(): SQLite3Result|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'SQLite3Result|false'], default: '')]
+    public function execute() {}
 
     /**
      * Binds a parameter to a statement variable
@@ -563,11 +589,12 @@ class SQLite3Stmt
      * on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function bindParam(
         #[LanguageLevelTypeAware(['8.0' => 'string|int'], default: '')] $param,
         #[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] &$var,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $type = SQLITE3_TEXT
-    ): bool {}
+    ) {}
 
     /**
      * Binds the value of a parameter to a statement variable
@@ -591,14 +618,16 @@ class SQLite3Stmt
      * on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function bindValue(
         #[LanguageLevelTypeAware(['8.0' => 'string|int'], default: '')] $param,
         #[LanguageLevelTypeAware(['8.0' => 'mixed'], default: '')] $value,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $type = SQLITE3_TEXT
-    ): bool {}
+    ) {}
 
     #[TentativeType]
-    public function readOnly(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function readOnly() {}
 
     /**
      * @param SQLite3 $sqlite3
@@ -617,7 +646,8 @@ class SQLite3Stmt
      * @since 7.4
      */
     #[TentativeType]
-    public function getSQL(bool $expand = false): string|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'string|false'], default: '')]
+    public function getSQL(bool $expand = false) {}
 
     /**
      * @since 8.5
@@ -647,7 +677,8 @@ class SQLite3Result
      * @return int the number of columns in the result set.
      */
     #[TentativeType]
-    public function numColumns(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function numColumns() {}
 
     /**
      * Returns the name of the nth column
@@ -659,7 +690,8 @@ class SQLite3Result
      * <i>column_number</i>.
      */
     #[TentativeType]
-    public function columnName(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $column): string|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'string|false'], default: '')]
+    public function columnName(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $column) {}
 
     /**
      * Returns the type of the nth column
@@ -674,7 +706,8 @@ class SQLite3Result
      * <b>SQLITE3_NULL</b>).
      */
     #[TentativeType]
-    public function columnType(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $column): int|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'int|false'], default: '')]
+    public function columnType(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $column) {}
 
     /**
      * Fetches a result row as an associative or numerically indexed array or both
@@ -692,7 +725,8 @@ class SQLite3Result
      * both. Alternately will return <b>FALSE</b> if there are no more rows.
      */
     #[TentativeType]
-    public function fetchArray(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $mode = SQLITE3_BOTH): array|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'array|false'], default: '')]
+    public function fetchArray(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $mode = SQLITE3_BOTH) {}
 
     /**
      * Resets the result set back to the first row
@@ -701,7 +735,8 @@ class SQLite3Result
      * back to the first row, <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function reset(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function reset() {}
 
     /**
      * Closes the result set

--- a/standard/standard_0.php
+++ b/standard/standard_0.php
@@ -71,25 +71,28 @@ class php_user_filter
      * </tr>
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
     public function filter(
         $in,
         $out,
         &$consumed,
         #[LanguageLevelTypeAware(['8.0' => 'bool'], default: '')] $closing
-    ): int {}
+    ) {}
 
     /**
      * @link https://php.net/manual/en/php-user-filter.oncreate.php
      * @return bool
      */
     #[TentativeType]
-    public function onCreate(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function onCreate() {}
 
     /**
      * @link https://php.net/manual/en/php-user-filter.onclose.php
      */
     #[TentativeType]
-    public function onClose(): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function onClose() {}
 }
 /**
  * @since 8.4

--- a/tests/cache/StubsInterfaces.json
+++ b/tests/cache/StubsInterfaces.json
@@ -69,14 +69,16 @@
                         "removedVersion": null
                     }
                 ],
-                "returnType": "bool",
+                "returnType": "",
                 "hasTentativeReturnType": true,
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
                 "returnTypeFromPhpDoc": "bool",
-                "languageLevelTypes": null,
-                "defaultType": null
+                "languageLevelTypes": {
+                    "8.1": "bool"
+                },
+                "defaultType": ""
             },
             {
                 "name": "offsetGet",
@@ -105,14 +107,16 @@
                         "removedVersion": null
                     }
                 ],
-                "returnType": "mixed",
+                "returnType": "",
                 "hasTentativeReturnType": true,
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
                 "returnTypeFromPhpDoc": "TValue",
-                "languageLevelTypes": null,
-                "defaultType": null
+                "languageLevelTypes": {
+                    "8.1": "mixed"
+                },
+                "defaultType": ""
             },
             {
                 "name": "offsetSet",
@@ -159,14 +163,16 @@
                         "removedVersion": null
                     }
                 ],
-                "returnType": "void",
+                "returnType": "",
                 "hasTentativeReturnType": true,
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
                 "returnTypeFromPhpDoc": "void",
-                "languageLevelTypes": null,
-                "defaultType": null
+                "languageLevelTypes": {
+                    "8.1": "void"
+                },
+                "defaultType": ""
             },
             {
                 "name": "offsetUnset",
@@ -195,14 +201,16 @@
                         "removedVersion": null
                     }
                 ],
-                "returnType": "void",
+                "returnType": "",
                 "hasTentativeReturnType": true,
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
                 "returnTypeFromPhpDoc": "void",
-                "languageLevelTypes": null,
-                "defaultType": null
+                "languageLevelTypes": {
+                    "8.1": "void"
+                },
+                "defaultType": ""
             }
         ],
         "constants": [],
@@ -5068,14 +5076,16 @@
                 "isDeprecated": false,
                 "accessModifier": "public",
                 "parameters": [],
-                "returnType": "int",
+                "returnType": "",
                 "hasTentativeReturnType": true,
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
                 "returnTypeFromPhpDoc": "int<0, max>",
-                "languageLevelTypes": null,
-                "defaultType": null
+                "languageLevelTypes": {
+                    "8.1": "int"
+                },
+                "defaultType": ""
             }
         ],
         "constants": [],
@@ -5443,14 +5453,16 @@
                         "removedVersion": null
                     }
                 ],
-                "returnType": "\\DateInterval",
+                "returnType": "",
                 "hasTentativeReturnType": true,
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
                 "returnTypeFromPhpDoc": "\\DateInterval",
-                "languageLevelTypes": null,
-                "defaultType": null
+                "languageLevelTypes": {
+                    "8.1": "DateInterval"
+                },
+                "defaultType": ""
             },
             {
                 "name": "format",
@@ -5479,14 +5491,16 @@
                         "removedVersion": null
                     }
                 ],
-                "returnType": "string",
+                "returnType": "",
                 "hasTentativeReturnType": true,
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
                 "returnTypeFromPhpDoc": "string",
-                "languageLevelTypes": null,
-                "defaultType": null
+                "languageLevelTypes": {
+                    "8.1": "string"
+                },
+                "defaultType": ""
             },
             {
                 "name": "getOffset",
@@ -5496,7 +5510,7 @@
                 "isDeprecated": false,
                 "accessModifier": "public",
                 "parameters": [],
-                "returnType": "int",
+                "returnType": "",
                 "hasTentativeReturnType": true,
                 "phpDoc": null,
                 "sinceVersion": null,
@@ -5534,14 +5548,16 @@
                 "isDeprecated": false,
                 "accessModifier": "public",
                 "parameters": [],
-                "returnType": "\\DateTimeZone|false",
+                "returnType": "",
                 "hasTentativeReturnType": true,
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
                 "returnTypeFromPhpDoc": "\\DateTimeZone|false",
-                "languageLevelTypes": null,
-                "defaultType": null
+                "languageLevelTypes": {
+                    "8.1": "DateTimeZone|false"
+                },
+                "defaultType": ""
             },
             {
                 "name": "__wakeup",
@@ -5551,14 +5567,16 @@
                 "isDeprecated": true,
                 "accessModifier": "public",
                 "parameters": [],
-                "returnType": "void",
+                "returnType": "",
                 "hasTentativeReturnType": true,
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
                 "returnTypeFromPhpDoc": "void",
-                "languageLevelTypes": null,
-                "defaultType": null
+                "languageLevelTypes": {
+                    "8.1": "void"
+                },
+                "defaultType": ""
             },
             {
                 "name": "__serialize",
@@ -9287,14 +9305,16 @@
                 "isDeprecated": false,
                 "accessModifier": "public",
                 "parameters": [],
-                "returnType": "mixed",
+                "returnType": "",
                 "hasTentativeReturnType": true,
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
                 "returnTypeFromPhpDoc": "TValue",
-                "languageLevelTypes": null,
-                "defaultType": null
+                "languageLevelTypes": {
+                    "8.1": "mixed"
+                },
+                "defaultType": ""
             },
             {
                 "name": "next",
@@ -9304,14 +9324,16 @@
                 "isDeprecated": false,
                 "accessModifier": "public",
                 "parameters": [],
-                "returnType": "void",
+                "returnType": "",
                 "hasTentativeReturnType": true,
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
                 "returnTypeFromPhpDoc": "void",
-                "languageLevelTypes": null,
-                "defaultType": null
+                "languageLevelTypes": {
+                    "8.1": "void"
+                },
+                "defaultType": ""
             },
             {
                 "name": "key",
@@ -9321,14 +9343,16 @@
                 "isDeprecated": false,
                 "accessModifier": "public",
                 "parameters": [],
-                "returnType": "mixed",
+                "returnType": "",
                 "hasTentativeReturnType": true,
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
                 "returnTypeFromPhpDoc": "TKey|null",
-                "languageLevelTypes": null,
-                "defaultType": null
+                "languageLevelTypes": {
+                    "8.1": "mixed"
+                },
+                "defaultType": ""
             },
             {
                 "name": "valid",
@@ -9338,14 +9362,16 @@
                 "isDeprecated": false,
                 "accessModifier": "public",
                 "parameters": [],
-                "returnType": "bool",
+                "returnType": "",
                 "hasTentativeReturnType": true,
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
                 "returnTypeFromPhpDoc": "bool",
-                "languageLevelTypes": null,
-                "defaultType": null
+                "languageLevelTypes": {
+                    "8.1": "bool"
+                },
+                "defaultType": ""
             },
             {
                 "name": "rewind",
@@ -9355,14 +9381,16 @@
                 "isDeprecated": false,
                 "accessModifier": "public",
                 "parameters": [],
-                "returnType": "void",
+                "returnType": "",
                 "hasTentativeReturnType": true,
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
                 "returnTypeFromPhpDoc": "void",
-                "languageLevelTypes": null,
-                "defaultType": null
+                "languageLevelTypes": {
+                    "8.1": "void"
+                },
+                "defaultType": ""
             }
         ],
         "constants": [],
@@ -9389,14 +9417,16 @@
                 "isDeprecated": false,
                 "accessModifier": "public",
                 "parameters": [],
-                "returnType": "\\Traversable",
+                "returnType": "",
                 "hasTentativeReturnType": true,
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
                 "returnTypeFromPhpDoc": "\\Traversable<TKey,TValue>|TValue[]",
-                "languageLevelTypes": null,
-                "defaultType": null
+                "languageLevelTypes": {
+                    "8.1": "Traversable"
+                },
+                "defaultType": ""
             }
         ],
         "constants": [],
@@ -9423,14 +9453,16 @@
                 "isDeprecated": false,
                 "accessModifier": "public",
                 "parameters": [],
-                "returnType": "mixed",
+                "returnType": "",
                 "hasTentativeReturnType": true,
                 "phpDoc": null,
                 "sinceVersion": "5.4",
                 "removedVersion": null,
                 "returnTypeFromPhpDoc": "mixed",
-                "languageLevelTypes": null,
-                "defaultType": null
+                "languageLevelTypes": {
+                    "8.1": "mixed"
+                },
+                "defaultType": ""
             }
         ],
         "constants": [],
@@ -10971,14 +11003,16 @@
                 "isDeprecated": false,
                 "accessModifier": "public",
                 "parameters": [],
-                "returnType": "\\Iterator|null",
+                "returnType": "",
                 "hasTentativeReturnType": true,
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
                 "returnTypeFromPhpDoc": "\\Iterator|null",
-                "languageLevelTypes": null,
-                "defaultType": null
+                "languageLevelTypes": {
+                    "8.1": "Iterator|null"
+                },
+                "defaultType": ""
             }
         ],
         "constants": [],
@@ -11053,14 +11087,16 @@
                 "isDeprecated": false,
                 "accessModifier": "public",
                 "parameters": [],
-                "returnType": "bool",
+                "returnType": "",
                 "hasTentativeReturnType": true,
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
                 "returnTypeFromPhpDoc": "bool",
-                "languageLevelTypes": null,
-                "defaultType": null
+                "languageLevelTypes": {
+                    "8.1": "bool"
+                },
+                "defaultType": ""
             },
             {
                 "name": "getChildren",
@@ -11070,14 +11106,16 @@
                 "isDeprecated": false,
                 "accessModifier": "public",
                 "parameters": [],
-                "returnType": "\\RecursiveIterator|null",
+                "returnType": "",
                 "hasTentativeReturnType": true,
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
                 "returnTypeFromPhpDoc": "\\RecursiveIterator|null",
-                "languageLevelTypes": null,
-                "defaultType": null
+                "languageLevelTypes": {
+                    "8.1": "RecursiveIterator|null"
+                },
+                "defaultType": ""
             }
         ],
         "constants": [],
@@ -11176,14 +11214,16 @@
                         "removedVersion": null
                     }
                 ],
-                "returnType": "void",
+                "returnType": "",
                 "hasTentativeReturnType": true,
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
                 "returnTypeFromPhpDoc": "void",
-                "languageLevelTypes": null,
-                "defaultType": null
+                "languageLevelTypes": {
+                    "8.1": "void"
+                },
+                "defaultType": ""
             }
         ],
         "constants": [],
@@ -11278,14 +11318,16 @@
                 "isDeprecated": false,
                 "accessModifier": "public",
                 "parameters": [],
-                "returnType": "bool",
+                "returnType": "",
                 "hasTentativeReturnType": true,
                 "phpDoc": null,
                 "sinceVersion": "5.4",
                 "removedVersion": null,
                 "returnTypeFromPhpDoc": "bool",
-                "languageLevelTypes": null,
-                "defaultType": null
+                "languageLevelTypes": {
+                    "8.1": "bool"
+                },
+                "defaultType": ""
             },
             {
                 "name": "destroy",
@@ -11314,14 +11356,16 @@
                         "removedVersion": null
                     }
                 ],
-                "returnType": "bool",
+                "returnType": "",
                 "hasTentativeReturnType": true,
                 "phpDoc": null,
                 "sinceVersion": "5.4",
                 "removedVersion": null,
                 "returnTypeFromPhpDoc": "bool",
-                "languageLevelTypes": null,
-                "defaultType": null
+                "languageLevelTypes": {
+                    "8.1": "bool"
+                },
+                "defaultType": ""
             },
             {
                 "name": "gc",
@@ -11350,7 +11394,7 @@
                         "removedVersion": null
                     }
                 ],
-                "returnType": "int|false",
+                "returnType": "",
                 "hasTentativeReturnType": true,
                 "phpDoc": null,
                 "sinceVersion": "5.4",
@@ -11406,14 +11450,16 @@
                         "removedVersion": null
                     }
                 ],
-                "returnType": "bool",
+                "returnType": "",
                 "hasTentativeReturnType": true,
                 "phpDoc": null,
                 "sinceVersion": "5.4",
                 "removedVersion": null,
                 "returnTypeFromPhpDoc": "bool",
-                "languageLevelTypes": null,
-                "defaultType": null
+                "languageLevelTypes": {
+                    "8.1": "bool"
+                },
+                "defaultType": ""
             },
             {
                 "name": "read",
@@ -11442,14 +11488,16 @@
                         "removedVersion": null
                     }
                 ],
-                "returnType": "string|false",
+                "returnType": "",
                 "hasTentativeReturnType": true,
                 "phpDoc": null,
                 "sinceVersion": "5.4",
                 "removedVersion": null,
                 "returnTypeFromPhpDoc": "string|false",
-                "languageLevelTypes": null,
-                "defaultType": null
+                "languageLevelTypes": {
+                    "8.1": "string|false"
+                },
+                "defaultType": ""
             },
             {
                 "name": "write",
@@ -11496,14 +11544,16 @@
                         "removedVersion": null
                     }
                 ],
-                "returnType": "bool",
+                "returnType": "",
                 "hasTentativeReturnType": true,
                 "phpDoc": null,
                 "sinceVersion": "5.4",
                 "removedVersion": null,
                 "returnTypeFromPhpDoc": "bool",
-                "languageLevelTypes": null,
-                "defaultType": null
+                "languageLevelTypes": {
+                    "8.1": "bool"
+                },
+                "defaultType": ""
             }
         ],
         "constants": [],
@@ -11528,14 +11578,16 @@
                 "isDeprecated": false,
                 "accessModifier": "public",
                 "parameters": [],
-                "returnType": "string",
+                "returnType": "",
                 "hasTentativeReturnType": true,
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
                 "returnTypeFromPhpDoc": "string",
-                "languageLevelTypes": null,
-                "defaultType": null
+                "languageLevelTypes": {
+                    "8.1": "string"
+                },
+                "defaultType": ""
             }
         ],
         "constants": [],
@@ -11577,14 +11629,16 @@
                         "removedVersion": null
                     }
                 ],
-                "returnType": "bool",
+                "returnType": "",
                 "hasTentativeReturnType": true,
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
                 "returnTypeFromPhpDoc": "bool",
-                "languageLevelTypes": null,
-                "defaultType": null
+                "languageLevelTypes": {
+                    "8.1": "bool"
+                },
+                "defaultType": ""
             },
             {
                 "name": "updateTimestamp",
@@ -11627,14 +11681,16 @@
                         "removedVersion": null
                     }
                 ],
-                "returnType": "bool",
+                "returnType": "",
                 "hasTentativeReturnType": true,
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
                 "returnTypeFromPhpDoc": "bool",
-                "languageLevelTypes": null,
-                "defaultType": null
+                "languageLevelTypes": {
+                    "8.1": "bool"
+                },
+                "defaultType": ""
             }
         ],
         "constants": [],
@@ -11676,14 +11732,16 @@
                         "removedVersion": null
                     }
                 ],
-                "returnType": "void",
+                "returnType": "",
                 "hasTentativeReturnType": true,
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
                 "returnTypeFromPhpDoc": "void",
-                "languageLevelTypes": null,
-                "defaultType": null
+                "languageLevelTypes": {
+                    "8.1": "void"
+                },
+                "defaultType": ""
             }
         ],
         "constants": [],
@@ -11725,14 +11783,16 @@
                         "removedVersion": null
                     }
                 ],
-                "returnType": "void",
+                "returnType": "",
                 "hasTentativeReturnType": true,
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
                 "returnTypeFromPhpDoc": "void",
-                "languageLevelTypes": null,
-                "defaultType": null
+                "languageLevelTypes": {
+                    "8.1": "void"
+                },
+                "defaultType": ""
             },
             {
                 "name": "detach",
@@ -11759,14 +11819,16 @@
                         "removedVersion": null
                     }
                 ],
-                "returnType": "void",
+                "returnType": "",
                 "hasTentativeReturnType": true,
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
                 "returnTypeFromPhpDoc": "void",
-                "languageLevelTypes": null,
-                "defaultType": null
+                "languageLevelTypes": {
+                    "8.1": "void"
+                },
+                "defaultType": ""
             },
             {
                 "name": "notify",
@@ -11776,14 +11838,16 @@
                 "isDeprecated": false,
                 "accessModifier": "public",
                 "parameters": [],
-                "returnType": "void",
+                "returnType": "",
                 "hasTentativeReturnType": true,
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
                 "returnTypeFromPhpDoc": "void",
-                "languageLevelTypes": null,
-                "defaultType": null
+                "languageLevelTypes": {
+                    "8.1": "void"
+                },
+                "defaultType": ""
             }
         ],
         "constants": [],

--- a/tidy/tidy.php
+++ b/tidy/tidy.php
@@ -29,7 +29,8 @@ class tidy
      * The return type depends on the type of the specified one.
      */
     #[TentativeType]
-    public function getOpt(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $option): string|int|bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'string|int|bool'], default: '')]
+    public function getOpt(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $option) {}
 
     /**
      * (PHP 5, PECL tidy &gt;= 0.5.2)<br/>
@@ -38,7 +39,8 @@ class tidy
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function cleanRepair(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function cleanRepair() {}
 
     /**
      * (PHP 5, PECL tidy &gt;= 0.5.2)<br/>
@@ -74,12 +76,13 @@ class tidy
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function parseFile(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $filename,
         #[LanguageLevelTypeAware(['8.0' => 'array|string|null'], default: '')] $config = null,
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $encoding = null,
         #[LanguageLevelTypeAware(['8.0' => 'bool'], default: '')] $useIncludePath = false
-    ): bool {}
+    ) {}
 
     /**
      * (PHP 5, PECL tidy &gt;= 0.5.2)<br/>
@@ -109,11 +112,12 @@ class tidy
      * @return bool a new <b>tidy</b> instance.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function parseString(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $string,
         #[LanguageLevelTypeAware(['8.0' => 'array|string|null'], default: '')] $config = null,
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $encoding = null
-    ): bool {}
+    ) {}
 
     /**
      * (PHP 5, PECL tidy &gt;= 0.7.0)<br/>
@@ -144,11 +148,12 @@ class tidy
      * @return string|false the repaired string.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'string|false'], default: '')]
     public static function repairString(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $string,
         #[LanguageLevelTypeAware(['8.0' => 'array|string|null'], default: '')] $config = null,
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $encoding = null
-    ): string|false {}
+    ) {}
 
     /**
      * (PHP 5, PECL tidy &gt;= 0.7.0)<br/>
@@ -182,12 +187,13 @@ class tidy
      * @return string|false the repaired contents as a string.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'string|false'], default: '')]
     public static function repairFile(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $filename,
         #[LanguageLevelTypeAware(['8.0' => 'array|string|null'], default: '')] $config = null,
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $encoding = null,
         #[LanguageLevelTypeAware(['8.0' => 'bool'], default: '')] $useIncludePath = false
-    ): string|false {}
+    ) {}
 
     /**
      * (PHP 5, PECL tidy &gt;= 0.5.2)<br/>
@@ -196,7 +202,8 @@ class tidy
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function diagnose(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function diagnose() {}
 
     /**
      * (PHP 5, PECL tidy &gt;= 0.5.2)<br/>
@@ -205,7 +212,8 @@ class tidy
      * @return string a string with the release date of the Tidy library.
      */
     #[TentativeType]
-    public function getRelease(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function getRelease() {}
 
     /**
      * (PHP 5, PECL tidy &gt;= 0.7.0)<br/>
@@ -217,7 +225,8 @@ class tidy
      * For an explanation about each option, visit http://tidy.sourceforge.net/docs/quickref.html.
      */
     #[TentativeType]
-    public function getConfig(): array {}
+    #[LanguageLevelTypeAware(['8.1' => 'array'], default: '')]
+    public function getConfig() {}
 
     /**
      * (PHP 5, PECL tidy &gt;= 0.5.2)<br/>
@@ -227,7 +236,8 @@ class tidy
      * errors, or 2 for errors.
      */
     #[TentativeType]
-    public function getStatus(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function getStatus() {}
 
     /**
      * (PHP 5, PECL tidy &gt;= 0.5.2)<br/>
@@ -240,7 +250,8 @@ class tidy
      * return 0.
      */
     #[TentativeType]
-    public function getHtmlVer(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function getHtmlVer() {}
 
     /**
      * Returns the documentation for the given option name
@@ -252,7 +263,8 @@ class tidy
      * <b>FALSE</b> otherwise.
      */
     #[TentativeType]
-    public function getOptDoc(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $option): string|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'string|false'], default: '')]
+    public function getOptDoc(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $option) {}
 
     /**
      * (PHP 5, PECL tidy &gt;= 0.5.2)<br/>
@@ -266,7 +278,8 @@ class tidy
      * return <b>FALSE</b>.
      */
     #[TentativeType]
-    public function isXhtml(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isXhtml() {}
 
     /**
      * (PHP 5, PECL tidy &gt;= 0.5.2)<br/>
@@ -281,7 +294,8 @@ class tidy
      * return <b>FALSE</b>.
      */
     #[TentativeType]
-    public function isXml(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isXml() {}
 
     /**
      * (PHP 5, PECL tidy 0.5.2-1.0.0)<br/>
@@ -290,7 +304,8 @@ class tidy
      * @return tidyNode|null the <b>tidyNode</b> object.
      */
     #[TentativeType]
-    public function root(): ?tidyNode {}
+    #[LanguageLevelTypeAware(['8.1' => 'tidyNode|null'], default: '')]
+    public function root() {}
 
     /**
      * (PHP 5, PECL tidy 0.5.2-1.0.0)<br/>
@@ -299,7 +314,8 @@ class tidy
      * @return tidyNode|null the <b>tidyNode</b> object.
      */
     #[TentativeType]
-    public function head(): ?tidyNode {}
+    #[LanguageLevelTypeAware(['8.1' => 'tidyNode|null'], default: '')]
+    public function head() {}
 
     /**
      * (PHP 5, PECL tidy 0.5.2-1.0.0)<br/>
@@ -308,7 +324,8 @@ class tidy
      * @return tidyNode|null the <b>tidyNode</b> object.
      */
     #[TentativeType]
-    public function html(): ?tidyNode {}
+    #[LanguageLevelTypeAware(['8.1' => 'tidyNode|null'], default: '')]
+    public function html() {}
 
     /**
      * (PHP 5, PECL tidy 0.5.2-1.0)<br/>
@@ -318,7 +335,8 @@ class tidy
      * &lt;body&gt; tag of the tidy parse tree.
      */
     #[TentativeType]
-    public function body(): ?tidyNode {}
+    #[LanguageLevelTypeAware(['8.1' => 'tidyNode|null'], default: '')]
+    public function body() {}
 
     /**
      * (PHP 5, PECL tidy &gt;= 0.5.2)<br/>

--- a/xmlreader/xmlreader.php
+++ b/xmlreader/xmlreader.php
@@ -271,7 +271,8 @@ class XMLReader
      * @since 5.1.2
      */
     #[TentativeType]
-    public function getAttribute(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name): ?string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string|null'], default: '')]
+    public function getAttribute(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name) {}
 
     /**
      * Get the value of an attribute by index
@@ -284,7 +285,8 @@ class XMLReader
      * @since 5.1.2
      */
     #[TentativeType]
-    public function getAttributeNo(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $index): ?string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string|null'], default: '')]
+    public function getAttributeNo(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $index) {}
 
     /**
      * Get the value of an attribute by localname and URI
@@ -301,10 +303,11 @@ class XMLReader
      * @since 5.1.2
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'string|null'], default: '')]
     public function getAttributeNs(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $namespace
-    ): ?string {}
+    ) {}
 
     /**
      * Indicates if specified property has been set
@@ -317,7 +320,8 @@ class XMLReader
      * @since 5.1.2
      */
     #[TentativeType]
-    public function getParserProperty(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $property): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function getParserProperty(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $property) {}
 
     /**
      * Indicates if the parsed document is valid
@@ -326,7 +330,8 @@ class XMLReader
      * @since 5.1.2
      */
     #[TentativeType]
-    public function isValid(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function isValid() {}
 
     /**
      * Lookup namespace for a prefix
@@ -338,7 +343,8 @@ class XMLReader
      * @since 5.1.2
      */
     #[TentativeType]
-    public function lookupNamespace(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $prefix): ?string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string|null'], default: '')]
+    public function lookupNamespace(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $prefix) {}
 
     /**
      * Move cursor to an attribute by index
@@ -350,7 +356,8 @@ class XMLReader
      * @since 5.1.2
      */
     #[TentativeType]
-    public function moveToAttributeNo(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $index): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function moveToAttributeNo(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $index) {}
 
     /**
      * Move cursor to a named attribute
@@ -362,7 +369,8 @@ class XMLReader
      * @since 5.1.2
      */
     #[TentativeType]
-    public function moveToAttribute(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function moveToAttribute(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name) {}
 
     /**
      * Move cursor to a named attribute
@@ -377,10 +385,11 @@ class XMLReader
      * @since 5.1.2
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function moveToAttributeNs(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $namespace
-    ): bool {}
+    ) {}
 
     /**
      * Position cursor on the parent Element of current Attribute
@@ -390,7 +399,8 @@ class XMLReader
      * @since 5.1.2
      */
     #[TentativeType]
-    public function moveToElement(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function moveToElement() {}
 
     /**
      * Position cursor on the first Attribute
@@ -399,7 +409,8 @@ class XMLReader
      * @since 5.1.2
      */
     #[TentativeType]
-    public function moveToFirstAttribute(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function moveToFirstAttribute() {}
 
     /**
      * Position cursor on the next Attribute
@@ -408,7 +419,8 @@ class XMLReader
      * @since 5.1.2
      */
     #[TentativeType]
-    public function moveToNextAttribute(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function moveToNextAttribute() {}
 
     /**
      * Set the URI containing the XML to parse
@@ -440,7 +452,8 @@ class XMLReader
      * @since 5.1.2
      */
     #[TentativeType]
-    public function read(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function read() {}
 
     /**
      * Move cursor to next node skipping all subtrees
@@ -452,7 +465,8 @@ class XMLReader
      * @since 5.1.2
      */
     #[TentativeType]
-    public function next(#[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $name = null): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function next(#[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $name = null) {}
 
     /**
      * Retrieve XML from current node
@@ -460,7 +474,8 @@ class XMLReader
      * @return string the contents of the current node as a string. Empty string on failure.
      */
     #[TentativeType]
-    public function readInnerXml(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function readInnerXml() {}
 
     /**
      * Retrieve XML from current node, including it self
@@ -468,7 +483,8 @@ class XMLReader
      * @return string the contents of current node, including itself, as a string. Empty string on failure.
      */
     #[TentativeType]
-    public function readOuterXml(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function readOuterXml() {}
 
     /**
      * Reads the contents of the current node as a string
@@ -477,7 +493,8 @@ class XMLReader
      * failure.
      */
     #[TentativeType]
-    public function readString(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function readString() {}
 
     /**
      * Validate document against XSD
@@ -488,7 +505,8 @@ class XMLReader
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function setSchema(#[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $filename): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function setSchema(#[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $filename) {}
 
     /**
      * Set parser options
@@ -505,10 +523,11 @@ class XMLReader
      * @since 5.1.2
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function setParserProperty(
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $property,
         #[LanguageLevelTypeAware(['8.0' => 'bool'], default: '')] $value
-    ): bool {}
+    ) {}
 
     /**
      * Set the filename or URI for a RelaxNG Schema
@@ -519,7 +538,8 @@ class XMLReader
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function setRelaxNGSchema(#[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $filename): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function setRelaxNGSchema(#[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $filename) {}
 
     /**
      * Set the data containing a RelaxNG Schema
@@ -531,7 +551,8 @@ class XMLReader
      * @since 5.1.2
      */
     #[TentativeType]
-    public function setRelaxNGSchemaSource(#[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $source): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function setRelaxNGSchemaSource(#[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $source) {}
 
     /**
      * Set the data containing the XML to parse
@@ -564,9 +585,10 @@ class XMLReader
      * @since 5.1.2
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'DOMNode|false'], default: '')]
     public function expand(
         #[PhpStormStubsElementAvailable(from: '7.0')] #[LanguageLevelTypeAware(['8.0' => 'DOMNode|null'], default: '')] $baseNode = null
-    ): DOMNode|false {}
+    ) {}
 
     /**
      * @since 8.4

--- a/xmlwriter/xmlwriter.php
+++ b/xmlwriter/xmlwriter.php
@@ -22,7 +22,8 @@ class XMLWriter
      * xmlwriter functions on success, <b>FALSE</b> on error.
      */
     #[TentativeType]
-    public function openUri(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $uri): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function openUri(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $uri) {}
 
     /**
      * (PHP 5 &gt;= 5.1.2, PECL xmlwriter &gt;= 0.1.0)<br/>
@@ -35,7 +36,8 @@ class XMLWriter
      * xmlwriter functions on success, <b>FALSE</b> on error.
      */
     #[TentativeType]
-    public function openMemory(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function openMemory() {}
 
     /**
      * (PHP 5 &gt;= 5.1.2, PECL xmlwriter &gt;= 0.1.0)<br/>
@@ -47,7 +49,8 @@ class XMLWriter
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function setIndent(#[LanguageLevelTypeAware(['8.0' => 'bool'], default: '')] $enable): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function setIndent(#[LanguageLevelTypeAware(['8.0' => 'bool'], default: '')] $enable) {}
 
     /**
      * (PHP 5 &gt;= 5.1.2, PECL xmlwriter &gt;= 0.1.0)<br/>
@@ -59,7 +62,8 @@ class XMLWriter
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function setIndentString(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $indentation): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function setIndentString(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $indentation) {}
 
     /**
      * (PHP 5 &gt;= 5.1.2, PECL xmlwriter &gt;= 1.0.0)<br/>
@@ -68,7 +72,8 @@ class XMLWriter
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function startComment(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function startComment() {}
 
     /**
      * (PHP 5 &gt;= 5.1.2, PECL xmlwriter &gt;= 1.0.0)<br/>
@@ -77,7 +82,8 @@ class XMLWriter
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function endComment(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function endComment() {}
 
     /**
      * (PHP 5 &gt;= 5.1.2, PECL xmlwriter &gt;= 0.1.0)<br/>
@@ -89,7 +95,8 @@ class XMLWriter
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function startAttribute(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function startAttribute(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name) {}
 
     /**
      * (PHP 5 &gt;= 5.1.2, PECL xmlwriter &gt;= 0.1.0)<br/>
@@ -98,7 +105,8 @@ class XMLWriter
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function endAttribute(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function endAttribute() {}
 
     /**
      * (PHP 5 &gt;= 5.1.2, PECL xmlwriter &gt;= 0.1.0)<br/>
@@ -113,10 +121,11 @@ class XMLWriter
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function writeAttribute(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $value
-    ): bool {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.1.2, PECL xmlwriter &gt;= 0.1.0)<br/>
@@ -134,11 +143,12 @@ class XMLWriter
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function startAttributeNs(
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $prefix,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name,
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $namespace
-    ): bool {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.1.2, PECL xmlwriter &gt;= 0.1.0)<br/>
@@ -159,12 +169,13 @@ class XMLWriter
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function writeAttributeNs(
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $prefix,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name,
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $namespace,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $value
-    ): bool {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.1.2, PECL xmlwriter &gt;= 0.1.0)<br/>
@@ -176,7 +187,8 @@ class XMLWriter
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function startElement(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function startElement(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name) {}
 
     /**
      * (PHP 5 &gt;= 5.1.2, PECL xmlwriter &gt;= 0.1.0)<br/>
@@ -185,7 +197,8 @@ class XMLWriter
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function endElement(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function endElement() {}
 
     /**
      * (PHP 5 &gt;= 5.2.0, PECL xmlwriter &gt;= 2.0.4)<br/>
@@ -194,7 +207,8 @@ class XMLWriter
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function fullEndElement(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function fullEndElement() {}
 
     /**
      * (PHP 5 &gt;= 5.1.2, PECL xmlwriter &gt;= 0.1.0)<br/>
@@ -212,11 +226,12 @@ class XMLWriter
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function startElementNs(
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $prefix,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name,
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $namespace
-    ): bool {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.1.2, PECL xmlwriter &gt;= 0.1.0)<br/>
@@ -231,10 +246,11 @@ class XMLWriter
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function writeElement(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name,
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $content = null
-    ): bool {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.1.2, PECL xmlwriter &gt;= 0.1.0)<br/>
@@ -255,12 +271,13 @@ class XMLWriter
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function writeElementNs(
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $prefix,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name,
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $namespace,
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $content = null
-    ): bool {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.1.2, PECL xmlwriter &gt;= 0.1.0)<br/>
@@ -272,7 +289,8 @@ class XMLWriter
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function startPi(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $target): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function startPi(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $target) {}
 
     /**
      * (PHP 5 &gt;= 5.1.2, PECL xmlwriter &gt;= 0.1.0)<br/>
@@ -281,7 +299,8 @@ class XMLWriter
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function endPi(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function endPi() {}
 
     /**
      * (PHP 5 &gt;= 5.1.2, PECL xmlwriter &gt;= 0.1.0)<br/>
@@ -296,10 +315,11 @@ class XMLWriter
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function writePi(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $target,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $content
-    ): bool {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.1.2, PECL xmlwriter &gt;= 0.1.0)<br/>
@@ -308,7 +328,8 @@ class XMLWriter
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function startCdata(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function startCdata() {}
 
     /**
      * (PHP 5 &gt;= 5.1.2, PECL xmlwriter &gt;= 0.1.0)<br/>
@@ -317,7 +338,8 @@ class XMLWriter
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function endCdata(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function endCdata() {}
 
     /**
      * (PHP 5 &gt;= 5.1.2, PECL xmlwriter &gt;= 0.1.0)<br/>
@@ -329,7 +351,8 @@ class XMLWriter
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function writeCdata(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $content): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function writeCdata(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $content) {}
 
     /**
      * (PHP 5 &gt;= 5.1.2, PECL xmlwriter &gt;= 0.1.0)<br/>
@@ -341,7 +364,8 @@ class XMLWriter
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function text(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $content): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function text(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $content) {}
 
     /**
      * (PHP 5 &gt;= 5.2.0, PECL xmlwriter &gt;= 2.0.4)<br/>
@@ -353,7 +377,8 @@ class XMLWriter
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function writeRaw(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $content): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function writeRaw(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $content) {}
 
     /**
      * (PHP 5 &gt;= 5.1.2, PECL xmlwriter &gt;= 0.1.0)<br/>
@@ -371,11 +396,12 @@ class XMLWriter
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function startDocument(
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $version = '1.0',
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $encoding = null,
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $standalone = null
-    ): bool {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.1.2, PECL xmlwriter &gt;= 0.1.0)<br/>
@@ -384,7 +410,8 @@ class XMLWriter
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function endDocument(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function endDocument() {}
 
     /**
      * (PHP 5 &gt;= 5.1.2, PECL xmlwriter &gt;= 0.1.0)<br/>
@@ -396,7 +423,8 @@ class XMLWriter
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function writeComment(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $content): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function writeComment(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $content) {}
 
     /**
      * (PHP 5 &gt;= 5.1.2, PECL xmlwriter &gt;= 0.1.0)<br/>
@@ -414,11 +442,12 @@ class XMLWriter
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function startDtd(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $qualifiedName,
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $publicId = null,
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $systemId = null
-    ): bool {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.1.2, PECL xmlwriter &gt;= 0.1.0)<br/>
@@ -427,7 +456,8 @@ class XMLWriter
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function endDtd(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function endDtd() {}
 
     /**
      * (PHP 5 &gt;= 5.1.2, PECL xmlwriter &gt;= 0.1.0)<br/>
@@ -448,12 +478,13 @@ class XMLWriter
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function writeDtd(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name,
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $publicId = null,
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $systemId = null,
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $content = null
-    ): bool {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.1.2, PECL xmlwriter &gt;= 0.1.0)<br/>
@@ -465,7 +496,8 @@ class XMLWriter
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function startDtdElement(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $qualifiedName): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function startDtdElement(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $qualifiedName) {}
 
     /**
      * (PHP 5 &gt;= 5.1.2, PECL xmlwriter &gt;= 0.1.0)<br/>
@@ -474,7 +506,8 @@ class XMLWriter
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function endDtdElement(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function endDtdElement() {}
 
     /**
      * (PHP 5 &gt;= 5.1.2, PECL xmlwriter &gt;= 0.1.0)<br/>
@@ -489,10 +522,11 @@ class XMLWriter
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function writeDtdElement(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $content
-    ): bool {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.1.2, PECL xmlwriter &gt;= 0.1.0)<br/>
@@ -504,7 +538,8 @@ class XMLWriter
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function startDtdAttlist(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function startDtdAttlist(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name) {}
 
     /**
      * (PHP 5 &gt;= 5.1.2, PECL xmlwriter &gt;= 0.1.0)<br/>
@@ -513,7 +548,8 @@ class XMLWriter
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function endDtdAttlist(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function endDtdAttlist() {}
 
     /**
      * (PHP 5 &gt;= 5.1.2, PECL xmlwriter &gt;= 0.1.0)<br/>
@@ -528,10 +564,11 @@ class XMLWriter
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function writeDtdAttlist(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $content
-    ): bool {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.1.2, PECL xmlwriter &gt;= 0.1.0)<br/>
@@ -544,10 +581,11 @@ class XMLWriter
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function startDtdEntity(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name,
         #[LanguageLevelTypeAware(['8.0' => 'bool'], default: '')] $isParam
-    ): bool {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.1.2, PECL xmlwriter &gt;= 0.1.0)<br/>
@@ -556,7 +594,8 @@ class XMLWriter
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function endDtdEntity(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function endDtdEntity() {}
 
     /**
      * (PHP 5 &gt;= 5.1.2, PECL xmlwriter &gt;= 0.1.0)<br/>
@@ -575,6 +614,7 @@ class XMLWriter
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function writeDtdEntity(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $content,
@@ -582,7 +622,7 @@ class XMLWriter
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $publicId = null,
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $systemId = null,
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $notationData = null
-    ): bool {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.1.2, PECL xmlwriter &gt;= 0.1.0)<br/>
@@ -594,7 +634,8 @@ class XMLWriter
      * @return string the current buffer as a string.
      */
     #[TentativeType]
-    public function outputMemory(#[LanguageLevelTypeAware(['8.0' => 'bool'], default: '')] $flush = true): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function outputMemory(#[LanguageLevelTypeAware(['8.0' => 'bool'], default: '')] $flush = true) {}
 
     /**
      * (PHP 5 &gt;= 5.1.2, PECL xmlwriter &gt;= 1.0.0)<br/>
@@ -608,7 +649,8 @@ class XMLWriter
      * written bytes.
      */
     #[TentativeType]
-    public function flush(#[LanguageLevelTypeAware(['8.0' => 'bool'], default: '')] $empty = true): string|int {}
+    #[LanguageLevelTypeAware(['8.1' => 'string|int'], default: '')]
+    public function flush(#[LanguageLevelTypeAware(['8.0' => 'bool'], default: '')] $empty = true) {}
 
     /**
      * @since 8.4

--- a/xsl/xsl.php
+++ b/xsl/xsl.php
@@ -19,7 +19,8 @@ class XSLTProcessor
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function importStylesheet(#[LanguageLevelTypeAware(['8.0' => 'object'], default: '')] $stylesheet): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function importStylesheet(#[LanguageLevelTypeAware(['8.0' => 'object'], default: '')] $stylesheet) {}
 
     /**
      * Transform to a DOMDocument
@@ -29,10 +30,11 @@ class XSLTProcessor
      * @return DOMDocument|false The resulting <b>DOMDocument</b> or <b>FALSE</b> on error.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'object|false'], default: '')]
     public function transformToDoc(
         #[LanguageLevelTypeAware(['8.0' => 'object'], default: '')] $document,
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $returnClass = null
-    ): object|false {}
+    ) {}
 
     /**
      * Transform to URI
@@ -46,10 +48,11 @@ class XSLTProcessor
      * @return int the number of bytes written or <b>FALSE</b> if an error occurred.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
     public function transformToUri(
         #[LanguageLevelTypeAware(['8.0' => 'object'], default: '')] $document,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $uri
-    ): int {}
+    ) {}
 
     /**
      * Transform to XML
@@ -60,7 +63,8 @@ class XSLTProcessor
      * @return string|false|null The result of the transformation as a string or <b>FALSE</b> on error.
      */
     #[TentativeType]
-    public function transformToXml(#[LanguageLevelTypeAware(['8.0' => 'object'], default: '')] $document): string|false|null {}
+    #[LanguageLevelTypeAware(['8.1' => 'string|false|null'], default: '')]
+    public function transformToXml(#[LanguageLevelTypeAware(['8.0' => 'object'], default: '')] $document) {}
 
     /**
      * Set value for a parameter
@@ -77,11 +81,12 @@ class XSLTProcessor
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function setParameter(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $namespace,
         #[LanguageLevelTypeAware(['8.0' => 'array|string'], default: '')] $name,
         #[LanguageLevelTypeAware(['8.0' => 'string|null'], default: '')] $value = null
-    ): bool {}
+    ) {}
 
     /**
      * Get value of a parameter
@@ -95,10 +100,11 @@ class XSLTProcessor
      * @return string|false The value of the parameter (as a string), or <b>FALSE</b> if it's not set.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'string|false'], default: '')]
     public function getParameter(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $namespace,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name
-    ): string|false {}
+    ) {}
 
     /**
      * Remove parameter
@@ -112,10 +118,11 @@ class XSLTProcessor
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function removeParameter(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $namespace,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name
-    ): bool {}
+    ) {}
 
     /**
      * Determine if PHP has EXSLT support
@@ -124,7 +131,8 @@ class XSLTProcessor
      * @since 5.0
      */
     #[TentativeType]
-    public function hasExsltSupport(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function hasExsltSupport() {}
 
     /**
      * Enables the ability to use PHP functions as XSLT functions
@@ -141,7 +149,8 @@ class XSLTProcessor
      * @since 5.0
      */
     #[TentativeType]
-    public function registerPHPFunctions(#[LanguageLevelTypeAware(['8.0' => 'array|string|null'], default: '')] $functions = null): void {}
+    #[LanguageLevelTypeAware(['8.1' => 'void'], default: '')]
+    public function registerPHPFunctions(#[LanguageLevelTypeAware(['8.0' => 'array|string|null'], default: '')] $functions = null) {}
 
     /**
      * Sets profiling output file
@@ -161,7 +170,8 @@ class XSLTProcessor
      * @since 5.4
      */
     #[TentativeType]
-    public function setSecurityPrefs(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $preferences): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function setSecurityPrefs(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $preferences) {}
 
     /**
      * Get security preferences
@@ -170,7 +180,8 @@ class XSLTProcessor
      * @since 5.4
      */
     #[TentativeType]
-    public function getSecurityPrefs(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function getSecurityPrefs() {}
 }
 define('XSL_CLONE_AUTO', 0);
 define('XSL_CLONE_NEVER', -1);

--- a/zip/zip.php
+++ b/zip/zip.php
@@ -701,10 +701,11 @@ class ZipArchive implements Countable
      * </p>
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'int|bool'], default: '')]
     public function open(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $filename,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $flags = null
-    ): int|bool {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.2.0, PECL zip &gt;= 1.1.0)<br/>
@@ -713,7 +714,8 @@ class ZipArchive implements Countable
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function close(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function close() {}
 
     /**
      * (PHP 7 &gt;= 7.2.0, PECL zip &gt;= 1.15.0)<br/>
@@ -723,7 +725,8 @@ class ZipArchive implements Countable
      * @since 7.2
      */
     #[TentativeType]
-    public function count(): int {}
+    #[LanguageLevelTypeAware(['8.1' => 'int'], default: '')]
+    public function count() {}
 
     /**
      * Returns the status error message, system and/or zip messages
@@ -732,7 +735,8 @@ class ZipArchive implements Countable
      * @since 5.2
      */
     #[TentativeType]
-    public function getStatusString(): string {}
+    #[LanguageLevelTypeAware(['8.1' => 'string'], default: '')]
+    public function getStatusString() {}
 
     /**
      * (PHP 5 &gt;= 5.2.0, PECL zip &gt;= 1.8.0)<br/>
@@ -745,10 +749,11 @@ class ZipArchive implements Countable
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function addEmptyDir(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $dirname,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $flags = 0
-    ): bool {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.2.0, PECL zip &gt;= 1.1.0)<br/>
@@ -765,11 +770,12 @@ class ZipArchive implements Countable
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function addFromString(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $content,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $flags = 8192
-    ): bool {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.2.0, PECL zip &gt;= 1.1.0)<br/>
@@ -791,13 +797,14 @@ class ZipArchive implements Countable
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function addFile(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $filepath,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $entryname = null,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $start = 0,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $length = 0,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $flags = 8192
-    ): bool {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL zip &gt;= 1.9.0)<br/>
@@ -824,11 +831,12 @@ class ZipArchive implements Countable
      * @return array|false
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'array|false'], default: '')]
     public function addGlob(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $pattern,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $flags = 0,
         array $options = []
-    ): array|false {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.3.0, PECL zip &gt;= 1.9.0)<br/>
@@ -846,11 +854,12 @@ class ZipArchive implements Countable
      * @return array|false
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'array|false'], default: '')]
     public function addPattern(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $pattern,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $path = '.',
         array $options = []
-    ): array|false {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.2.0, PECL zip &gt;= 1.5.0)<br/>
@@ -865,10 +874,11 @@ class ZipArchive implements Countable
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function renameIndex(
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $index,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $new_name
-    ): bool {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.2.0, PECL zip &gt;= 1.5.0)<br/>
@@ -883,10 +893,11 @@ class ZipArchive implements Countable
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function renameName(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $new_name
-    ): bool {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.2.0, PECL zip &gt;= 1.4.0)<br/>
@@ -898,7 +909,8 @@ class ZipArchive implements Countable
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function setArchiveComment(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $comment): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function setArchiveComment(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $comment) {}
 
     /**
      * (PHP 5 &gt;= 5.2.0, PECL zip &gt;= 1.1.0)<br/>
@@ -911,7 +923,8 @@ class ZipArchive implements Countable
      * @return string|false the Zip archive comment or <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function getArchiveComment(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $flags = null): string|false {}
+    #[LanguageLevelTypeAware(['8.1' => 'string|false'], default: '')]
+    public function getArchiveComment(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $flags = null) {}
 
     /**
      * (PHP 5 &gt;= 5.2.0, PECL zip &gt;= 1.4.0)<br/>
@@ -926,10 +939,11 @@ class ZipArchive implements Countable
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function setCommentIndex(
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $index,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $comment
-    ): bool {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.2.0, PECL zip &gt;= 1.4.0)<br/>
@@ -944,10 +958,11 @@ class ZipArchive implements Countable
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function setCommentName(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name,
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $comment
-    ): bool {}
+    ) {}
 
     /**
      * Set the compression method of an entry defined by its index
@@ -959,7 +974,8 @@ class ZipArchive implements Countable
      * @since 7.0
      */
     #[TentativeType]
-    public function setCompressionIndex(int $index, int $method, int $compflags = 0): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function setCompressionIndex(int $index, int $method, int $compflags = 0) {}
 
     /**
      * Set the compression method of an entry defined by its name
@@ -971,7 +987,8 @@ class ZipArchive implements Countable
      * @since 7.0
      */
     #[TentativeType]
-    public function setCompressionName(string $name, int $method, int $compflags = 0): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function setCompressionName(string $name, int $method, int $compflags = 0) {}
 
     /**
      * Set the encryption method of an entry defined by its index
@@ -983,7 +1000,8 @@ class ZipArchive implements Countable
      * @since 7.2
      */
     #[TentativeType]
-    public function setEncryptionIndex(int $index, int $method, ?string $password = null): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function setEncryptionIndex(int $index, int $method, ?string $password = null) {}
 
     /**
      * Set the encryption method of an entry defined by its name
@@ -995,7 +1013,8 @@ class ZipArchive implements Countable
      * @since 7.2
      */
     #[TentativeType]
-    public function setEncryptionName(string $name, int $method, ?string $password = null): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function setEncryptionName(string $name, int $method, ?string $password = null) {}
 
     /**
      * (PHP 5 &gt;= 5.6.0, PECL zip &gt;= 1.12.0)<br/>
@@ -1003,7 +1022,8 @@ class ZipArchive implements Countable
      * @return bool
      */
     #[TentativeType]
-    public function setPassword(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $password): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function setPassword(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $password) {}
 
     /**
      * (PHP 5 &gt;= 5.2.0, PECL zip &gt;= 1.4.0)<br/>
@@ -1019,10 +1039,11 @@ class ZipArchive implements Countable
      * @return string|false the comment on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'string|false'], default: '')]
     public function getCommentIndex(
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $index,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $flags = null
-    ): string|false {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.2.0, PECL zip &gt;= 1.4.0)<br/>
@@ -1038,10 +1059,11 @@ class ZipArchive implements Countable
      * @return string|false the comment on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'string|false'], default: '')]
     public function getCommentName(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $flags = null
-    ): string|false {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.2.0, PECL zip &gt;= 1.5.0)<br/>
@@ -1053,7 +1075,8 @@ class ZipArchive implements Countable
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function deleteIndex(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $index): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function deleteIndex(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $index) {}
 
     /**
      * (PHP 5 &gt;= 5.2.0, PECL zip &gt;= 1.5.0)<br/>
@@ -1065,7 +1088,8 @@ class ZipArchive implements Countable
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function deleteName(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function deleteName(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name) {}
 
     /**
      * (PHP 5 &gt;= 5.2.0, PECL zip &gt;= 1.5.0)<br/>
@@ -1084,10 +1108,11 @@ class ZipArchive implements Countable
      * @return array{name: string, index: int, crc: int, size: int, mtime: int, comp_size: int, comp_method: int, encryption_method: int}|false an array containing the entry details or <b>FALSE</b> on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'array|false'], default: '')]
     public function statName(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $flags = null
-    ): array|false {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.2.0, PECL zip &gt;= 1.1.0)<br/>
@@ -1104,10 +1129,11 @@ class ZipArchive implements Countable
      * @return array{name: string, index: int, crc: int, size: int, mtime: int, comp_size: int, comp_method: int, encryption_method: int}|false an array containing the entry details or <b>FALSE</b> on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'array|false'], default: '')]
     public function statIndex(
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $index,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $flags = null
-    ): array|false {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.2.0, PECL zip &gt;= 1.5.0)<br/>
@@ -1124,10 +1150,11 @@ class ZipArchive implements Countable
      * @return int|false the index of the entry on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'int|false'], default: '')]
     public function locateName(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $flags = null
-    ): int|false {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.2.0, PECL zip &gt;= 1.5.0)<br/>
@@ -1143,10 +1170,11 @@ class ZipArchive implements Countable
      * @return string|false the name on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'string|false'], default: '')]
     public function getNameIndex(
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $index,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $flags = null
-    ): string|false {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.2.0, PECL zip &gt;= 1.1.0)<br/>
@@ -1155,7 +1183,8 @@ class ZipArchive implements Countable
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function unchangeArchive(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function unchangeArchive() {}
 
     /**
      * (PHP 5 &gt;= 5.2.0, PECL zip &gt;= 1.1.0)<br/>
@@ -1164,7 +1193,8 @@ class ZipArchive implements Countable
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function unchangeAll(): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function unchangeAll() {}
 
     /**
      * (PHP 5 &gt;= 5.2.0, PECL zip &gt;= 1.1.0)<br/>
@@ -1176,7 +1206,8 @@ class ZipArchive implements Countable
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function unchangeIndex(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $index): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function unchangeIndex(#[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $index) {}
 
     /**
      * (PHP 5 &gt;= 5.2.0, PECL zip &gt;= 1.5.0)<br/>
@@ -1188,7 +1219,8 @@ class ZipArchive implements Countable
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
-    public function unchangeName(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function unchangeName(#[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name) {}
 
     /**
      * (PHP 5 &gt;= 5.2.0, PECL zip &gt;= 1.1.0)<br/>
@@ -1204,10 +1236,11 @@ class ZipArchive implements Countable
      * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function extractTo(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $pathto,
         #[LanguageLevelTypeAware(['8.0' => 'array|string|null'], default: '')] $files = null
-    ): bool {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.2.0, PECL zip &gt;= 1.1.0)<br/>
@@ -1228,11 +1261,12 @@ class ZipArchive implements Countable
      * @return string|false the contents of the entry on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'string|false'], default: '')]
     public function getFromName(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $len = 0,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $flags = null
-    ): string|false {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.2.0, PECL zip &gt;= 1.3.0)<br/>
@@ -1255,11 +1289,12 @@ class ZipArchive implements Countable
      * @return string|false the contents of the entry on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'string|false'], default: '')]
     public function getFromIndex(
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $index,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $len = 0,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $flags = null
-    ): string|false {}
+    ) {}
 
     /**
      * (PHP 5 &gt;= 5.2.0, PECL zip &gt;= 1.1.0)<br/>
@@ -1299,12 +1334,13 @@ class ZipArchive implements Countable
      * @return bool Returns <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function setExternalAttributesName(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $opsys,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $attr,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $flags = null
-    ): bool {}
+    ) {}
 
     /**
      * Retrieve the external attributes of an entry defined by its name
@@ -1316,12 +1352,13 @@ class ZipArchive implements Countable
      * @return bool Returns <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function getExternalAttributesName(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] &$opsys,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] &$attr,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $flags = null
-    ): bool {}
+    ) {}
 
     /**
      * Set the external attributes of an entry defined by its index
@@ -1333,12 +1370,13 @@ class ZipArchive implements Countable
      * @return bool Returns <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function setExternalAttributesIndex(
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $index,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $opsys,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $attr,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $flags = null
-    ): bool {}
+    ) {}
 
     /**
      * Retrieve the external attributes of an entry defined by its index
@@ -1350,12 +1388,13 @@ class ZipArchive implements Countable
      * @return bool Returns <b>TRUE</b> on success or <b>FALSE</b> on failure.
      */
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function getExternalAttributesIndex(
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $index,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] &$opsys,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] &$attr,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $flags = null
-    ): bool {}
+    ) {}
 
     #[LanguageLevelTypeAware(['8.0' => 'bool'], default: '')]
     public static function isEncryptionMethodSupported(
@@ -1370,36 +1409,41 @@ class ZipArchive implements Countable
     ) {}
 
     #[TentativeType]
-    public function registerCancelCallback(#[LanguageLevelTypeAware(['8.0' => 'callable'], default: '')] $callback): bool {}
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
+    public function registerCancelCallback(#[LanguageLevelTypeAware(['8.0' => 'callable'], default: '')] $callback) {}
 
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function registerProgressCallback(
         #[LanguageLevelTypeAware(['8.0' => 'float'], default: '')] $rate,
         #[LanguageLevelTypeAware(['8.0' => 'callable'], default: '')] $callback
-    ): bool {}
+    ) {}
 
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function setMtimeName(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $name,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $timestamp,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $flags = null
-    ): bool {}
+    ) {}
 
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function setMtimeIndex(
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $index,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $timestamp,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $flags = null
-    ): bool {}
+    ) {}
 
     #[TentativeType]
+    #[LanguageLevelTypeAware(['8.1' => 'bool'], default: '')]
     public function replaceFile(
         #[LanguageLevelTypeAware(['8.0' => 'string'], default: '')] $filepath,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $index,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $start = null,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $length = null,
         #[LanguageLevelTypeAware(['8.0' => 'int'], default: '')] $flags = null
-    ): bool {}
+    ) {}
 
     #[LanguageLevelTypeAware(['8.0' => 'void'], default: '')]
     public function clearError() {}


### PR DESCRIPTION
Signature return types are not version aware unlike LanguageLevelTypeAware so TentativeType should affect only return types declared in attribute