### PR TITLE
Remove incorrect #[Deprecated] from ReflectionType::__toString() (undeprecated since PHP 8.0)

### DIFF
--- a/Reflection/ReflectionType.php
+++ b/Reflection/ReflectionType.php
@@ -44,7 +44,6 @@ abstract class ReflectionType implements Stringable
      * @since 7.0
      * @see ReflectionNamedType::getName()
      */
-    #[Deprecated(since: '7.4')]
     public function __toString(): string {}
 
     /**


### PR DESCRIPTION
`Reflection/ReflectionType.php` marks `__toString()` with `#[Deprecated(since: '7.4')]`. `ReflectionType::__toString()` was deprecated in 7.4 but un-deprecated in PHP 8.0, and casting a `ReflectionType` to string is the correct way to stringify compound (union/intersection) types, which have no `getName()`.

This was already fixed once and later regressed:

- `cf7e447dd` (2024-06-17, WI-77852, "ReflectionType::__toString is undeprecated since 8.0") removed the attribute.
- `e2028cae5` (2026-05-31, "update deprecation and removal annotations") re-added `#[Deprecated(since: '7.4')]`, reverting it. It is still present on `master`.

This PR restores `cf7e447dd` by removing the attribute again.

**Repro / impact:** `echo (string) $reflectionType;` runs without a deprecation notice on PHP 8.0+ (verified on 8.4 and 8.5 under `E_ALL`), yet tools that read `#[Deprecated]` from these stubs now flag it. PHPStan 2.2.3 bundled a stubs snapshot including `e2028cae5` (phpstan/phpstan#5861) and, with phpstan-deprecation-rules, newly reports `Casting class ReflectionType to string is deprecated. [class.toStringDeprecated]`; PHPStan 2.2.2 did not. PhpStorm's own inspection would show the same.

Related: WI-77852.