### PR TITLE
WI-85516 [phpstorm-stubs] Mark filename/path parameters with #[FileReference]

### DIFF
--- a/standard/standard_0.php
+++ b/standard/standard_0.php
@@ -5,6 +5,7 @@
 use JetBrains\PhpStorm\ArrayShape;
 use JetBrains\PhpStorm\Deprecated;
 use JetBrains\PhpStorm\ExpectedValues;
+use JetBrains\PhpStorm\FileReference;
 use JetBrains\PhpStorm\Internal\LanguageLevelTypeAware;
 use JetBrains\PhpStorm\Internal\PhpStormStubsElementAvailable;
 use JetBrains\PhpStorm\Internal\TentativeType;
@@ -817,7 +818,7 @@ function sha1(string $string, bool $binary = false): string {}
  * @return string|false a string on success, false otherwise.
  */
 #[Pure(true)]
-function sha1_file(string $filename, bool $binary = false): string|false {}
+function sha1_file(#[FileReference] string $filename, bool $binary = false): string|false {}
 
 /**
  * Calculate the md5 hash of a string
@@ -848,7 +849,7 @@ function md5(string $string, bool $binary = false): string {}
  * @return string|false a string on success, false otherwise.
  */
 #[Pure(true)]
-function md5_file(string $filename, bool $binary = false): string|false {}
+function md5_file(#[FileReference] string $filename, bool $binary = false): string|false {}
 
 /**
  * Calculates the crc32 polynomial of a string
@@ -956,7 +957,7 @@ function iptcembed(string $iptc_data, string $filename, int $spool = 0): string|
  * </p>
  */
 #[ArrayShape([0 => "int", 1 => "int", 2 => "int", 3 => "string", "bits" => "int", "channels" => "int", "mime" => "string"])]
-function getimagesize(string $filename, &$image_info = null): array|false {}
+function getimagesize(#[FileReference] string $filename, &$image_info = null): array|false {}
 
 /**
  * Get Mime-Type for image-type returned by getimagesize, exif_read_data, exif_thumbnail, exif_imagetype

--- a/standard/standard_2.php
+++ b/standard/standard_2.php
@@ -1,6 +1,7 @@
 <?php
 
 use JetBrains\PhpStorm\ArrayShape;
+use JetBrains\PhpStorm\FileReference;
 use JetBrains\PhpStorm\Internal\LanguageLevelTypeAware;
 use JetBrains\PhpStorm\Internal\PhpStormStubsElementAvailable;
 use JetBrains\PhpStorm\Internal\ReturnTypeContract as TypeContract;
@@ -595,7 +596,7 @@ function http_build_query(object|array $data, string $numeric_prefix = "", ?stri
  * @return string|false the contents of the symbolic link path or false on error.
  */
 #[Pure(true)]
-function readlink(string $path): string|false {}
+function readlink(#[FileReference] string $path): string|false {}
 
 /**
  * Gets information about a link
@@ -608,7 +609,7 @@ function readlink(string $path): string|false {}
  * system call. Returns 0 or false in case of error.
  */
 #[Pure(true)]
-function linkinfo(string $path): int|false {}
+function linkinfo(#[FileReference] string $path): int|false {}
 
 /**
  * Creates a symbolic link
@@ -621,7 +622,7 @@ function linkinfo(string $path): int|false {}
  * </p>
  * @return bool true on success or false on failure.
  */
-function symlink(string $target, string $link): bool {}
+function symlink(#[FileReference] string $target, #[FileReference] string $link): bool {}
 
 /**
  * Create a hard link
@@ -630,7 +631,7 @@ function symlink(string $target, string $link): bool {}
  * @param string $link The link name.
  * @return bool true on success or false on failure.
  */
-function link(string $target, string $link): bool {}
+function link(#[FileReference] string $target, #[FileReference] string $link): bool {}
 
 /**
  * Deletes a file
@@ -641,7 +642,7 @@ function link(string $target, string $link): bool {}
  * @param resource $context [optional]
  * @return bool true on success or false on failure.
  */
-function unlink(string $filename, $context = null): bool {}
+function unlink(#[FileReference] string $filename, $context = null): bool {}
 
 /**
  * Execute an external program

--- a/standard/standard_4.php
+++ b/standard/standard_4.php
@@ -2,6 +2,7 @@
 
 use JetBrains\PhpStorm\ArrayShape;
 use JetBrains\PhpStorm\Deprecated;
+use JetBrains\PhpStorm\FileReference;
 use JetBrains\PhpStorm\Internal\LanguageLevelTypeAware;
 use JetBrains\PhpStorm\Internal\PhpStormStubsElementAvailable;
 use JetBrains\PhpStorm\Pure;
@@ -346,7 +347,7 @@ function unregister_tick_function(callable $callback): void {}
  * code as a string instead of printing it out. Otherwise, it will return
  * true on success, false on failure.
  */
-function highlight_file(string $filename, bool $return = false): string|bool {}
+function highlight_file(#[FileReference] string $filename, bool $return = false): string|bool {}
 
 /**
  * Alias:
@@ -356,7 +357,7 @@ function highlight_file(string $filename, bool $return = false): string|bool {}
  * @param bool $return [optional]
  * @return string|bool
  */
-function show_source(string $filename, bool $return = false): string|bool {}
+function show_source(#[FileReference] string $filename, bool $return = false): string|bool {}
 
 /**
  * Syntax highlighting of a string
@@ -852,7 +853,7 @@ function ignore_user_abort(?bool $enable = null): int {}
  * and false on failure.
  */
 #[Pure(true)]
-function parse_ini_file(string $filename, bool $process_sections = false, int $scanner_mode = INI_SCANNER_NORMAL): array|false {}
+function parse_ini_file(#[FileReference] string $filename, bool $process_sections = false, int $scanner_mode = INI_SCANNER_NORMAL): array|false {}
 
 /**
  * Parse a configuration string

--- a/standard/standard_5.php
+++ b/standard/standard_5.php
@@ -2,6 +2,7 @@
 
 use JetBrains\PhpStorm\Deprecated;
 use JetBrains\PhpStorm\ExpectedValues;
+use JetBrains\PhpStorm\FileReference;
 use JetBrains\PhpStorm\Internal\LanguageLevelTypeAware;
 use JetBrains\PhpStorm\Pure;
 
@@ -401,7 +402,7 @@ function popen(string $command, string $mode) {}
  * </p>
  * @return false|int the number of bytes read from the file, or FALSE on failure
  */
-function readfile(string $filename, bool $use_include_path = false, $context = null): int|false {}
+function readfile(#[FileReference] string $filename, bool $use_include_path = false, $context = null): int|false {}
 
 /**
  * Rewind the position of a file pointer
@@ -423,7 +424,7 @@ function rewind($stream): bool {}
  * @param resource $context [optional]
  * @return bool true on success or false on failure.
  */
-function rmdir(string $directory, $context = null): bool {}
+function rmdir(#[FileReference] string $directory, $context = null): bool {}
 
 /**
  * Changes the current umask
@@ -704,7 +705,7 @@ function fread($stream, int $length): string|false {}
  * @param resource $context [optional]
  * @return resource|false a file pointer resource on success, or false on error.
  */
-function fopen(string $filename, string $mode, bool $use_include_path = false, $context = null) {}
+function fopen(#[FileReference] string $filename, string $mode, bool $use_include_path = false, $context = null) {}
 
 /**
  * Output all remaining data on a file pointer
@@ -895,7 +896,7 @@ function fputs($stream, string $data, ?int $length = null): int|false {}
  * @param resource $context [optional]
  * @return bool true on success or false on failure.
  */
-function mkdir(string $directory, int $permissions = 0777, bool $recursive = false, $context = null): bool {}
+function mkdir(#[FileReference] string $directory, int $permissions = 0777, bool $recursive = false, $context = null): bool {}
 
 /**
  * Renames a file or directory
@@ -913,7 +914,7 @@ function mkdir(string $directory, int $permissions = 0777, bool $recursive = fal
  * @param resource $context [optional]
  * @return bool true on success or false on failure.
  */
-function rename(string $from, string $to, $context = null): bool {}
+function rename(#[FileReference] string $from, #[FileReference] string $to, $context = null): bool {}
 
 /**
  * Copies file
@@ -935,7 +936,7 @@ function rename(string $from, string $to, $context = null): bool {}
  * </p>
  * @return bool true on success or false on failure.
  */
-function copy(string $from, string $to, $context = null): bool {}
+function copy(#[FileReference] string $from, #[FileReference] string $to, $context = null): bool {}
 
 /**
  * Create file with unique file name
@@ -950,7 +951,7 @@ function copy(string $from, string $to, $context = null): bool {}
  * @return string|false the new temporary filename, or false on
  * failure.
  */
-function tempnam(string $directory, string $prefix): string|false {}
+function tempnam(#[FileReference] string $directory, string $prefix): string|false {}
 
 /**
  * Creates a temporary file
@@ -990,7 +991,7 @@ function tmpfile() {}
  * </p>
  */
 #[Pure(true)]
-function file(string $filename, int $flags = 0, $context = null): array|false {}
+function file(#[FileReference] string $filename, int $flags = 0, $context = null): array|false {}
 
 /**
  * Reads entire file into a string
@@ -1017,7 +1018,7 @@ function file(string $filename, int $flags = 0, $context = null): array|false {}
  * @return string|false The function returns the read data or false on failure.
  */
 #[Pure(true)]
-function file_get_contents(string $filename, bool $use_include_path = false, $context = null, int $offset = 0, ?int $length = null): string|false {}
+function file_get_contents(#[FileReference] string $filename, bool $use_include_path = false, $context = null, int $offset = 0, ?int $length = null): string|false {}
 
 /**
  * Write a string to a file
@@ -1090,4 +1091,4 @@ function file_get_contents(string $filename, bool $use_include_path = false, $co
  * @return int|false The function returns the number of bytes that were written to the file, or
  * false on failure.
  */
-function file_put_contents(string $filename, mixed $data, int $flags = 0, $context = null): int|false {}
+function file_put_contents(#[FileReference] string $filename, mixed $data, int $flags = 0, $context = null): int|false {}

--- a/standard/standard_6.php
+++ b/standard/standard_6.php
@@ -2,6 +2,7 @@
 
 use JetBrains\PhpStorm\ArrayShape;
 use JetBrains\PhpStorm\Deprecated;
+use JetBrains\PhpStorm\FileReference;
 use JetBrains\PhpStorm\Internal\LanguageLevelTypeAware;
 use JetBrains\PhpStorm\Internal\PhpStormStubsElementAvailable;
 use JetBrains\PhpStorm\Pure;
@@ -1167,7 +1168,7 @@ function socket_get_status($stream): array {}
  * </p>
  */
 #[Pure(true)]
-function realpath(string $path): string|false {}
+function realpath(#[FileReference] string $path): string|false {}
 
 /**
  * Match filename against a pattern

--- a/standard/standard_7.php
+++ b/standard/standard_7.php
@@ -2,6 +2,7 @@
 
 use JetBrains\PhpStorm\ArrayShape;
 use JetBrains\PhpStorm\Deprecated;
+use JetBrains\PhpStorm\FileReference;
 use JetBrains\PhpStorm\Internal\LanguageLevelTypeAware;
 use JetBrains\PhpStorm\Internal\PhpStormStubsElementAvailable;
 use JetBrains\PhpStorm\Pure;
@@ -307,7 +308,7 @@ function crypt(string $string, string $salt): string {}
  * '@' to the
  * front of the function name.
  */
-function opendir(string $directory, $context = null) {}
+function opendir(#[FileReference] string $directory, $context = null) {}
 
 /**
  * Close directory handle
@@ -330,7 +331,7 @@ function closedir($dir_handle = null): void {}
  * </p>
  * @return bool true on success or false on failure.
  */
-function chdir(string $directory): bool {}
+function chdir(#[FileReference] string $directory): bool {}
 
 /**
  * Change the root directory
@@ -340,7 +341,7 @@ function chdir(string $directory): bool {}
  * </p>
  * @return bool true on success or false on failure.
  */
-function chroot(string $directory): bool {}
+function chroot(#[FileReference] string $directory): bool {}
 
 /**
  * Gets the current working directory
@@ -395,7 +396,7 @@ function readdir($dir_handle = null): string|false {}
  * @return Directory|false an instance of Directory, or <b>NULL</b> with wrong
  * parameters, or <b>FALSE</b> in case of another error
  */
-function dir(string $directory, $context = null): Directory|false {}
+function dir(#[FileReference] string $directory, $context = null): Directory|false {}
 
 /**
  * Alias of dir()
@@ -428,7 +429,7 @@ function getdir(string $directory, $context = null): Directory|false {}
  * boolean false is returned, and an error of level
  * E_WARNING is generated.
  */
-function scandir(string $directory, int $sorting_order = 0, $context = null): array|false {}
+function scandir(#[FileReference] string $directory, int $sorting_order = 0, $context = null): array|false {}
 
 /**
  * Find pathnames matching a pattern
@@ -465,7 +466,7 @@ function glob(string $pattern, int $flags = 0): array|false {}
  * The time is returned as a Unix timestamp.
  */
 #[Pure(true)]
-function fileatime(string $filename): int|false {}
+function fileatime(#[FileReference] string $filename): int|false {}
 
 /**
  * Gets inode change time of file
@@ -477,7 +478,7 @@ function fileatime(string $filename): int|false {}
  * The time is returned as a Unix timestamp.
  */
 #[Pure(true)]
-function filectime(string $filename): int|false {}
+function filectime(#[FileReference] string $filename): int|false {}
 
 /**
  * Gets file group
@@ -491,7 +492,7 @@ function filectime(string $filename): int|false {}
  * Upon failure, false is returned.
  */
 #[Pure(true)]
-function filegroup(string $filename): int|false {}
+function filegroup(#[FileReference] string $filename): int|false {}
 
 /**
  * Gets file inode
@@ -502,7 +503,7 @@ function filegroup(string $filename): int|false {}
  * @return int|false the inode number of the file, or false on failure.
  */
 #[Pure(true)]
-function fileinode(string $filename): int|false {}
+function fileinode(#[FileReference] string $filename): int|false {}
 
 /**
  * Gets file modification time
@@ -515,7 +516,7 @@ function fileinode(string $filename): int|false {}
  * suitable for the date function.
  */
 #[Pure(true)]
-function filemtime(string $filename): int|false {}
+function filemtime(#[FileReference] string $filename): int|false {}
 
 /**
  * Gets file owner
@@ -528,7 +529,7 @@ function filemtime(string $filename): int|false {}
  * posix_getpwuid to resolve it to a username.
  */
 #[Pure(true)]
-function fileowner(string $filename): int|false {}
+function fileowner(#[FileReference] string $filename): int|false {}
 
 /**
  * Gets file permissions
@@ -539,7 +540,7 @@ function fileowner(string $filename): int|false {}
  * @return int|false the permissions on the file, or false on failure.
  */
 #[Pure(true)]
-function fileperms(string $filename): int|false {}
+function fileperms(#[FileReference] string $filename): int|false {}
 
 /**
  * Gets file size
@@ -551,7 +552,7 @@ function fileperms(string $filename): int|false {}
  * of level E_WARNING) in case of an error.
  */
 #[Pure(true)]
-function filesize(string $filename): int|false {}
+function filesize(#[FileReference] string $filename): int|false {}
 
 /**
  * Gets file type
@@ -568,7 +569,7 @@ function filesize(string $filename): int|false {}
  * or if the file type is unknown.
  */
 #[Pure(true)]
-function filetype(string $filename): string|false {}
+function filetype(#[FileReference] string $filename): string|false {}
 
 /**
  * Checks whether a file or directory exists
@@ -597,7 +598,7 @@ function filetype(string $filename): string|false {}
  * The check is done using the real UID/GID instead of the effective one.
  */
 #[Pure(true)]
-function file_exists(string $filename): bool {}
+function file_exists(#[FileReference] string $filename): bool {}
 
 /**
  * Tells whether the filename is writable
@@ -609,7 +610,7 @@ function file_exists(string $filename): bool {}
  * writable.
  */
 #[Pure(true)]
-function is_writable(string $filename): bool {}
+function is_writable(#[FileReference] string $filename): bool {}
 
 /**
  * Alias:
@@ -622,7 +623,7 @@ function is_writable(string $filename): bool {}
  * writable.
  */
 #[Pure(true)]
-function is_writeable(string $filename): bool {}
+function is_writeable(#[FileReference] string $filename): bool {}
 
 /**
  * Tells whether a file or a directory exists and is readable
@@ -634,7 +635,7 @@ function is_writeable(string $filename): bool {}
  * filename exists and is readable, false otherwise.
  */
 #[Pure(true)]
-function is_readable(string $filename): bool {}
+function is_readable(#[FileReference] string $filename): bool {}
 
 /**
  * Tells whether the filename is executable
@@ -646,7 +647,7 @@ function is_readable(string $filename): bool {}
  * error.
  */
 #[Pure(true)]
-function is_executable(string $filename): bool {}
+function is_executable(#[FileReference] string $filename): bool {}
 
 /**
  * Tells whether the filename is a regular file
@@ -658,7 +659,7 @@ function is_executable(string $filename): bool {}
  * otherwise.
  */
 #[Pure(true)]
-function is_file(string $filename): bool {}
+function is_file(#[FileReference] string $filename): bool {}
 
 /**
  * Tells whether the filename is a directory
@@ -673,7 +674,7 @@ function is_file(string $filename): bool {}
  * otherwise.
  */
 #[Pure(true)]
-function is_dir(string $filename): bool {}
+function is_dir(#[FileReference] string $filename): bool {}
 
 /**
  * Tells whether the filename is a symbolic link
@@ -685,7 +686,7 @@ function is_dir(string $filename): bool {}
  * otherwise.
  */
 #[Pure(true)]
-function is_link(string $filename): bool {}
+function is_link(#[FileReference] string $filename): bool {}
 
 /**
  * Gives information about a file
@@ -792,7 +793,7 @@ function is_link(string $filename): bool {}
     "blksize" => "int",
     "blocks" => "int"
 ])]
-function stat(string $filename): array|false {}
+function stat(#[FileReference] string $filename): array|false {}
 
 /**
  * Gives information about a file or symbolic link
@@ -809,7 +810,7 @@ function stat(string $filename): array|false {}
  * file pointed to by the symbolic link.
  */
 #[Pure(true)]
-function lstat(string $filename): array|false {}
+function lstat(#[FileReference] string $filename): array|false {}
 
 /**
  * Changes file owner
@@ -822,7 +823,7 @@ function lstat(string $filename): array|false {}
  * </p>
  * @return bool true on success or false on failure.
  */
-function chown(string $filename, string|int $user): bool {}
+function chown(#[FileReference] string $filename, string|int $user): bool {}
 
 /**
  * Changes file group
@@ -835,7 +836,7 @@ function chown(string $filename, string|int $user): bool {}
  * </p>
  * @return bool true on success or false on failure.
  */
-function chgrp(string $filename, string|int $group): bool {}
+function chgrp(#[FileReference] string $filename, string|int $group): bool {}
 
 /**
  * Changes user ownership of symlink
@@ -849,7 +850,7 @@ function chgrp(string $filename, string|int $group): bool {}
  * @return bool true on success or false on failure.
  * @since 5.1
  */
-function lchown(string $filename, string|int $user): bool {}
+function lchown(#[FileReference] string $filename, string|int $user): bool {}
 
 /**
  * Changes group ownership of symlink
@@ -863,7 +864,7 @@ function lchown(string $filename, string|int $user): bool {}
  * @return bool true on success or false on failure.
  * @since 5.1
  */
-function lchgrp(string $filename, string|int $group): bool {}
+function lchgrp(#[FileReference] string $filename, string|int $group): bool {}
 
 /**
  * Changes file mode
@@ -898,7 +899,7 @@ function lchgrp(string $filename, string|int $group): bool {}
  * </p>
  * @return bool true on success or false on failure.
  */
-function chmod(string $filename, int $permissions): bool {}
+function chmod(#[FileReference] string $filename, int $permissions): bool {}
 
 /**
  * Sets access and modification time of file
@@ -917,7 +918,7 @@ function chmod(string $filename, int $permissions): bool {}
  * </p>
  * @return bool true on success or false on failure.
  */
-function touch(string $filename, ?int $mtime = null, ?int $atime = null): bool {}
+function touch(#[FileReference] string $filename, ?int $mtime = null, ?int $atime = null): bool {}
 
 /**
  * Clears file status cache
@@ -943,7 +944,7 @@ function clearstatcache(bool $clear_realpath_cache = false, string $filename = '
  * or false on failure.
  */
 #[Pure(true)]
-function disk_total_space(string $directory): float|false {}
+function disk_total_space(#[FileReference] string $directory): float|false {}
 
 /**
  * Returns available space in directory
@@ -960,7 +961,7 @@ function disk_total_space(string $directory): float|false {}
  * or false on failure.
  */
 #[Pure(true)]
-function disk_free_space(string $directory): float|false {}
+function disk_free_space(#[FileReference] string $directory): float|false {}
 
 /**
  * Alias of {@see disk_free_space}
@@ -970,7 +971,7 @@ function disk_free_space(string $directory): float|false {}
  * @return float|false
  */
 #[Pure(true)]
-function diskfreespace(string $directory): float|false {}
+function diskfreespace(#[FileReference] string $directory): float|false {}
 
 /**
  * Send mail


### PR DESCRIPTION


Add #[FileReference] attribute to filename and path parameters of standard library file functions (sha1_file, md5_file, getimagesize, readlink, symlink, link, unlink, readfile, rmdir, fopen, mkdir, rename, copy, and others).