### PR TITLE
`ReflectionType::__toString()` is not deprecated

### DIFF
--- a/Reflection/ReflectionType.php
+++ b/Reflection/ReflectionType.php
@@ -42,7 +42,6 @@ abstract class ReflectionType implements Stringable
      * @since 7.0
      * @see ReflectionNamedType::getName()
      */
-    #[Deprecated(since: '7.4')]
     public function __toString(): string {}
 
     /**


### PR DESCRIPTION
This method has been deprecated on and off, but is currently not deprecated.

https://github.com/phpstan/phpstan/issues/14963