### PR TITLE
[phpstorm-stubs] Introduce `DeprecationParser`

### DIFF
--- a/tests/Framework/Model/StubsMetadata.php
+++ b/tests/Framework/Model/StubsMetadata.php
@@ -11,6 +11,7 @@ final class StubsMetadata
     private ?string $phpDoc = null;
     private ?string $sinceVersion = null;
     private ?string $removedVersion = null;
+    private ?string $deprecatedSinceVersion = null;
     private ?array $languageLevelTypes = null;
     private ?string $defaultType = null;
     private ?string $typeFromPhpDoc = null;
@@ -70,6 +71,23 @@ final class StubsMetadata
     public function setRemovedVersion(?string $removedVersion): void
     {
         $this->removedVersion = $removedVersion;
+    }
+
+    /**
+     * PHP version the element becomes deprecated at, as declared by `#[Deprecated(since:)]` or
+     * `@_deprecated <version>`. Null means the element carries no deprecation version — either it
+     * is not deprecated at all, or it is deprecated in every version it exists in. The flag itself
+     * lives on the element (`PHPFunction::isDeprecated()`), since reflection reports it too;
+     * only the version is stub-specific.
+     */
+    public function getDeprecatedSinceVersion(): ?string
+    {
+        return $this->deprecatedSinceVersion;
+    }
+
+    public function setDeprecatedSinceVersion(?string $deprecatedSinceVersion): void
+    {
+        $this->deprecatedSinceVersion = $deprecatedSinceVersion;
     }
 
     public function getLanguageLevelTypes(): ?array

--- a/tests/Framework/Parsers/Stubs/AttributeDetectionTrait.php
+++ b/tests/Framework/Parsers/Stubs/AttributeDetectionTrait.php
@@ -6,9 +6,12 @@ namespace StubTests\Framework\Parsers\Stubs;
  * Shared attribute detection logic for stub parsers.
  *
  * Provides methods to check if an attribute list contains specific
- * JetBrains PhpStorm or built-in PHP attributes (TentativeType, Deprecated).
+ * JetBrains PhpStorm or built-in PHP attributes.
  *
- * Used by StubFunctionParser, StubMethodParser, and StubParameterParser.
+ * Deprecation is not detected here: it carries a version alongside the flag, so it is read by
+ * {@see \StubTests\Framework\Parsers\Stubs\Versions\DeprecationParser} instead.
+ *
+ * Used by StubFunctionParser and StubMethodParser.
  */
 trait AttributeDetectionTrait
 {
@@ -26,28 +29,6 @@ trait AttributeDetectionTrait
             if ($fullName === 'JetBrains\\PhpStorm\\Internal\\TentativeType'
                 || $fullName === 'TentativeType'
                 || str_ends_with($fullName, '\\Internal\\TentativeType')
-            ) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Check whether any attribute resolves to a deprecation marker.
-     * Handles both JetBrains `#[JetBrains\PhpStorm\Deprecated]` and the built-in PHP `#[Deprecated]`.
-     *
-     * @param array $attributes Array of AttributeNode objects
-     * @param array $imports    Map of import aliases to fully qualified names
-     */
-    private function hasDeprecatedAttribute(array $attributes, array $imports): bool
-    {
-        foreach ($attributes as $attribute) {
-            $name = $attribute->getName();
-            $fullName = $imports[$name] ?? $name;
-            if ($fullName === 'JetBrains\\PhpStorm\\Deprecated'
-                || str_ends_with($fullName, '\\PhpStorm\\Deprecated')
-                || $fullName === 'Deprecated'
             ) {
                 return true;
             }

--- a/tests/Framework/Parsers/Stubs/PhpDoc/ParsedPhpDoc.php
+++ b/tests/Framework/Parsers/Stubs/PhpDoc/ParsedPhpDoc.php
@@ -17,6 +17,12 @@ class ParsedPhpDoc
     public bool $isDeprecated = false;
 
     /**
+     * PHP version from the `@_deprecated <version>` tag, or null when the tag carries no
+     * recognisable PHP version (which means "deprecated in every version").
+     */
+    public ?string $deprecatedSinceVersion = null;
+
+    /**
      * Names of parameters marked as [optional] in param PhpDoc descriptions.
      * These parameters are optional even without a default value in the signature.
      *
@@ -36,7 +42,8 @@ class ParsedPhpDoc
         ?string $sinceVersion = null,
         ?string $removedVersion = null,
         bool $isDeprecated = false,
-        array $optionalParams = []
+        array $optionalParams = [],
+        ?string $deprecatedSinceVersion = null
     ) {
         $this->rawPhpDoc = $rawPhpDoc;
         $this->returnType = $returnType;
@@ -46,5 +53,6 @@ class ParsedPhpDoc
         $this->removedVersion = $removedVersion;
         $this->isDeprecated = $isDeprecated;
         $this->optionalParams = $optionalParams;
+        $this->deprecatedSinceVersion = $deprecatedSinceVersion;
     }
 }

--- a/tests/Framework/Parsers/Stubs/PhpDoc/PhpDocumentorParser.php
+++ b/tests/Framework/Parsers/Stubs/PhpDoc/PhpDocumentorParser.php
@@ -3,6 +3,7 @@
 namespace StubTests\Framework\Parsers\Stubs\PhpDoc;
 
 use phpDocumentor\Reflection\DocBlock;
+use phpDocumentor\Reflection\DocBlock\Tags\Deprecated;
 use phpDocumentor\Reflection\DocBlock\Tags\Generic;
 use phpDocumentor\Reflection\DocBlock\Tags\Param;
 use phpDocumentor\Reflection\DocBlock\Tags\Return_;
@@ -10,6 +11,7 @@ use phpDocumentor\Reflection\DocBlock\Tags\Since;
 use phpDocumentor\Reflection\DocBlock\Tags\Var_;
 use phpDocumentor\Reflection\DocBlockFactory;
 use StubTests\Framework\Parsers\Stubs\Nodes\DocCommentNode;
+use StubTests\Framework\Parsers\Stubs\Versions\DeprecationParser;
 
 /**
  * PhpDoc parser implementation using phpDocumentor library.
@@ -57,6 +59,7 @@ class PhpDocumentorParser implements PhpDocParserInterface
         $parsed->sinceVersion = $this->extractSinceVersion($docBlock);
         $parsed->removedVersion = $this->extractRemovedVersion($docBlock);
         $parsed->isDeprecated = $this->hasDeprecatedTag($docBlock);
+        $parsed->deprecatedSinceVersion = $this->extractDeprecatedSinceVersion($docBlock);
 
         // phpDocumentor silently drops @param/@return/@var tags whose type it cannot resolve
         // (e.g. phpstan/psalm types like array<TKey, TValue> or non-empty-array<int>). Recover
@@ -364,5 +367,31 @@ class PhpDocumentorParser implements PhpDocParserInterface
     {
         $deprecatedTags = $docBlock->getTagsByName('deprecated');
         return !empty($deprecatedTags);
+    }
+
+    /**
+     * Read the PHP version out of `@_deprecated <version> [description]`.
+     *
+     * The leading version vector is a PHP language level on most entries (`@_deprecated 7.1`) but a
+     * library version on others (`@_deprecated 2.3.0 use ... instead`, for PECL extensions versioned
+     * independently of PHP), so only recognised PHP versions are accepted —
+     * see {@see DeprecationParser::normalizePhpVersion()}. Anything else yields null, meaning
+     * "deprecated regardless of version", which is how a bare `@_deprecated` already behaves.
+     */
+    private function extractDeprecatedSinceVersion(DocBlock $docBlock): ?string
+    {
+        $deprecatedTags = $docBlock->getTagsByName('deprecated');
+        if (empty($deprecatedTags)) {
+            return null;
+        }
+
+        $deprecatedTag = $deprecatedTags[0];
+        if (!$deprecatedTag instanceof Deprecated) {
+            return null;
+        }
+
+        $version = $deprecatedTag->getVersion();
+
+        return $version === null ? null : DeprecationParser::normalizePhpVersion($version);
     }
 }

--- a/tests/Framework/Parsers/Stubs/StubFunctionParser.php
+++ b/tests/Framework/Parsers/Stubs/StubFunctionParser.php
@@ -9,6 +9,7 @@ use StubTests\Framework\Parsers\Stubs\Types\DefaultTypeParser;
 use StubTests\Framework\Parsers\Stubs\Types\TypeParserInterface;
 use StubTests\Framework\Parsers\Stubs\Versions\AvailableVersionParserInterface;
 use StubTests\Framework\Parsers\Stubs\Versions\DefaultAvailableVersionParser;
+use StubTests\Framework\Parsers\Stubs\Versions\DeprecationParser;
 use StubTests\Framework\Model\PHPFunction;
 use StubTests\Framework\Parsers\Stubs\Adapters\Nikic\NikicNodeExtractor;
 use StubTests\Framework\Parsers\Stubs\Nodes\FunctionNode;
@@ -25,6 +26,7 @@ class StubFunctionParser implements MultiEntityStubParserInterface
     private PhpDocParserInterface $phpDocParser;
     private TypeParserInterface $typeParser;
     private AvailableVersionParserInterface $versionParser;
+    private DeprecationParser $deprecationParser;
     private StubParameterParser $parameterParser;
 
     public function __construct(
@@ -37,6 +39,7 @@ class StubFunctionParser implements MultiEntityStubParserInterface
         $this->phpDocParser = $phpDocParser ?? new PhpDocumentorParser();
         $this->typeParser = $typeParser ?? new DefaultTypeParser();
         $this->versionParser = $versionParser ?? new DefaultAvailableVersionParser();
+        $this->deprecationParser = new DeprecationParser();
         $this->parameterParser = new StubParameterParser($typeParser, $versionParser);
     }
 
@@ -91,7 +94,9 @@ class StubFunctionParser implements MultiEntityStubParserInterface
 
         // Apply parsed PhpDoc data to function
         $phpFunction->initStubsMetadata()->setPhpDoc($parsedPhpDoc->rawPhpDoc);
-        $phpFunction->setDeprecated($parsedPhpDoc->isDeprecated || $this->hasDeprecatedAttribute($node->getAttributes(), $imports));
+        $deprecation = $this->deprecationParser->parseDeprecation($node->getAttributes(), $imports, $parsedPhpDoc);
+        $phpFunction->setDeprecated($deprecation->isDeprecated);
+        $phpFunction->initStubsMetadata()->setDeprecatedSinceVersion($deprecation->sinceVersion);
         $phpFunction->setHasTentativeReturnType($this->hasTentativeTypeAttribute($node->getAttributes(), $imports));
 
         // Parse and apply available version (from PhpDoc + attributes)

--- a/tests/Framework/Parsers/Stubs/StubMethodParser.php
+++ b/tests/Framework/Parsers/Stubs/StubMethodParser.php
@@ -10,6 +10,7 @@ use StubTests\Framework\Parsers\Stubs\Types\DefaultTypeParser;
 use StubTests\Framework\Parsers\Stubs\Types\TypeParserInterface;
 use StubTests\Framework\Parsers\Stubs\Versions\AvailableVersionParserInterface;
 use StubTests\Framework\Parsers\Stubs\Versions\DefaultAvailableVersionParser;
+use StubTests\Framework\Parsers\Stubs\Versions\DeprecationParser;
 use StubTests\Framework\Model\PHPMethod;
 use StubTests\Framework\Parsers\Stubs\Nodes\MethodNode;
 
@@ -23,6 +24,7 @@ class StubMethodParser
     private PhpDocParserInterface $phpDocParser;
     private TypeParserInterface $typeParser;
     private AvailableVersionParserInterface $versionParser;
+    private DeprecationParser $deprecationParser;
     private StubParameterParser $parameterParser;
 
     public function __construct(
@@ -33,6 +35,7 @@ class StubMethodParser
         $this->phpDocParser = $phpDocParser ?? new PhpDocumentorParser();
         $this->typeParser = $typeParser ?? new DefaultTypeParser();
         $this->versionParser = $versionParser ?? new DefaultAvailableVersionParser();
+        $this->deprecationParser = new DeprecationParser();
         $this->parameterParser = new StubParameterParser($typeParser, $versionParser);
     }
 
@@ -78,7 +81,9 @@ class StubMethodParser
 
         // Apply parsed PhpDoc data to method
         $method->initStubsMetadata()->setPhpDoc($parsedPhpDoc->rawPhpDoc);
-        $method->setDeprecated($parsedPhpDoc->isDeprecated || $this->hasDeprecatedAttribute($node->getAttributes(), $imports));
+        $deprecation = $this->deprecationParser->parseDeprecation($node->getAttributes(), $imports, $parsedPhpDoc);
+        $method->setDeprecated($deprecation->isDeprecated);
+        $method->initStubsMetadata()->setDeprecatedSinceVersion($deprecation->sinceVersion);
         $method->setHasTentativeReturnType($this->hasTentativeTypeAttribute($node->getAttributes(), $imports));
 
         // Parse and apply available version (from PhpDoc + attributes)

--- a/tests/Framework/Parsers/Stubs/StubParameterParser.php
+++ b/tests/Framework/Parsers/Stubs/StubParameterParser.php
@@ -7,6 +7,7 @@ use StubTests\Framework\Parsers\Stubs\Types\DefaultTypeParser;
 use StubTests\Framework\Parsers\Stubs\Types\TypeParserInterface;
 use StubTests\Framework\Parsers\Stubs\Versions\AvailableVersionParserInterface;
 use StubTests\Framework\Parsers\Stubs\Versions\DefaultAvailableVersionParser;
+use StubTests\Framework\Parsers\Stubs\Versions\DeprecationParser;
 use StubTests\Framework\Model\PHPParameter;
 use StubTests\Framework\Parsers\Stubs\Nodes\ParameterNode;
 
@@ -16,9 +17,9 @@ use StubTests\Framework\Parsers\Stubs\Nodes\ParameterNode;
  */
 class StubParameterParser
 {
-    use AttributeDetectionTrait;
     private TypeParserInterface $typeParser;
     private AvailableVersionParserInterface $versionParser;
+    private DeprecationParser $deprecationParser;
 
     public function __construct(
         ?TypeParserInterface $typeParser = null,
@@ -26,6 +27,7 @@ class StubParameterParser
     ) {
         $this->typeParser = $typeParser ?? new DefaultTypeParser();
         $this->versionParser = $versionParser ?? new DefaultAvailableVersionParser();
+        $this->deprecationParser = new DeprecationParser();
     }
 
     /**
@@ -87,8 +89,11 @@ class StubParameterParser
             || in_array($paramName, $optionalParamsFromPhpDoc, true);
         $parameter->setIsOptional($isOptional);
 
-        // Detect #[Deprecated] attribute on the parameter
-        $parameter->setDeprecated($this->hasDeprecatedAttribute($node->getAttributes(), $imports));
+        // Detect #[Deprecated] attribute on the parameter. Parameters carry no PhpDoc of their
+        // own, so the attribute is the only deprecation source here.
+        $deprecation = $this->deprecationParser->parseDeprecation($node->getAttributes(), $imports);
+        $parameter->setDeprecated($deprecation->isDeprecated);
+        $parameter->initStubsMetadata()->setDeprecatedSinceVersion($deprecation->sinceVersion);
 
         // Parse available version from attributes using version parser with import context
         // Note: Parameters typically don't have PhpDoc, only attributes

--- a/tests/Framework/Parsers/Stubs/Versions/DeprecationParser.php
+++ b/tests/Framework/Parsers/Stubs/Versions/DeprecationParser.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace StubTests\Framework\Parsers\Stubs\Versions;
+
+use StubTests\Framework\Parsers\Stubs\Nodes\AttributeNode;
+use StubTests\Framework\Parsers\Stubs\PhpDoc\ParsedPhpDoc;
+use StubTests\Framework\Runner\PhpVersions;
+
+/**
+ * Extracts deprecation state — the flag and the PHP version it starts at — from a stub element.
+ *
+ * Two distinct attributes mark deprecation in the stubs, and their positional arguments differ:
+ * - `JetBrains\PhpStorm\Deprecated($reason, $replacement, $since)` — `since` is argument 2.
+ * - the built-in `\Deprecated(?string $message, ?string $since)` (PHP 8.4+) — `since` is argument 1.
+ * The named `since:` form is what the stubs overwhelmingly use, but positional args are read too,
+ * per flavour, so a positional `since` is never mistaken for a replacement or a message.
+ *
+ * Precedence mirrors {@see DefaultAvailableVersionParser}: an attribute overrides the PhpDoc tag.
+ */
+class DeprecationParser
+{
+    private const FLAVOUR_JETBRAINS = 'jetbrains';
+    private const FLAVOUR_BUILTIN = 'builtin';
+
+    /**
+     * Position of the `since` argument when it is passed positionally, per attribute flavour.
+     */
+    private const SINCE_POSITION = [
+        self::FLAVOUR_JETBRAINS => 2,
+        self::FLAVOUR_BUILTIN => 1,
+    ];
+
+    /**
+     * @param array $attributes Array of AttributeNode objects
+     * @param array $imports Map of import aliases to fully qualified names
+     * @param ParsedPhpDoc|null $phpDoc Already-parsed PhpDoc, contributing `@_deprecated [version]`
+     */
+    public function parseDeprecation(array $attributes, array $imports = [], ?ParsedPhpDoc $phpDoc = null): ParsedDeprecation
+    {
+        $isDeprecated = $phpDoc?->isDeprecated ?? false;
+        $sinceVersion = $phpDoc?->deprecatedSinceVersion;
+
+        foreach ($attributes as $attribute) {
+            if (!$attribute instanceof AttributeNode) {
+                continue;
+            }
+
+            $name = $attribute->getName();
+            $flavour = $this->deprecationFlavour($imports[$name] ?? $name);
+            if ($flavour === null) {
+                continue;
+            }
+
+            $isDeprecated = true;
+
+            $attributeSince = $this->extractSince($attribute->getArguments(), $flavour);
+            if ($attributeSince !== null) {
+                $sinceVersion = $attributeSince;
+            }
+
+            break; // Only the first deprecation attribute is meaningful
+        }
+
+        return new ParsedDeprecation($isDeprecated, $isDeprecated ? $sinceVersion : null);
+    }
+
+    /**
+     * Classify a resolved attribute name as one of the two deprecation attributes, or null
+     * when it is not a deprecation marker at all.
+     */
+    private function deprecationFlavour(string $fullName): ?string
+    {
+        if ($fullName === 'JetBrains\\PhpStorm\\Deprecated' || str_ends_with($fullName, '\\PhpStorm\\Deprecated')) {
+            return self::FLAVOUR_JETBRAINS;
+        }
+
+        // No import mapped the name, so it resolves against the global namespace: the built-in
+        // #[\Deprecated] introduced in PHP 8.4.
+        if ($fullName === 'Deprecated' || $fullName === '\\Deprecated') {
+            return self::FLAVOUR_BUILTIN;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array $arguments Attribute arguments keyed by name, or by position when unnamed
+     */
+    private function extractSince(array $arguments, string $flavour): ?string
+    {
+        $since = $arguments['since'] ?? $arguments[self::SINCE_POSITION[$flavour]] ?? null;
+
+        // Also rejects null, which is_scalar() reports as false.
+        if (!is_scalar($since)) {
+            return null;
+        }
+
+        $since = trim((string)$since);
+
+        return $since === '' ? null : $since;
+    }
+
+    /**
+     * Is `$version` one of the PHP versions this suite validates?
+     *
+     * Used to filter the `@_deprecated` PhpDoc tag, whose leading token is a PHP version on some
+     * entries (`@_deprecated 7.1`) but a library version on others (`@_deprecated 2.3.0 use ...`,
+     * for PECL extensions that version independently of PHP). Only recognised PHP versions are
+     * accepted, so a library version is never read as a language level. A patch component is
+     * tolerated — `@_deprecated 7.0.7` narrows to 7.0 — because deprecation is tracked per minor.
+     */
+    public static function normalizePhpVersion(string $version): ?string
+    {
+        if (!preg_match('/^(\d+\.\d+)(?:\.\d+)?$/', $version, $matches)) {
+            return null;
+        }
+
+        return PhpVersions::tryFrom($matches[1])?->value;
+    }
+}

--- a/tests/Framework/Parsers/Stubs/Versions/ParsedDeprecation.php
+++ b/tests/Framework/Parsers/Stubs/Versions/ParsedDeprecation.php
@@ -15,6 +15,5 @@ final class ParsedDeprecation
     public function __construct(
         public readonly bool $isDeprecated = false,
         public readonly ?string $sinceVersion = null
-    ) {
-    }
+    ) {}
 }

--- a/tests/Framework/Parsers/Stubs/Versions/ParsedDeprecation.php
+++ b/tests/Framework/Parsers/Stubs/Versions/ParsedDeprecation.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace StubTests\Framework\Parsers\Stubs\Versions;
+
+/**
+ * Value object holding the deprecation state of a stub element.
+ *
+ * `$sinceVersion` is the PHP language level the element becomes deprecated at. It is null
+ * when deprecation is declared without a version, which means "deprecated in every version
+ * the element exists in" — the same meaning the JetBrains attribute gives its `$since = "5.6"`
+ * default, 5.6 being the earliest version this suite validates.
+ */
+final class ParsedDeprecation
+{
+    public function __construct(
+        public readonly bool $isDeprecated = false,
+        public readonly ?string $sinceVersion = null
+    ) {
+    }
+}

--- a/tests/Framework/Serialization/Stubs/PHPFunctionSerializer.php
+++ b/tests/Framework/Serialization/Stubs/PHPFunctionSerializer.php
@@ -44,6 +44,7 @@ class PHPFunctionSerializer implements EntityTypeSerializerInterface
         $data['phpDoc'] = $this->serializePhpDoc($entity->getId(), $entity->getStubsMetadata()?->getPhpDoc(), $phpDocStorage);
         $data['sinceVersion'] = $this->toJsonSafe($entity->getStubsMetadata()?->getSinceVersion());
         $data['removedVersion'] = $this->toJsonSafe($entity->getStubsMetadata()?->getRemovedVersion());
+        $data['deprecatedSinceVersion'] = $this->toJsonSafe($entity->getStubsMetadata()?->getDeprecatedSinceVersion());
         $data['returnTypeFromPhpDoc'] = $this->toJsonSafe($entity->getStubsMetadata()?->getTypeFromPhpDoc());
         $data['languageLevelTypes'] = $this->toJsonSafe($entity->getStubsMetadata()?->getLanguageLevelTypes());
         $data['defaultType'] = $this->toJsonSafe($entity->getStubsMetadata()?->getDefaultType());
@@ -79,6 +80,7 @@ class PHPFunctionSerializer implements EntityTypeSerializerInterface
         $function->initStubsMetadata()->setPhpDoc($this->deserializePhpDoc($functionId, $data['phpDoc'] ?? null, $phpDocStorage));
         $function->initStubsMetadata()->setSinceVersion($data['sinceVersion'] ?? null);
         $function->initStubsMetadata()->setRemovedVersion($data['removedVersion'] ?? null);
+        $function->initStubsMetadata()->setDeprecatedSinceVersion($data['deprecatedSinceVersion'] ?? null);
         $function->initStubsMetadata()->setTypeFromPhpDoc($data['returnTypeFromPhpDoc'] ?? null);
         $function->initStubsMetadata()->setLanguageLevelTypes($data['languageLevelTypes'] ?? null);
         $function->initStubsMetadata()->setDefaultType($data['defaultType'] ?? null);

--- a/tests/Framework/Serialization/Stubs/SerializerHelperTrait.php
+++ b/tests/Framework/Serialization/Stubs/SerializerHelperTrait.php
@@ -13,7 +13,8 @@ use StubTests\Framework\Serialization\PhpDocRepository;
  * Stubs-specific serialization extending the shared SubEntitySerializerTrait.
  *
  * Overrides the enrich*() hooks to append stub metadata (phpDoc, sinceVersion,
- * removedVersion, LanguageLevelTypeAware fields) to serialized/deserialized entities.
+ * removedVersion, deprecatedSinceVersion, LanguageLevelTypeAware fields) to
+ * serialized/deserialized entities.
  * Also provides PhpDoc storage helper methods.
  */
 trait SerializerHelperTrait
@@ -50,6 +51,7 @@ trait SerializerHelperTrait
         $data['phpDoc'] = $this->serializePhpDoc($methodId, $method->getStubsMetadata()?->getPhpDoc(), $phpDocStorage);
         $data['sinceVersion'] = $this->toJsonSafe($method->getStubsMetadata()?->getSinceVersion());
         $data['removedVersion'] = $this->toJsonSafe($method->getStubsMetadata()?->getRemovedVersion());
+        $data['deprecatedSinceVersion'] = $this->toJsonSafe($method->getStubsMetadata()?->getDeprecatedSinceVersion());
         $data['returnTypeFromPhpDoc'] = $this->toJsonSafe($method->getStubsMetadata()?->getTypeFromPhpDoc());
         $data['languageLevelTypes'] = $this->toJsonSafe($method->getStubsMetadata()?->getLanguageLevelTypes());
         $data['defaultType'] = $this->toJsonSafe($method->getStubsMetadata()?->getDefaultType());
@@ -62,6 +64,7 @@ trait SerializerHelperTrait
         $data['defaultType'] = $this->toJsonSafe($parameter->getStubsMetadata()?->getDefaultType());
         $data['sinceVersion'] = $this->toJsonSafe($parameter->getStubsMetadata()?->getSinceVersion());
         $data['removedVersion'] = $this->toJsonSafe($parameter->getStubsMetadata()?->getRemovedVersion());
+        $data['deprecatedSinceVersion'] = $this->toJsonSafe($parameter->getStubsMetadata()?->getDeprecatedSinceVersion());
     }
 
     protected function enrichSerializedProperty(array &$data, PHPProperty $property, ?string $parentId, ?PhpDocRepository $phpDocStorage): void
@@ -89,6 +92,7 @@ trait SerializerHelperTrait
         $method->initStubsMetadata()->setPhpDoc($this->deserializePhpDoc($methodId, $data['phpDoc'] ?? null, $phpDocStorage));
         $method->initStubsMetadata()->setSinceVersion($data['sinceVersion'] ?? null);
         $method->initStubsMetadata()->setRemovedVersion($data['removedVersion'] ?? null);
+        $method->initStubsMetadata()->setDeprecatedSinceVersion($data['deprecatedSinceVersion'] ?? null);
         $method->initStubsMetadata()->setTypeFromPhpDoc($data['returnTypeFromPhpDoc'] ?? null);
         $method->initStubsMetadata()->setLanguageLevelTypes($data['languageLevelTypes'] ?? null);
         $method->initStubsMetadata()->setDefaultType($data['defaultType'] ?? null);
@@ -101,6 +105,7 @@ trait SerializerHelperTrait
         $parameter->initStubsMetadata()->setDefaultType($data['defaultType'] ?? null);
         $parameter->initStubsMetadata()->setSinceVersion($data['sinceVersion'] ?? null);
         $parameter->initStubsMetadata()->setRemovedVersion($data['removedVersion'] ?? null);
+        $parameter->initStubsMetadata()->setDeprecatedSinceVersion($data['deprecatedSinceVersion'] ?? null);
     }
 
     protected function enrichDeserializedProperty(PHPProperty $property, array $data, ?string $parentId, ?PhpDocRepository $phpDocStorage): void

--- a/tests/Framework/Validator/Classes/Methods/ClassMethodsParameterDeprecationCheck.php
+++ b/tests/Framework/Validator/Classes/Methods/ClassMethodsParameterDeprecationCheck.php
@@ -7,6 +7,7 @@ use StubTests\Framework\Validator\Contracts\DescribesMethodMismatch;
 use StubTests\Framework\Validator\Contracts\MemberKind;
 use StubTests\Framework\Model\PHPMethod;
 use StubTests\Framework\Validator\KnownProblems\CheckType;
+use StubTests\Framework\Validator\Services\DeprecationComparator;
 
 /**
  * Validates that parameters deprecated in reflection are also deprecated in stubs.
@@ -51,9 +52,8 @@ class ClassMethodsParameterDeprecationCheck extends AbstractMemberFlagCheck impl
         $mismatches = [];
         foreach ($reflParams as $reflParam) {
             $reflName = $reflParam->getName();
-            $reflDeprecated = $reflParam->isDeprecated();
 
-            if (!$reflDeprecated) {
+            if (!DeprecationComparator::isDeprecatedIn($reflParam, $phpVersion)) {
                 continue;
             }
 
@@ -62,9 +62,7 @@ class ClassMethodsParameterDeprecationCheck extends AbstractMemberFlagCheck impl
                 continue;
             }
 
-            $stubDeprecated = $stubParamsByName[$reflName]->isDeprecated();
-
-            if (!$stubDeprecated) {
+            if (!DeprecationComparator::isDeprecatedIn($stubParamsByName[$reflName], $phpVersion)) {
                 $mismatches[] = "\${$reflName}";
             }
         }

--- a/tests/Framework/Validator/Classes/Methods/MethodDeprecationCheck.php
+++ b/tests/Framework/Validator/Classes/Methods/MethodDeprecationCheck.php
@@ -7,6 +7,7 @@ use StubTests\Framework\Validator\Contracts\DescribesMethodMismatch;
 use StubTests\Framework\Validator\Contracts\MemberKind;
 use StubTests\Framework\Model\PHPMethod;
 use StubTests\Framework\Validator\KnownProblems\CheckType;
+use StubTests\Framework\Validator\Services\DeprecationComparator;
 
 /**
  * Validates that methods marked as deprecated in reflection are also deprecated in stubs.
@@ -17,11 +18,13 @@ use StubTests\Framework\Validator\KnownProblems\CheckType;
  *    and interfaces), stripping PS_UNRESERVE_PREFIX_ where needed.
  * 3. If the stub method is not found it is silently skipped — existence is
  *    ClassMethodsExistCheck's responsibility.
- * 4. When both sides are found, their deprecation status is compared: if reflection
- *    reports the method as deprecated but the stub does not, a failure is reported.
+ * 4. When both sides are found, their deprecation status at $phpVersion is compared and any
+ *    disagreement is reported.
  *
- * The check is one-directional: reflection-deprecated → stub must be deprecated.
- * The reverse is not enforced.
+ * The check is bidirectional: the two sides must agree. A stub deprecation that starts later
+ * than the version under test does not count as deprecated here — `#[Deprecated(since: '8.4')]`
+ * reads as deprecated on 8.4 and above only, which is what makes the reverse direction
+ * (stub-deprecated → reflection must be deprecated) checkable at all.
  *
  * Known problems are supported at two granularities:
  * - class-level: EntityType::CLASS_TYPE + classId + 'MethodDeprecationCheck'
@@ -51,11 +54,15 @@ class MethodDeprecationCheck extends AbstractMemberFlagCheck implements Describe
         // isDeprecated(). The guard could never be false, and if a non-PHPMethod were ever
         // passed it silently reported "not deprecated" for every method in the suite — a green
         // run that validated nothing. The parameter type now raises a TypeError instead.
-        $reflDeprecated = $reflMethod->isDeprecated();
-        $stubDeprecated = $stubMethod->isDeprecated();
+        $reflDeprecated = DeprecationComparator::isDeprecatedIn($reflMethod, $phpVersion);
+        $stubDeprecated = DeprecationComparator::isDeprecatedIn($stubMethod, $phpVersion);
 
         if ($reflDeprecated && !$stubDeprecated) {
             return "Method {$methodEntityId} is deprecated in PHP {$phpVersion} but not marked as deprecated in stubs";
+        }
+
+        if ($stubDeprecated && !$reflDeprecated) {
+            return "Method {$methodEntityId} is marked as deprecated in stubs but is not deprecated in PHP {$phpVersion}";
         }
 
         return null;

--- a/tests/Framework/Validator/Functions/FunctionDeprecationCheck.php
+++ b/tests/Framework/Validator/Functions/FunctionDeprecationCheck.php
@@ -50,7 +50,7 @@ class FunctionDeprecationCheck extends AbstractCallableCheck
             return $results;
         }
 
-        if (DeprecationComparator::isMismatch($reflCallable, $stubCallable)) {
+        if (DeprecationComparator::isMismatch($reflCallable, $stubCallable, $phpVersion)) {
             $results->addFailure(
                 $entityId,
                 "Function {$entityId} is deprecated in PHP {$phpVersion} but not marked as deprecated in stubs"

--- a/tests/Framework/Validator/Functions/FunctionParameterDeprecationCheck.php
+++ b/tests/Framework/Validator/Functions/FunctionParameterDeprecationCheck.php
@@ -7,6 +7,7 @@ use StubTests\Framework\Validator\AbstractCallableCheck;
 use StubTests\Framework\Validator\Contracts\CheckResultSet;
 use StubTests\Framework\Validator\KnownProblems\CheckType;
 use StubTests\Framework\Validator\KnownProblems\EntityType;
+use StubTests\Framework\Validator\Services\DeprecationComparator;
 use StubTests\Framework\Validator\Services\ParameterFilterHelper;
 
 /**
@@ -65,8 +66,7 @@ class FunctionParameterDeprecationCheck extends AbstractCallableCheck
         foreach ($reflParams as $reflParam) {
             $reflName = $reflParam->getName();
 
-            $reflDeprecated = $reflParam->isDeprecated();
-            if (!$reflDeprecated) {
+            if (!DeprecationComparator::isDeprecatedIn($reflParam, $phpVersion)) {
                 continue;
             }
 
@@ -74,9 +74,7 @@ class FunctionParameterDeprecationCheck extends AbstractCallableCheck
                 continue;
             }
 
-            $stubDeprecated = $stubParamsByName[$reflName]->isDeprecated();
-
-            if (!$stubDeprecated) {
+            if (!DeprecationComparator::isDeprecatedIn($stubParamsByName[$reflName], $phpVersion)) {
                 $mismatches[] = "\${$reflName}";
             }
         }

--- a/tests/Framework/Validator/KnownProblems/DefaultKnownProblemsProvider.php
+++ b/tests/Framework/Validator/KnownProblems/DefaultKnownProblemsProvider.php
@@ -863,6 +863,27 @@ class DefaultKnownProblemsProvider implements KnownProblemsProvider
                 reason: 'GMP was made final in PHP 8.4. Stubs declare it final to match the current PHP behaviour; PHP 5.6–8.3 reflection reports non-final.'
             ),
 
+            // Directory - became final in PHP 8.5; the stub matches pre-8.5 behaviour here,
+            // so the mismatch runs the other way from the entries above.
+            new ProblemDefinition(
+                entityType: EntityType::CLASS_TYPE,
+                entityId: '\\Directory',
+                type: ProblemType::INTERNAL_IMPLEMENTATION,
+                affectedChecks: [CheckType::CLASS_FINAL],
+                versionRange: new PhpVersionRange(PhpVersions::PHP_8_5, PhpVersions::LATEST),
+                reason: 'Directory was marked final in PHP 8.5. The stub declares it without final (matching PHP <8.5 behaviour), but reflection for PHP 8.5 reports isFinal=true.'
+            ),
+
+            // ReflectionConstant - introduced and marked final in PHP 8.4
+            new ProblemDefinition(
+                entityType: EntityType::CLASS_TYPE,
+                entityId: '\\ReflectionConstant',
+                type: ProblemType::INTERNAL_IMPLEMENTATION,
+                affectedChecks: [CheckType::CLASS_FINAL],
+                versionRange: new PhpVersionRange(PhpVersions::PHP_8_4, PhpVersions::PHP_8_4),
+                reason: 'ReflectionConstant was marked final in PHP 8.4. The stub declares it without final (matching other PHP versions), but reflection for PHP 8.4 reports isFinal=true.'
+            ),
+
             // ReflectionGenerator - introduced in PHP 7.0, became final in PHP 8.0
             new ProblemDefinition(
                 entityType: EntityType::CLASS_TYPE,
@@ -1801,22 +1822,99 @@ class DefaultKnownProblemsProvider implements KnownProblemsProvider
                 reason: 'imap_sort() $reverse was int before PHP 8.0; PhpDoc documents the PHP 8.0+ bool type. The int→bool change is intentional; the PhpDoc is correct for current PHP.'
             ),
 
+            // ── MethodDeprecationCheck known problems ─────────────────────────────
+            //
+            // MethodDeprecationCheck compares both directions, so a deprecation the stub
+            // declares must also be reported by reflection for the version under test, and
+            // vice versa. Two situations below cannot satisfy that:
+            //
+            // 1. The deprecation window has an upper bound. StubsMetadata carries only
+            //    deprecatedSinceVersion — a lower bound — so a deprecation that PHP later
+            //    reverted cannot be expressed at all.
+            // 2. The deprecation is real but invisible to reflection, because PHP raises it as
+            //    an E_DEPRECATED at call time (or documents it only) rather than setting the
+            //    ZEND_ACC_DEPRECATED flag that ReflectionMethod::isDeprecated() reads.
+            //
+            // Version ranges below were read off the committed reflection caches, not assumed.
+
+            // ReflectionType::__toString — deprecated in 7.4, un-deprecated again in 8.0.
+            // Reflection reports isDeprecated=true for 7.4 only and false for 7.0-7.3 and 8.0+.
+            // Case 1: since:'7.4' would have to mean "7.4 onwards" and would wrongly mark the
+            // method deprecated for 8.0-8.6, so the stub carries no #[Deprecated] at all and
+            // the single 7.4 disagreement is suppressed here instead.
             new ProblemDefinition(
-                entityType: EntityType::CLASS_TYPE,
-                entityId: '\\Directory',
+                entityType: EntityType::METHOD,
+                entityId: '\\ReflectionType::__toString',
                 type: ProblemType::INTERNAL_IMPLEMENTATION,
-                affectedChecks: [CheckType::CLASS_FINAL],
-                versionRange: new PhpVersionRange(PhpVersions::PHP_8_5, PhpVersions::LATEST),
-                reason: 'Directory was marked final in PHP 8.5. The stub declares it without final (matching PHP <8.5 behaviour), but reflection for PHP 8.5 reports isFinal=true.'
+                affectedChecks: [CheckType::DEPRECATION],
+                versionRange: new PhpVersionRange(PhpVersions::PHP_7_4, PhpVersions::PHP_7_4),
+                reason: 'ReflectionType::__toString was deprecated in PHP 7.4 and the deprecation was reverted in 8.0; reflection reports isDeprecated=true for 7.4 only. deprecatedSinceVersion is a lower bound with no upper bound, so no attribute value describes a single deprecated version: since:\'7.4\' would also claim 8.0-8.6. The stub therefore omits #[Deprecated] and this suppresses the resulting 7.4 mismatch.'
             ),
 
+            // ReflectionNamedType inherits __toString from ReflectionType; the check resolves it
+            // through the stub hierarchy and reports it under the subclass id as well.
             new ProblemDefinition(
-                entityType: EntityType::CLASS_TYPE,
-                entityId: '\\ReflectionConstant',
+                entityType: EntityType::METHOD,
+                entityId: '\\ReflectionNamedType::__toString',
                 type: ProblemType::INTERNAL_IMPLEMENTATION,
-                affectedChecks: [CheckType::CLASS_FINAL],
-                versionRange: new PhpVersionRange(PhpVersions::PHP_8_4, PhpVersions::PHP_8_4),
-                reason: 'ReflectionConstant was marked final in PHP 8.4. The stub declares it without final (matching other PHP versions), but reflection for PHP 8.4 reports isFinal=true.'
+                affectedChecks: [CheckType::DEPRECATION],
+                versionRange: new PhpVersionRange(PhpVersions::PHP_7_4, PhpVersions::PHP_7_4),
+                reason: 'ReflectionNamedType inherits __toString from ReflectionType, which was deprecated in PHP 7.4 and un-deprecated in 8.0. Same cause as \\ReflectionType::__toString: the deprecation window has an upper bound that deprecatedSinceVersion cannot express.'
+            ),
+
+            // SplFileObject::fgetss — fgetss() was deprecated in PHP 7.3 and removed in 8.0
+            // (the stub records the removal as @removed 8.0). Case 2: PHP raised the
+            // deprecation as an E_DEPRECATED when the function was called and never set the
+            // reflection flag, so isDeprecated() is false for 7.3-7.4. The stub keeps
+            // #[Deprecated(since: '7.3')] so PhpStorm still warns users on those versions.
+            new ProblemDefinition(
+                entityType: EntityType::METHOD,
+                entityId: '\\SplFileObject::fgetss',
+                type: ProblemType::INTERNAL_IMPLEMENTATION,
+                affectedChecks: [CheckType::DEPRECATION],
+                versionRange: new PhpVersionRange(PhpVersions::PHP_7_3, PhpVersions::PHP_7_4),
+                reason: 'fgetss() was deprecated in PHP 7.3 and removed in 8.0. PHP emitted the deprecation as a call-time E_DEPRECATED rather than setting the reflection deprecation flag, so ReflectionMethod::isDeprecated() returns false for 7.3-7.4. The stub keeps #[Deprecated(since: \'7.3\')] so the IDE reports it; only the unverifiable comparison is skipped.'
+            ),
+
+            // SplTempFileObject extends SplFileObject and inherits fgetss.
+            new ProblemDefinition(
+                entityType: EntityType::METHOD,
+                entityId: '\\SplTempFileObject::fgetss',
+                type: ProblemType::INTERNAL_IMPLEMENTATION,
+                affectedChecks: [CheckType::DEPRECATION],
+                versionRange: new PhpVersionRange(PhpVersions::PHP_7_3, PhpVersions::PHP_7_4),
+                reason: 'SplTempFileObject extends SplFileObject and inherits fgetss. Same cause as \\SplFileObject::fgetss: the PHP 7.3 deprecation was call-time only and is not exposed through reflection.'
+            ),
+
+            // IntlDateFormatter::setTimeZoneId — deprecated in PHP 5.5 and removed in 7.0 (the
+            // stub records the removal as @removed 7.0). Case 2 again: the intl deprecation is
+            // documentation-level and not exposed through reflection, so isDeprecated() is
+            // false at 5.6 — the only cached version where the method still exists.
+            new ProblemDefinition(
+                entityType: EntityType::METHOD,
+                entityId: '\\IntlDateFormatter::setTimeZoneId',
+                type: ProblemType::INTERNAL_IMPLEMENTATION,
+                affectedChecks: [CheckType::DEPRECATION],
+                versionRange: new PhpVersionRange(PhpVersions::PHP_5_6, PhpVersions::PHP_5_6),
+                reason: 'IntlDateFormatter::setTimeZoneId was deprecated in PHP 5.5 and removed in 7.0, so 5.6 is the only validated version where it exists. The intl deprecation is documentation-level and never set the reflection deprecation flag, so isDeprecated() is false there. The stub keeps #[Deprecated(since: \'5.5\')] so the IDE reports it.'
+            ),
+
+            // SoapClient::__call — documented as deprecated in favour of __soapCall(), but PHP
+            // never set the reflection deprecation flag: isDeprecated() is false at every
+            // validated version (verified 5.6-8.6 against the committed caches). Case 2 again.
+            //
+            // The range is EARLIEST..LATEST because the gap is a property of ext-soap, not of a
+            // particular version, so it must keep applying to versions added later. The cost of
+            // that width: if PHP ever does flag the method, this entry hides the fact that the
+            // two sides finally agree instead of letting the check confirm it. Re-test by
+            // dropping this entry whenever ext-soap deprecations are revisited.
+            new ProblemDefinition(
+                entityType: EntityType::METHOD,
+                entityId: '\\SoapClient::__call',
+                type: ProblemType::INTERNAL_IMPLEMENTATION,
+                affectedChecks: [CheckType::DEPRECATION],
+                versionRange: new PhpVersionRange(PhpVersions::EARLIEST, PhpVersions::LATEST),
+                reason: 'SoapClient::__call is documented as deprecated in favour of SoapClient::__soapCall(), but ext-soap never set the reflection deprecation flag, so ReflectionMethod::isDeprecated() returns false for every validated version. The stub keeps #[Deprecated] so PhpStorm reports it; only the unverifiable comparison is skipped.'
             ),
         ];
 

--- a/tests/Framework/Validator/KnownProblems/ProblemType.php
+++ b/tests/Framework/Validator/KnownProblems/ProblemType.php
@@ -26,17 +26,30 @@ enum ProblemType: string
     case OVERLOADED_SIGNATURE = 'overloaded_signature';
 
     /**
-     * Stubs intentionally declare an interface or behaviour that is implemented
-     * internally (at the C level) but not exposed by PHP's reflection API.
+     * Stubs intentionally declare an interface, modifier or behaviour that PHP's reflection
+     * API does not report for the version under test.
      *
-     * Some internal classes implement interfaces through the C API without
-     * listing them in the class declaration visible to reflection.  Stubs add
-     * the explicit declaration so that IDEs (e.g. PhpStorm) can provide correct
-     * type-checking and code-completion.
+     * This is the general-purpose category for a stub/reflection divergence that is correct
+     * on the stub side. It covers three recurring shapes:
      *
-     * Example: SimpleXMLElement implements ArrayAccess at the C level;
-     * reflection never reports ArrayAccess, but PhpStorm requires the explicit
-     * declaration to enable array-offset type inference.
+     * 1. Implemented at the C level, never exposed. Some internal classes implement
+     *    interfaces through the C API without listing them in the declaration reflection
+     *    sees. Stubs add the explicit declaration so IDEs can type-check against it.
+     *    Example: SimpleXMLElement implements ArrayAccess at the C level; reflection never
+     *    reports it, but PhpStorm needs it for array-offset type inference.
+     *
+     * 2. A modifier that changed across versions. A stub carries one `final`/`static`
+     *    declaration for all versions, so it necessarily disagrees with reflection for the
+     *    versions before (or after) the change.
+     *    Example: GMP became final in 8.4, so the stub disagrees with reflection on 5.6-8.3.
+     *
+     * 3. A deprecation reflection does not expose. PHP raises some deprecations as a
+     *    call-time E_DEPRECATED, or documents them only, without setting the flag
+     *    ReflectionMethod::isDeprecated() reads. The stub keeps the marker so the IDE warns.
+     *    Example: fgetss() was deprecated in 7.3, but isDeprecated() is false for 7.3-7.4.
+     *
+     * Shape 3 also absorbs the case where the deprecation window has an upper bound, which
+     * StubsMetadata cannot express: it stores only a lower bound (deprecatedSinceVersion).
      */
     case INTERNAL_IMPLEMENTATION = 'internal_implementation';
 

--- a/tests/Framework/Validator/Services/DeprecationComparator.php
+++ b/tests/Framework/Validator/Services/DeprecationComparator.php
@@ -3,17 +3,44 @@
 namespace StubTests\Framework\Validator\Services;
 
 use StubTests\Framework\Model\PHPFunction;
+use StubTests\Framework\Model\PHPParameter;
 
 /**
- * Checks if a function/method is deprecated in reflection but not in stubs.
+ * Resolves deprecation state at a given PHP version, and compares the two sides.
  *
- * One-directional: reflection-deprecated -> stub must be deprecated.
- * The reverse is not enforced.
+ * Reflection reports deprecation for the single version it was captured under, so its flag is
+ * already version-specific. Stubs describe every version at once, so a stub flag alone says
+ * nothing about *when* deprecation starts — `#[Deprecated(since: '8.4')]` has to read as "not
+ * deprecated" on 8.3 and "deprecated" on 8.4. That version lives in
+ * {@see \StubTests\Framework\Model\StubsMetadata::getDeprecatedSinceVersion()}; without it,
+ * deprecation applies to every version, which is also how reflection-side elements behave
+ * (they carry no stub metadata at all).
  */
 final class DeprecationComparator
 {
-    public static function isMismatch(PHPFunction $reflCallable, PHPFunction $stubCallable): bool
+    /**
+     * Is the element deprecated as of $phpVersion?
+     */
+    public static function isDeprecatedIn(PHPFunction|PHPParameter $element, string $phpVersion): bool
     {
-        return $reflCallable->isDeprecated() && !$stubCallable->isDeprecated();
+        if (!$element->isDeprecated()) {
+            return false;
+        }
+
+        $since = $element->getStubsMetadata()?->getDeprecatedSinceVersion();
+
+        return $since === null || version_compare($phpVersion, $since, '>=');
+    }
+
+    /**
+     * Is the callable deprecated in reflection for $phpVersion but not in stubs?
+     *
+     * One-directional: reflection-deprecated -> stub must be deprecated. The reverse is not
+     * enforced here.
+     */
+    public static function isMismatch(PHPFunction $reflCallable, PHPFunction $stubCallable, string $phpVersion): bool
+    {
+        return self::isDeprecatedIn($reflCallable, $phpVersion)
+            && !self::isDeprecatedIn($stubCallable, $phpVersion);
     }
 }

--- a/tests/Unit/Parsers/AST/DeprecationParserTest.php
+++ b/tests/Unit/Parsers/AST/DeprecationParserTest.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace StubTests\Unit\Parsers\AST;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase as BaseTestCase;
+use StubTests\Framework\Parsers\Stubs\StubClassParser;
+use StubTests\Framework\Parsers\Stubs\StubFunctionParser;
+use StubTests\Framework\Parsers\Stubs\Versions\DeprecationParser;
+use StubTests\Framework\Runner\PhpVersions;
+use StubTests\Unit\Parsers\AST\fixtures\FixtureStubsDataProvider;
+
+/**
+ * Covers extraction of the deprecation version — `#[Deprecated(since:)]` and
+ * `@_deprecated <version>` — into StubsMetadata::getDeprecatedSinceVersion().
+ *
+ * Parsing goes through extractAndParseAll() rather than the single-entity parse() convenience
+ * method, because only the former supplies the import map. Resolving `Deprecated` through
+ * imports is what distinguishes the JetBrains attribute from the built-in one, and the two
+ * order their positional arguments differently.
+ */
+class DeprecationParserTest extends BaseTestCase
+{
+    private StubFunctionParser $functionParser;
+    private StubClassParser $classParser;
+    private FixtureStubsDataProvider $filesProvider;
+
+    protected function setUp(): void
+    {
+        $this->functionParser = new StubFunctionParser();
+        $this->classParser = new StubClassParser();
+        $this->filesProvider = new FixtureStubsDataProvider(__DIR__ . '/fixtures/Deprecation');
+    }
+
+    /**
+     * Attribute forms are single-line variants of one construct, so the code stays next to the
+     * version it is expected to yield. The PhpDoc forms need a docblock and live in fixtures —
+     * see {@see phpDocDeprecationProvider}.
+     */
+    public static function attributeDeprecationProvider(): array
+    {
+        return [
+            'not deprecated' => [
+                '<?php function f(): void {}',
+                false,
+                null,
+            ],
+            'JetBrains attribute, named since' => [
+                '<?php use JetBrains\PhpStorm\Deprecated; #[Deprecated("reason", since: "8.4")] function f(): void {}',
+                true,
+                '8.4',
+            ],
+            'JetBrains attribute, no since' => [
+                '<?php use JetBrains\PhpStorm\Deprecated; #[Deprecated("reason")] function f(): void {}',
+                true,
+                null,
+            ],
+            'JetBrains attribute, bare' => [
+                '<?php use JetBrains\PhpStorm\Deprecated; #[Deprecated] function f(): void {}',
+                true,
+                null,
+            ],
+            // JetBrains signature is ($reason, $replacement, $since) — since is argument 2.
+            'JetBrains attribute, positional since' => [
+                '<?php use JetBrains\PhpStorm\Deprecated; #[Deprecated("reason", "replacement", "8.4")] function f(): void {}',
+                true,
+                '8.4',
+            ],
+            'JetBrains attribute, fully qualified' => [
+                '<?php #[\JetBrains\PhpStorm\Deprecated(since: "7.3")] function f(): void {}',
+                true,
+                '7.3',
+            ],
+            'built-in attribute, bare' => [
+                '<?php #[Deprecated] function f(): void {}',
+                true,
+                null,
+            ],
+            'built-in attribute, named since' => [
+                '<?php #[Deprecated(message: "msg", since: "8.5")] function f(): void {}',
+                true,
+                '8.5',
+            ],
+            // Built-in signature is ($message, $since) — since is argument 1, not 2.
+            'built-in attribute, positional since' => [
+                '<?php #[Deprecated("msg", "8.4")] function f(): void {}',
+                true,
+                '8.4',
+            ],
+        ];
+    }
+
+    #[DataProvider('attributeDeprecationProvider')]
+    public function testItParsesDeprecationFromAttributes(string $stubCode, bool $expectedDeprecated, ?string $expectedSince)
+    {
+        $function = $this->functionParser->extractAndParseAll($stubCode)[0];
+
+        self::assertSame($expectedDeprecated, $function->isDeprecated());
+        self::assertSame($expectedSince, $function->getStubsMetadata()?->getDeprecatedSinceVersion());
+    }
+
+    public static function phpDocDeprecationProvider(): array
+    {
+        return [
+            'PhpDoc tag with PHP version' => ['phpdoc_php_version.txt', '7.1'],
+            'PhpDoc tag with patch version narrows to the minor' => ['phpdoc_patch_version.txt', '7.0'],
+            // A library version in that slot must not be read as a language level.
+            'PhpDoc tag with library version' => ['phpdoc_library_version.txt', null],
+            'PhpDoc tag without version' => ['phpdoc_without_version.txt', null],
+            'attribute overrides PhpDoc tag' => ['attribute_overrides_phpdoc.txt', '8.0'],
+            'attribute without since does not clear the PhpDoc version' => ['attribute_without_since_keeps_phpdoc.txt', '7.1'],
+        ];
+    }
+
+    #[DataProvider('phpDocDeprecationProvider')]
+    public function testItParsesDeprecationFromPhpDoc(string $fixtureFile, ?string $expectedSince)
+    {
+        $stubCode = $this->filesProvider->getStubFileContent($fixtureFile);
+        $function = $this->functionParser->extractAndParseAll($stubCode)[0];
+
+        self::assertTrue($function->isDeprecated());
+        self::assertSame($expectedSince, $function->getStubsMetadata()?->getDeprecatedSinceVersion());
+    }
+
+    public function testItParsesMethodDeprecationVersion()
+    {
+        $stubCode = '<?php use JetBrains\PhpStorm\Deprecated; class C { #[Deprecated("reason", since: "8.4")] public function m(): void {} }';
+        $method = $this->classParser->extractAndParseAll($stubCode)[0]->getMethods()[0];
+
+        self::assertTrue($method->isDeprecated());
+        self::assertSame('8.4', $method->getStubsMetadata()?->getDeprecatedSinceVersion());
+    }
+
+    public function testItParsesParameterDeprecationVersion()
+    {
+        $stubCode = '<?php use JetBrains\PhpStorm\Deprecated; class C { public function m(#[Deprecated(since: "8.2")] $p, $q): void {} }';
+        $parameters = $this->classParser->extractAndParseAll($stubCode)[0]->getMethods()[0]->getParameters();
+
+        self::assertTrue($parameters[0]->isDeprecated());
+        self::assertSame('8.2', $parameters[0]->getStubsMetadata()?->getDeprecatedSinceVersion());
+
+        self::assertFalse($parameters[1]->isDeprecated());
+        self::assertNull($parameters[1]->getStubsMetadata()?->getDeprecatedSinceVersion());
+    }
+
+    /**
+     * A version is only carried when the element is actually deprecated, so a stale `@_deprecated`
+     * version can never leak onto a non-deprecated element.
+     */
+    public function testItLeavesTheVersionNullWhenNotDeprecated()
+    {
+        $function = $this->functionParser->extractAndParseAll('<?php /** @since 7.0 */ function f(): void {}')[0];
+
+        self::assertFalse($function->isDeprecated());
+        self::assertNull($function->getStubsMetadata()?->getDeprecatedSinceVersion());
+    }
+
+    public static function phpVersionNormalizationProvider(): array
+    {
+        return [
+            'known minor' => ['8.4', '8.4'],
+            'earliest supported' => ['5.6', '5.6'],
+            'patch narrows to minor' => ['7.0.7', '7.0'],
+            'PHP version older than the suite covers' => ['5.3', null],
+            'library version' => ['2.3.0', null],
+            // Deliberately a version that can never be added to PhpVersions. Using a plausible
+            // next release (9.0) would turn this case into a false failure the day it ships.
+            'unrecognised version' => ['99.0', null],
+            'not a version' => ['use g() instead', null],
+            'empty' => ['', null],
+        ];
+    }
+
+    #[DataProvider('phpVersionNormalizationProvider')]
+    public function testItAcceptsOnlyKnownPhpVersionsFromPhpDoc(string $version, ?string $expected)
+    {
+        self::assertSame($expected, DeprecationParser::normalizePhpVersion($version));
+    }
+
+    /**
+     * Guards the boundary the filter silently depends on. If the newest supported version ever
+     * stopped being recognised, every `@_deprecated <newest>` would collapse to null — i.e. to
+     * "deprecated in every version" — which is the widest possible claim and the opposite of
+     * what the tag says. The failure would otherwise be silent.
+     */
+    public function testItAcceptsTheNewestAndOldestSupportedPhpVersions()
+    {
+        $latest = PhpVersions::LATEST->value;
+        $earliest = PhpVersions::EARLIEST->value;
+
+        self::assertSame($latest, DeprecationParser::normalizePhpVersion($latest));
+        self::assertSame($earliest, DeprecationParser::normalizePhpVersion($earliest));
+    }
+}

--- a/tests/Unit/Parsers/AST/fixtures/Deprecation/attribute_overrides_phpdoc.txt
+++ b/tests/Unit/Parsers/AST/fixtures/Deprecation/attribute_overrides_phpdoc.txt
@@ -1,0 +1,9 @@
+<?php
+
+use JetBrains\PhpStorm\Deprecated;
+
+/**
+ * @deprecated 7.1
+ */
+#[Deprecated(since: '8.0')]
+function f(): void {}

--- a/tests/Unit/Parsers/AST/fixtures/Deprecation/attribute_without_since_keeps_phpdoc.txt
+++ b/tests/Unit/Parsers/AST/fixtures/Deprecation/attribute_without_since_keeps_phpdoc.txt
@@ -1,0 +1,9 @@
+<?php
+
+use JetBrains\PhpStorm\Deprecated;
+
+/**
+ * @deprecated 7.1
+ */
+#[Deprecated('reason')]
+function f(): void {}

--- a/tests/Unit/Parsers/AST/fixtures/Deprecation/phpdoc_library_version.txt
+++ b/tests/Unit/Parsers/AST/fixtures/Deprecation/phpdoc_library_version.txt
@@ -1,0 +1,8 @@
+<?php
+
+/**
+ * Extensions versioned independently of PHP put their own version in this slot.
+ *
+ * @deprecated 2.3.0 use g() instead
+ */
+function f(): void {}

--- a/tests/Unit/Parsers/AST/fixtures/Deprecation/phpdoc_patch_version.txt
+++ b/tests/Unit/Parsers/AST/fixtures/Deprecation/phpdoc_patch_version.txt
@@ -1,0 +1,6 @@
+<?php
+
+/**
+ * @deprecated 7.0.7
+ */
+function f(): void {}

--- a/tests/Unit/Parsers/AST/fixtures/Deprecation/phpdoc_php_version.txt
+++ b/tests/Unit/Parsers/AST/fixtures/Deprecation/phpdoc_php_version.txt
@@ -1,0 +1,6 @@
+<?php
+
+/**
+ * @deprecated 7.1 use g() instead
+ */
+function f(): void {}

--- a/tests/Unit/Parsers/AST/fixtures/Deprecation/phpdoc_without_version.txt
+++ b/tests/Unit/Parsers/AST/fixtures/Deprecation/phpdoc_without_version.txt
@@ -1,0 +1,6 @@
+<?php
+
+/**
+ * @deprecated
+ */
+function f(): void {}

--- a/tests/Unit/Parsers/Serialization/StubsEntitySerializerTest.php
+++ b/tests/Unit/Parsers/Serialization/StubsEntitySerializerTest.php
@@ -754,4 +754,64 @@ class StubsEntitySerializerTest extends TestCase
 
         self::assertSame(['Countable'], $result['parentInterfaces']);
     }
+
+    public function testFunctionDeprecatedSinceVersionSurvivesARoundtrip(): void
+    {
+        $function = new PHPFunction();
+        $function->setName('testFunction');
+        $function->setId('\\testFunction');
+        $function->setDeprecated(true);
+        $function->initStubsMetadata()->setDeprecatedSinceVersion('8.4');
+
+        $result = $this->serializer->serialize($function);
+        self::assertSame('8.4', $result['deprecatedSinceVersion']);
+
+        $restored = $this->serializer->deserialize($result);
+        self::assertTrue($restored->isDeprecated());
+        self::assertSame('8.4', $restored->getStubsMetadata()?->getDeprecatedSinceVersion());
+    }
+
+    public function testMethodAndParameterDeprecatedSinceVersionSurviveARoundtrip(): void
+    {
+        $parameter = new PHPParameter('deprecatedParam');
+        $parameter->setDeprecated(true);
+        $parameter->initStubsMetadata()->setDeprecatedSinceVersion('8.2');
+
+        $method = new PHPMethod();
+        $method->setName('testMethod');
+        $method->setAccess(AccessModifier::PUBLIC);
+        $method->setDeprecated(true);
+        $method->setParameters([$parameter]);
+        $method->initStubsMetadata()->setDeprecatedSinceVersion('8.4');
+
+        $class = new PHPClass();
+        $class->setName('TestClass');
+        $class->setId('\\TestClass');
+        $class->addMethod($method);
+
+        $result = $this->serializer->serialize($class);
+        self::assertSame('8.4', $result['methods'][0]['deprecatedSinceVersion']);
+        self::assertSame('8.2', $result['methods'][0]['parameters'][0]['deprecatedSinceVersion']);
+
+        $restoredMethod = $this->serializer->deserialize($result)->getMethods()[0];
+        self::assertSame('8.4', $restoredMethod->getStubsMetadata()?->getDeprecatedSinceVersion());
+        self::assertSame('8.2', $restoredMethod->getParameters()[0]->getStubsMetadata()?->getDeprecatedSinceVersion());
+    }
+
+    /**
+     * Caches written before the field existed simply have no key; deserialization must treat
+     * that as "no version recorded" rather than fail.
+     */
+    public function testMissingDeprecatedSinceVersionDeserializesToNull(): void
+    {
+        $restored = $this->serializer->deserialize([
+            '_type' => 'PHPFunction',
+            'name' => 'legacyFunction',
+            'id' => '\\legacyFunction',
+            'isDeprecated' => true,
+        ]);
+
+        self::assertTrue($restored->isDeprecated());
+        self::assertNull($restored->getStubsMetadata()?->getDeprecatedSinceVersion());
+    }
 }

--- a/tests/Unit/Validator/CheckTestCase.php
+++ b/tests/Unit/Validator/CheckTestCase.php
@@ -183,9 +183,18 @@ abstract class CheckTestCase extends TestCase
      * @param mixed|null $type Parameter type (optional)
      * @param string|null $sinceVersion Version when parameter was introduced (optional)
      * @param string|null $removedVersion Version when parameter was removed (optional)
+     * @param bool $isDeprecated Whether the parameter is marked deprecated
+     * @param string|null $deprecatedSinceVersion PHP version the deprecation starts at; null
+     *                                            means "deprecated in every version"
      */
-    protected function createMockParameter(string $name, $type = null, ?string $sinceVersion = null, ?string $removedVersion = null): PHPParameter
-    {
+    protected function createMockParameter(
+        string $name,
+        $type = null,
+        ?string $sinceVersion = null,
+        ?string $removedVersion = null,
+        bool $isDeprecated = false,
+        ?string $deprecatedSinceVersion = null,
+    ): PHPParameter {
         $parameter = new PHPParameter($name);
         if ($type !== null) {
             $parameter->setType($type);
@@ -193,6 +202,10 @@ abstract class CheckTestCase extends TestCase
         if ($sinceVersion !== null || $removedVersion !== null) {
             $parameter->initStubsMetadata()->setSinceVersion($sinceVersion);
             $parameter->initStubsMetadata()->setRemovedVersion($removedVersion);
+        }
+        $parameter->setDeprecated($isDeprecated);
+        if ($deprecatedSinceVersion !== null) {
+            $parameter->initStubsMetadata()->setDeprecatedSinceVersion($deprecatedSinceVersion);
         }
 
         return $parameter;
@@ -328,6 +341,7 @@ abstract class CheckTestCase extends TestCase
         bool $isStatic = false,
         bool $isDeprecated = false,
         bool $isTentative = false,
+        ?string $deprecatedSinceVersion = null,
     ): PHPMethod {
         $method = new PHPMethod();
         $method->setName($name);
@@ -344,6 +358,9 @@ abstract class CheckTestCase extends TestCase
             $method->initStubsMetadata()->setSinceVersion($sinceVersion);
             $method->initStubsMetadata()->setRemovedVersion($removedVersion);
         }
+        if ($deprecatedSinceVersion !== null) {
+            $method->initStubsMetadata()->setDeprecatedSinceVersion($deprecatedSinceVersion);
+        }
         return $method;
     }
 
@@ -359,6 +376,7 @@ abstract class CheckTestCase extends TestCase
         bool $isDeprecated = false,
         bool $isTentative = false,
         ?string $typeFromPhpDoc = null,
+        ?string $deprecatedSinceVersion = null,
     ): PHPFunction {
         $function = new PHPFunction();
         $function->setId($id);
@@ -375,6 +393,9 @@ abstract class CheckTestCase extends TestCase
         }
         if ($typeFromPhpDoc !== null) {
             $function->initStubsMetadata()->setTypeFromPhpDoc($typeFromPhpDoc);
+        }
+        if ($deprecatedSinceVersion !== null) {
+            $function->initStubsMetadata()->setDeprecatedSinceVersion($deprecatedSinceVersion);
         }
         return $function;
     }
@@ -429,6 +450,7 @@ abstract class CheckTestCase extends TestCase
         mixed $defaultValue = null,
         ?array $languageLevelTypes = null,
         ?string $defaultType = null,
+        ?string $deprecatedSinceVersion = null,
     ): PHPParameter {
         $param = new PHPParameter($name);
         if ($type !== null) {
@@ -450,6 +472,9 @@ abstract class CheckTestCase extends TestCase
         }
         if ($defaultType !== null) {
             $param->initStubsMetadata()->setDefaultType($defaultType);
+        }
+        if ($deprecatedSinceVersion !== null) {
+            $param->initStubsMetadata()->setDeprecatedSinceVersion($deprecatedSinceVersion);
         }
         return $param;
     }

--- a/tests/Unit/Validator/Classes/Methods/ClassMethodsParameterDeprecationCheckTest.php
+++ b/tests/Unit/Validator/Classes/Methods/ClassMethodsParameterDeprecationCheckTest.php
@@ -152,6 +152,53 @@ class ClassMethodsParameterDeprecationCheckTest extends CheckTestCase
         $this->assertStringContainsString('deprecated in PHP 8.0', $result->getFailures()[$failureKey]);
     }
 
+    // ── Version-aware stub deprecation ────────────────────────────────────────
+
+    public function testStubParameterDeprecationStartingLaterDoesNotSatisfyReflection(): void
+    {
+        // The stub deprecates $case_insensitive only from 8.4, so at 8.0 it does not answer
+        // the reflection deprecation.
+        $className = '\MyClass';
+
+        $reflMethod = $this->createMockMethod('define', [$this->makeParam('case_insensitive', deprecated: true)]);
+        $stubMethod = $this->createMockMethod('define', [
+            $this->makeParam('case_insensitive', deprecated: true, deprecatedSinceVersion: '8.4'),
+        ]);
+
+        $reflClass = $this->createMockClassWithProperties($className, null, null, null, [$reflMethod]);
+        $stubClass = $this->createMockClassWithProperties($className, null, null, null, [$stubMethod]);
+
+        $provider = $this->createMockReflectionProvider([], [$reflClass]);
+        $stubs = $this->createMockStorageManager();
+        $stubs->method('getClasses')->willReturn([$stubClass]);
+
+        $result = (new ClassMethodsParameterDeprecationCheck($provider))->run($stubs, $className, '8.0');
+
+        $this->assertTrue($result->hasFailures());
+        $this->assertStringContainsString('$case_insensitive', $result->getFailures()[$className . '::define']);
+    }
+
+    public function testStubParameterDeprecationSatisfiesReflectionFromItsSinceVersionOnwards(): void
+    {
+        $className = '\MyClass';
+
+        $reflMethod = $this->createMockMethod('define', [$this->makeParam('case_insensitive', deprecated: true)]);
+        $stubMethod = $this->createMockMethod('define', [
+            $this->makeParam('case_insensitive', deprecated: true, deprecatedSinceVersion: '8.4'),
+        ]);
+
+        $reflClass = $this->createMockClassWithProperties($className, null, null, null, [$reflMethod]);
+        $stubClass = $this->createMockClassWithProperties($className, null, null, null, [$stubMethod]);
+
+        $provider = $this->createMockReflectionProvider([], [$reflClass]);
+        $stubs = $this->createMockStorageManager();
+        $stubs->method('getClasses')->willReturn([$stubClass]);
+
+        $result = (new ClassMethodsParameterDeprecationCheck($provider))->run($stubs, $className, '8.4');
+
+        $this->assertFalse($result->hasFailures());
+    }
+
     public function testDeprecatedInStubsButNotInReflectionIsSuccess(): void
     {
         // One-way check: stubs can be more conservative

--- a/tests/Unit/Validator/Classes/Methods/MethodDeprecationCheckTest.php
+++ b/tests/Unit/Validator/Classes/Methods/MethodDeprecationCheckTest.php
@@ -180,9 +180,9 @@ class MethodDeprecationCheckTest extends CheckTestCase
         $this->assertStringContainsString('not marked as deprecated in stubs', $result->getFailures()[$failureKey]);
     }
 
-    public function testDeprecatedInStubsButNotInReflectionIsSuccess(): void
+    public function testDeprecatedInStubsButNotInReflectionIsFailure(): void
     {
-        // One-way check: stubs can be more conservative
+        // Both sides must agree, so a stub-only deprecation is reported too.
         $className = '\MyClass';
 
         $reflClass = $this->createMockClassWithProperties(
@@ -206,7 +206,70 @@ class MethodDeprecationCheckTest extends CheckTestCase
 
         $result = (new MethodDeprecationCheck($provider))->run($stubs, $className, '8.0');
 
+        $this->assertTrue($result->hasFailures());
+        $failureKey = $className . '::forwardDeprecated';
+        $this->assertStringContainsString(
+            'marked as deprecated in stubs but is not deprecated in PHP 8.0',
+            $result->getFailures()[$failureKey]
+        );
+    }
+
+    public function testStubDeprecationStartingLaterThanTheVersionUnderTestIsNotAMismatch(): void
+    {
+        // #[Deprecated(since: '8.4')] must read as "not deprecated" on 8.0, matching reflection.
+        $className = '\MyClass';
+
+        $reflClass = $this->createMockClassWithProperties(
+            $className,
+            null,
+            null,
+            null,
+            [$this->makeMethod('laterDeprecated')]
+        );
+        $stubClass = $this->createMockClassWithProperties(
+            $className,
+            null,
+            null,
+            null,
+            [$this->makeMethod('laterDeprecated', isDeprecated: true, deprecatedSinceVersion: '8.4')]
+        );
+
+        $provider = $this->createMockReflectionProvider([], [$reflClass]);
+        $stubs = $this->createMockStorageManager();
+        $stubs->method('getClasses')->willReturn([$stubClass]);
+
+        $result = (new MethodDeprecationCheck($provider))->run($stubs, $className, '8.0');
+
         $this->assertFalse($result->hasFailures());
+    }
+
+    public function testStubDeprecationIsEnforcedFromItsSinceVersionOnwards(): void
+    {
+        // Same stub, now validated at 8.4: the deprecation applies, so reflection must agree.
+        $className = '\MyClass';
+
+        $reflClass = $this->createMockClassWithProperties(
+            $className,
+            null,
+            null,
+            null,
+            [$this->makeMethod('laterDeprecated')]
+        );
+        $stubClass = $this->createMockClassWithProperties(
+            $className,
+            null,
+            null,
+            null,
+            [$this->makeMethod('laterDeprecated', isDeprecated: true, deprecatedSinceVersion: '8.4')]
+        );
+
+        $provider = $this->createMockReflectionProvider([], [$reflClass]);
+        $stubs = $this->createMockStorageManager();
+        $stubs->method('getClasses')->willReturn([$stubClass]);
+
+        $result = (new MethodDeprecationCheck($provider))->run($stubs, $className, '8.4');
+
+        $this->assertTrue($result->hasFailures());
     }
 
     public function testMethodMissingFromStubsIsNotReportedAsDeprecationMismatch(): void

--- a/tests/Unit/Validator/Enums/EnumMethodDeprecationCheckTest.php
+++ b/tests/Unit/Validator/Enums/EnumMethodDeprecationCheckTest.php
@@ -56,10 +56,10 @@ class EnumMethodDeprecationCheckTest extends CheckTestCase
         $this->assertStringNotContainsString('Class', $failures[$enumId . '::cases']);
     }
 
-    public function testDeprecatedStubWithNonDeprecatedReflectionPasses(): void
+    public function testDeprecatedStubWithNonDeprecatedReflectionIsFailure(): void
     {
         $enumId = '\RoundingMode';
-        // Reflection says NOT deprecated, stub says deprecated → OK (one-directional)
+        // Reflection says NOT deprecated, stub says deprecated → failure (both sides must agree)
         $reflEnum = $this->makeEnum($enumId, [$this->makeMethod('cases')]);
         $stubEnum = $this->makeEnum($enumId, [$this->makeMethod('cases', isDeprecated: true)]);
 
@@ -69,6 +69,6 @@ class EnumMethodDeprecationCheckTest extends CheckTestCase
 
         $result = (new MethodDeprecationCheck(reflectionProvider: $provider, entityTypeConfig: EntityTypeConfig::forEnum()))->run($stubs, $enumId, '8.1');
 
-        $this->assertFalse($result->hasFailures());
+        $this->assertTrue($result->hasFailures());
     }
 }

--- a/tests/Unit/Validator/Functions/FunctionDeprecationCheckTest.php
+++ b/tests/Unit/Validator/Functions/FunctionDeprecationCheckTest.php
@@ -124,6 +124,43 @@ class FunctionDeprecationCheckTest extends CheckTestCase
         $this->assertStringContainsString('not marked as deprecated in stubs', $result->getFailures()[$id]);
     }
 
+    // ── Version-aware stub deprecation ────────────────────────────────────────
+
+    public function testStubDeprecationStartingLaterThanTheVersionUnderTestDoesNotSatisfyReflection(): void
+    {
+        // #[Deprecated(since: '8.4')] must read as "not deprecated" on 8.1, so a reflection
+        // deprecation at 8.1 is still an unmet obligation.
+        $id = '\\strftime';
+
+        $provider = $this->createMockReflectionProvider([$this->makeFunction($id, isDeprecated: true)]);
+        $stubs = $this->createMockStorageManager();
+        $stubs->method('getFunctions')->willReturn([
+            $this->makeFunction($id, isDeprecated: true, deprecatedSinceVersion: '8.4'),
+        ]);
+
+        $result = (new FunctionDeprecationCheck($provider))->run($stubs, $id, '8.1');
+
+        $this->assertTrue($result->hasFailures());
+        $this->assertStringContainsString('not marked as deprecated in stubs', $result->getFailures()[$id]);
+    }
+
+    public function testStubDeprecationSatisfiesReflectionFromItsSinceVersionOnwards(): void
+    {
+        // Same stub, now validated at 8.4: the deprecation applies and the sides agree.
+        $id = '\\strftime';
+
+        $provider = $this->createMockReflectionProvider([$this->makeFunction($id, isDeprecated: true)]);
+        $stubs = $this->createMockStorageManager();
+        $stubs->method('getFunctions')->willReturn([
+            $this->makeFunction($id, isDeprecated: true, deprecatedSinceVersion: '8.4'),
+        ]);
+
+        $result = (new FunctionDeprecationCheck($provider))->run($stubs, $id, '8.4');
+
+        $this->assertFalse($result->hasFailures());
+        $this->assertEquals(1, $result->getSuccessCount());
+    }
+
     public function testDeprecatedInStubsButNotInReflectionIsSuccess(): void
     {
         // One-way check: stubs can be more conservative

--- a/tests/Unit/Validator/Functions/FunctionParameterDeprecationCheckTest.php
+++ b/tests/Unit/Validator/Functions/FunctionParameterDeprecationCheckTest.php
@@ -139,6 +139,49 @@ class FunctionParameterDeprecationCheckTest extends CheckTestCase
         $this->assertStringContainsString('deprecated in PHP 8.0', $result->getFailures()[$id]);
     }
 
+    // ── Version-aware stub deprecation ────────────────────────────────────────
+
+    public function testStubParameterDeprecationStartingLaterDoesNotSatisfyReflection(): void
+    {
+        // The stub deprecates $case_insensitive only from 8.4, so at 8.0 the reflection
+        // deprecation is still unmatched.
+        $id = '\\define';
+
+        $provider = $this->createMockReflectionProvider([
+            $this->makeFunction($id, [$this->makeParam('case_insensitive', deprecated: true)])
+        ]);
+        $stubs = $this->createMockStorageManager();
+        $stubs->method('getFunctions')->willReturn([
+            $this->makeFunction($id, [
+                $this->makeParam('case_insensitive', deprecated: true, deprecatedSinceVersion: '8.4'),
+            ])
+        ]);
+
+        $result = (new FunctionParameterDeprecationCheck($provider))->run($stubs, $id, '8.0');
+
+        $this->assertTrue($result->hasFailures());
+        $this->assertStringContainsString('$case_insensitive', $result->getFailures()[$id]);
+    }
+
+    public function testStubParameterDeprecationSatisfiesReflectionFromItsSinceVersionOnwards(): void
+    {
+        $id = '\\define';
+
+        $provider = $this->createMockReflectionProvider([
+            $this->makeFunction($id, [$this->makeParam('case_insensitive', deprecated: true)])
+        ]);
+        $stubs = $this->createMockStorageManager();
+        $stubs->method('getFunctions')->willReturn([
+            $this->makeFunction($id, [
+                $this->makeParam('case_insensitive', deprecated: true, deprecatedSinceVersion: '8.4'),
+            ])
+        ]);
+
+        $result = (new FunctionParameterDeprecationCheck($provider))->run($stubs, $id, '8.4');
+
+        $this->assertFalse($result->hasFailures());
+    }
+
     public function testDeprecatedInStubsButNotInReflectionIsSuccess(): void
     {
         // One-way check: stubs can be more conservative

--- a/tests/Unit/Validator/Interfaces/InterfaceMethodDeprecationCheckTest.php
+++ b/tests/Unit/Validator/Interfaces/InterfaceMethodDeprecationCheckTest.php
@@ -122,7 +122,7 @@ class InterfaceMethodDeprecationCheckTest extends CheckTestCase
         $this->assertStringContainsString('deprecated', $failures[$interfaceId . '::oldMethod']);
     }
 
-    public function testStubDeprecatedReflectionNotIsNotReported(): void
+    public function testStubDeprecatedReflectionNotIsFailure(): void
     {
         // One-directional: only reflection-deprecated → stub must be deprecated.
         $interfaceId = '\MyInterface';
@@ -135,7 +135,7 @@ class InterfaceMethodDeprecationCheckTest extends CheckTestCase
 
         $result = (new MethodDeprecationCheck(reflectionProvider: $provider, entityTypeConfig: EntityTypeConfig::forInterface()))->run($stubs, $interfaceId, '8.0');
 
-        $this->assertFalse($result->hasFailures());
+        $this->assertTrue($result->hasFailures());
     }
 
     // ── Parent interface traversal ────────────────────────────────────────────

--- a/tests/Unit/Validator/Services/DeprecationComparatorTest.php
+++ b/tests/Unit/Validator/Services/DeprecationComparatorTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace StubTests\Unit\Validator\Services;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use StubTests\Framework\Model\PHPFunction;
+use StubTests\Framework\Model\PHPParameter;
+use StubTests\Framework\Validator\Services\DeprecationComparator;
+
+class DeprecationComparatorTest extends TestCase
+{
+    private static function makeFunction(bool $isDeprecated, ?string $deprecatedSince): PHPFunction
+    {
+        $function = new PHPFunction();
+        $function->setName('f');
+        $function->setDeprecated($isDeprecated);
+        $function->initStubsMetadata()->setDeprecatedSinceVersion($deprecatedSince);
+
+        return $function;
+    }
+
+    public static function deprecatedInProvider(): array
+    {
+        return [
+            'not deprecated at all' => [false, null, '8.4', false],
+            'deprecated without a version applies everywhere' => [true, null, '5.6', true],
+            'version under test is below since' => [true, '8.4', '8.3', false],
+            'version under test equals since' => [true, '8.4', '8.4', true],
+            'version under test is above since' => [true, '8.4', '8.5', true],
+            // Some stubs declare a since older than the earliest version validated here.
+            'since older than the suite covers' => [true, '5.3', '5.6', true],
+        ];
+    }
+
+    #[DataProvider('deprecatedInProvider')]
+    public function testItResolvesDeprecationAtAVersion(
+        bool $isDeprecated,
+        ?string $deprecatedSince,
+        string $phpVersion,
+        bool $expected
+    ): void {
+        self::assertSame($expected, DeprecationComparator::isDeprecatedIn(self::makeFunction($isDeprecated, $deprecatedSince), $phpVersion));
+    }
+
+    /**
+     * Reflection-side elements carry no stub metadata, so their flag has to be taken verbatim.
+     */
+    public function testItTreatsAnElementWithoutStubMetadataAsDeprecatedEverywhere(): void
+    {
+        $function = new PHPFunction();
+        $function->setName('f');
+        $function->setDeprecated(true);
+
+        self::assertNull($function->getStubsMetadata());
+        self::assertTrue(DeprecationComparator::isDeprecatedIn($function, '5.6'));
+    }
+
+    public function testItResolvesParameterDeprecation(): void
+    {
+        $parameter = new PHPParameter('p');
+        $parameter->setDeprecated(true);
+        $parameter->initStubsMetadata()->setDeprecatedSinceVersion('8.1');
+
+        self::assertFalse(DeprecationComparator::isDeprecatedIn($parameter, '8.0'));
+        self::assertTrue(DeprecationComparator::isDeprecatedIn($parameter, '8.1'));
+    }
+
+    public function testItReportsAMismatchWhenTheStubDeprecationStartsLater(): void
+    {
+        $reflection = self::makeFunction(true, null);
+        $stub = self::makeFunction(true, '8.5');
+
+        self::assertTrue(DeprecationComparator::isMismatch($reflection, $stub, '8.4'));
+        self::assertFalse(DeprecationComparator::isMismatch($reflection, $stub, '8.5'));
+    }
+
+    public function testItReportsNoMismatchWhenOnlyTheStubIsDeprecated(): void
+    {
+        // isMismatch stays one-directional: a stub-only deprecation is not its concern.
+        $reflection = self::makeFunction(false, null);
+        $stub = self::makeFunction(true, null);
+
+        self::assertFalse(DeprecationComparator::isMismatch($reflection, $stub, '8.4'));
+    }
+}

--- a/tests/cache/StubsEnums.json
+++ b/tests/cache/StubsEnums.json
@@ -32,6 +32,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -58,7 +59,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "static",
@@ -66,6 +68,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -92,7 +95,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "static|null",
@@ -100,6 +104,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -145,6 +150,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -162,6 +168,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -179,6 +186,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -270,6 +278,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -310,6 +319,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -336,7 +346,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "static",
@@ -344,6 +355,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -370,7 +382,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "static|null",
@@ -378,6 +391,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -421,6 +435,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -493,6 +508,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -749,6 +765,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -841,6 +858,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null

--- a/tests/cache/StubsInterfaces.json
+++ b/tests/cache/StubsInterfaces.json
@@ -23,6 +23,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -66,7 +67,8 @@
                         },
                         "defaultType": "",
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "bool",
@@ -74,6 +76,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "bool",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -102,7 +105,8 @@
                         },
                         "defaultType": "",
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "mixed",
@@ -110,6 +114,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "TValue",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -138,7 +143,8 @@
                         },
                         "defaultType": "",
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     },
                     {
                         "name": "value",
@@ -156,7 +162,8 @@
                         },
                         "defaultType": "",
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -164,6 +171,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "void",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -192,7 +200,8 @@
                         },
                         "defaultType": "",
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -200,6 +209,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "void",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -241,7 +251,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "static",
@@ -249,6 +260,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "static",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -275,7 +287,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "static|null",
@@ -283,6 +296,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "static|null",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -317,6 +331,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -334,6 +349,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -351,6 +367,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "array",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -368,6 +385,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\Cassandra\\Function_",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -385,6 +403,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\Cassandra\\Function_",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -402,6 +421,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\Cassandra\\Value",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -419,6 +439,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\Cassandra\\Type",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -436,6 +457,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\Cassandra\\Type",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -453,6 +475,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -494,7 +517,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "",
@@ -502,6 +526,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\Cassandra\\Session",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -528,7 +553,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "",
@@ -536,6 +562,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\Cassandra\\Future",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -568,6 +595,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -585,6 +613,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\Cassandra\\Type",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -602,6 +631,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "bool",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -619,6 +649,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "bool",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -636,6 +667,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "bool",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -653,6 +685,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -670,6 +703,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -716,6 +750,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -733,6 +768,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -750,6 +786,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "array",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -767,6 +804,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\Cassandra\\Type",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -784,6 +822,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -801,6 +840,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -818,6 +858,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -835,6 +876,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "bool",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -876,7 +918,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "",
@@ -884,6 +927,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "mixed",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -916,6 +960,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -933,6 +978,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -950,6 +996,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -976,7 +1023,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "",
@@ -984,6 +1032,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\Cassandra\\Value",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -1001,6 +1050,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "array",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -1018,6 +1068,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -1035,6 +1086,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "bool",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -1067,6 +1119,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -1084,6 +1137,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -1101,6 +1155,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\Cassandra\\Map",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -1118,6 +1173,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -1144,7 +1200,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "",
@@ -1152,6 +1209,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\Cassandra\\Table|null",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -1169,6 +1227,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "array",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -1195,7 +1254,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "",
@@ -1203,6 +1263,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\Cassandra\\Type\\UserType|null",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -1220,6 +1281,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "array",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -1246,7 +1308,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "",
@@ -1254,6 +1317,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\Cassandra\\MaterializedView|null",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -1271,6 +1335,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "array",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -1297,7 +1362,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     },
                     {
                         "name": "params",
@@ -1313,7 +1379,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "",
@@ -1321,6 +1388,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\Cassandra\\Function_|null",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -1338,6 +1406,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "array",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -1364,7 +1433,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     },
                     {
                         "name": "params",
@@ -1380,7 +1450,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "",
@@ -1388,6 +1459,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\Cassandra\\Aggregate|null",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -1405,6 +1477,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "array",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -1446,7 +1519,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "",
@@ -1454,6 +1528,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\Cassandra\\Numeric",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -1480,7 +1555,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "",
@@ -1488,6 +1564,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\Cassandra\\Numeric",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -1514,7 +1591,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "",
@@ -1522,6 +1600,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\Cassandra\\Numeric",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -1548,7 +1627,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "",
@@ -1556,6 +1636,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\Cassandra\\Numeric",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -1582,7 +1663,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "",
@@ -1590,6 +1672,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\Cassandra\\Numeric",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -1607,6 +1690,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\Cassandra\\Numeric",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -1624,6 +1708,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\Cassandra\\Numeric",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -1641,6 +1726,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\Cassandra\\Numeric",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -1658,6 +1744,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "int",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -1675,6 +1762,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "float",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -1730,7 +1818,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "",
@@ -1738,6 +1827,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\Cassandra\\Keyspace",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -1755,6 +1845,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "array",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -1796,7 +1887,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     },
                     {
                         "name": "options",
@@ -1812,7 +1904,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "",
@@ -1820,6 +1913,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\Cassandra\\Rows",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -1846,7 +1940,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     },
                     {
                         "name": "options",
@@ -1862,7 +1957,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "",
@@ -1870,6 +1966,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\Cassandra\\FutureRows",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -1896,7 +1993,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     },
                     {
                         "name": "options",
@@ -1912,7 +2010,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "",
@@ -1920,6 +2019,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\Cassandra\\PreparedStatement",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -1946,7 +2046,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     },
                     {
                         "name": "options",
@@ -1962,7 +2063,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "",
@@ -1970,6 +2072,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\Cassandra\\FuturePreparedStatement",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -1996,7 +2099,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "",
@@ -2004,6 +2108,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "null",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -2021,6 +2126,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\Cassandra\\FutureClose",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -2038,6 +2144,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "array",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -2055,6 +2162,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\Cassandra\\Schema",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -2101,6 +2209,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -2127,7 +2236,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "",
@@ -2135,6 +2245,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\Cassandra\\Value",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -2152,6 +2263,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "array",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -2169,6 +2281,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -2186,6 +2299,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "float",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -2203,6 +2317,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "float",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -2220,6 +2335,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "int",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -2237,6 +2353,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -2254,6 +2371,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "float",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -2271,6 +2389,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "int",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -2288,6 +2407,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "int",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -2305,6 +2425,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -2322,6 +2443,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "int",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -2339,6 +2461,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -2356,6 +2479,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\Cassandra\\Map",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -2373,6 +2497,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\Cassandra\\Map",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -2390,6 +2515,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "bool",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -2407,6 +2533,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "bool",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -2424,6 +2551,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "int",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -2441,6 +2569,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "int",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -2467,7 +2596,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "",
@@ -2475,6 +2605,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\Cassandra\\Column",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -2492,6 +2623,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "array",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -2509,6 +2641,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "array",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -2526,6 +2659,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "array",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -2543,6 +2677,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "array",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -2560,6 +2695,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "array",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -2606,6 +2742,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -2623,6 +2760,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "int",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -2655,6 +2793,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\Cassandra\\Type",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -2687,6 +2826,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "bool",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -2811,6 +2951,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\QueryMetaData|null",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -2828,6 +2969,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "array|null",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -2874,6 +3016,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "int",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -2908,6 +3051,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -2925,6 +3069,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string|null",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -2942,6 +3087,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string|null",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -2959,6 +3105,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "int",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -3085,6 +3232,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "bool",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -3119,6 +3267,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "array|null",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -3136,6 +3285,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "bool",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -3170,6 +3320,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "array|null",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -3187,6 +3338,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\DateTimeInterface|null",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -3230,7 +3382,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "object|null",
@@ -3238,6 +3391,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "object|null",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -3264,7 +3418,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "bool",
@@ -3272,6 +3427,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "bool",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -3298,7 +3454,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "int",
@@ -3306,6 +3463,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "int",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -3323,6 +3481,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\DateTimeInterface|null",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -3380,7 +3539,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     },
                     {
                         "name": "tags",
@@ -3396,7 +3556,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "\\Couchbase\\ValueRecorder",
@@ -3404,6 +3565,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\ValueRecorder",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -3445,7 +3607,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "array|null",
@@ -3453,6 +3616,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "array|null",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -3501,6 +3665,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\MutationToken|null",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -3535,6 +3700,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -3552,6 +3718,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "int",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -3569,6 +3736,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -3586,6 +3754,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -3618,6 +3787,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -3635,6 +3805,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "int|float|null",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -3652,6 +3823,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "int|float|null",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -3669,6 +3841,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "int",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -3701,6 +3874,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string|null",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -3718,6 +3892,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string|null",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -3735,6 +3910,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string|null",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -3752,6 +3928,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "array|null",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -3769,6 +3946,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "array|null",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -3786,6 +3964,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "array|null",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -3803,6 +3982,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "array|null",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -3820,6 +4000,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "array|null",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -3891,6 +4072,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\QueryMetaData|null",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -3908,6 +4090,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "array|null",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -3988,7 +4171,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     },
                     {
                         "name": "value",
@@ -4004,7 +4188,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -4012,6 +4197,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -4029,6 +4215,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -4070,7 +4257,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     },
                     {
                         "name": "parent",
@@ -4086,7 +4274,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "",
@@ -4094,6 +4283,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -4126,6 +4316,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string|null",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -4190,6 +4381,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -4207,6 +4399,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "int",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -4224,6 +4417,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "int",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -4241,6 +4435,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "int",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -4258,6 +4453,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "array",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -4275,6 +4471,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "array",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -4292,6 +4489,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "array",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -4363,6 +4561,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "int|null",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -4380,6 +4579,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "int|null",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -4397,6 +4597,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "int|null",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -4414,6 +4615,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "int|null",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -4431,6 +4633,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "float|null",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -4448,6 +4651,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "array|null",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -4508,6 +4712,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\SearchMetaData|null",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -4525,6 +4730,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "array|null",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -4542,6 +4748,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "array|null",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -4775,6 +4982,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -4792,6 +5000,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "int",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -4833,7 +5042,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -4841,6 +5051,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -4912,6 +5123,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "int|null",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -4929,6 +5141,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "array|null",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -4992,6 +5205,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "array",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -5024,6 +5238,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\ViewMetaData|null",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -5041,6 +5256,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "array|null",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -5073,6 +5289,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "int<0, max>",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -5105,6 +5322,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -5162,6 +5380,7 @@
                 "phpDoc": null,
                 "sinceVersion": "8.0",
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "void",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -5188,7 +5407,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -5196,6 +5416,7 @@
                 "phpDoc": null,
                 "sinceVersion": "8.0",
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "void",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -5222,7 +5443,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -5230,6 +5452,7 @@
                 "phpDoc": null,
                 "sinceVersion": "8.0",
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "void",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -5256,7 +5479,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -5264,6 +5488,7 @@
                 "phpDoc": null,
                 "sinceVersion": "8.0",
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "void",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -5305,7 +5530,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -5313,6 +5539,7 @@
                 "phpDoc": null,
                 "sinceVersion": "8.0",
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "void",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -5339,7 +5566,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -5347,6 +5575,7 @@
                 "phpDoc": null,
                 "sinceVersion": "8.0",
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "void",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -5373,7 +5602,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -5381,6 +5611,7 @@
                 "phpDoc": null,
                 "sinceVersion": "8.3",
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -5422,7 +5653,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     },
                     {
                         "name": "absolute",
@@ -5440,7 +5672,8 @@
                         },
                         "defaultType": "",
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "\\DateInterval",
@@ -5448,6 +5681,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\DateInterval",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -5476,7 +5710,8 @@
                         },
                         "defaultType": "",
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "string",
@@ -5484,6 +5719,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -5501,6 +5737,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "int|false",
                 "languageLevelTypes": {
                     "8.0": "int"
@@ -5520,6 +5757,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "int",
                 "languageLevelTypes": {
                     "8.1": "int"
@@ -5539,6 +5777,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\DateTimeZone|false",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -5556,6 +5795,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": "8.5",
                 "returnTypeFromPhpDoc": "void",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -5573,6 +5813,7 @@
                 "phpDoc": null,
                 "sinceVersion": "8.2",
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -5599,7 +5840,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -5607,6 +5849,7 @@
                 "phpDoc": null,
                 "sinceVersion": "8.2",
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -5624,6 +5867,7 @@
                 "phpDoc": null,
                 "sinceVersion": "8.4",
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -5769,6 +6013,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -5795,7 +6040,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -5803,6 +6049,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -5829,7 +6076,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -5837,6 +6085,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -5863,7 +6112,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -5871,6 +6121,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -5912,7 +6163,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -5920,6 +6172,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -5946,7 +6199,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -5954,6 +6208,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -5980,7 +6235,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -5988,6 +6244,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -6014,7 +6271,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "\\Dom\\Element|null",
@@ -6022,6 +6280,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -6048,7 +6307,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "\\Dom\\NodeList",
@@ -6056,6 +6316,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\NodeList<\\Element>",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -6088,6 +6349,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -6105,6 +6367,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "static",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -6122,6 +6385,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "bool",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -6139,6 +6403,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "TValue[]",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -6184,7 +6449,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "bool",
@@ -6192,6 +6458,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "bool",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -6209,6 +6476,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "mixed",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -6250,7 +6518,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "bool",
@@ -6258,6 +6527,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -6275,6 +6545,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "mixed",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -6316,7 +6587,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -6324,6 +6596,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -6350,7 +6623,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -6358,6 +6632,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -6375,6 +6650,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "int",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -6401,7 +6677,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "bool",
@@ -6409,6 +6686,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "bool",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -6435,7 +6713,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "",
@@ -6443,6 +6722,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\Sequence<TValue>",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -6469,7 +6749,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "",
@@ -6477,6 +6758,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "int|false",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -6494,6 +6776,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "TValue",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -6520,7 +6803,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "",
@@ -6528,6 +6812,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "TValue",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -6554,7 +6839,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     },
                     {
                         "name": "values",
@@ -6570,7 +6856,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -6578,6 +6865,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -6604,7 +6892,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "string",
@@ -6612,6 +6901,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -6629,6 +6919,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "TValue",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -6655,7 +6946,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "\\Ds\\Sequence",
@@ -6663,6 +6955,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\Sequence<TNewValue>",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -6689,7 +6982,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "\\Ds\\Sequence",
@@ -6697,6 +6991,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\Sequence<TValue|TValue2>",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -6714,6 +7009,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "TValue",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -6740,7 +7036,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -6748,6 +7045,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -6774,7 +7072,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     },
                     {
                         "name": "initial",
@@ -6790,7 +7089,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "",
@@ -6798,6 +7098,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "TCarry",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -6824,7 +7125,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "",
@@ -6832,6 +7134,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "TValue",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -6849,6 +7152,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -6866,6 +7170,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\Sequence<TValue>",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -6892,7 +7197,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -6900,6 +7206,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -6926,7 +7233,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     },
                     {
                         "name": "value",
@@ -6942,7 +7250,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -6950,6 +7259,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -6967,6 +7277,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "TValue",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -6993,7 +7304,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     },
                     {
                         "name": "length",
@@ -7009,7 +7321,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "",
@@ -7017,6 +7330,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\Sequence<TValue>",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -7043,7 +7357,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -7051,6 +7366,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -7077,7 +7393,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "",
@@ -7085,6 +7402,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\Sequence<TValue>",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -7102,6 +7420,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "float|int",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -7128,7 +7447,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -7136,6 +7456,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -7180,7 +7501,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     },
                     {
                         "name": "value",
@@ -7196,7 +7518,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -7204,6 +7527,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "void",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -7236,6 +7560,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -7253,6 +7578,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -7270,6 +7596,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -7296,7 +7623,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     },
                     {
                         "name": "type",
@@ -7312,7 +7640,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     },
                     {
                         "name": "subtype",
@@ -7328,7 +7657,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     },
                     {
                         "name": "action",
@@ -7344,7 +7674,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     },
                     {
                         "name": "timestamp",
@@ -7360,7 +7691,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "\\Elastic\\Apm\\SpanInterface",
@@ -7368,6 +7700,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\SpanInterface",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -7394,7 +7727,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     },
                     {
                         "name": "type",
@@ -7410,7 +7744,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     },
                     {
                         "name": "callback",
@@ -7426,7 +7761,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     },
                     {
                         "name": "subtype",
@@ -7442,7 +7778,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     },
                     {
                         "name": "action",
@@ -7458,7 +7795,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     },
                     {
                         "name": "timestamp",
@@ -7474,7 +7812,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "",
@@ -7482,6 +7821,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "mixed",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -7508,7 +7848,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -7516,6 +7857,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -7542,7 +7884,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -7550,6 +7893,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -7567,6 +7911,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -7593,7 +7938,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -7601,6 +7947,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -7627,7 +7974,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -7635,6 +7983,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -7652,6 +8001,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -7678,7 +8028,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "string|null",
@@ -7686,6 +8037,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string|null",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -7712,7 +8064,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "string|null",
@@ -7720,6 +8073,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string|null",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -7746,7 +8100,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -7754,6 +8109,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "void",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -7771,6 +8127,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -7788,6 +8145,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -7805,6 +8163,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -7846,7 +8205,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -7854,6 +8214,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "void",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -7895,7 +8256,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     },
                     {
                         "name": "resource",
@@ -7911,7 +8273,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     },
                     {
                         "name": "type",
@@ -7927,7 +8290,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -7935,6 +8299,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -7976,7 +8341,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -7984,6 +8350,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "void",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -8010,7 +8377,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -8018,6 +8386,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "void",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -8044,7 +8413,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -8052,6 +8422,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "void",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -8084,6 +8455,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -8101,6 +8473,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -8118,6 +8491,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -8152,6 +8526,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -8169,6 +8544,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -8195,7 +8571,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -8203,6 +8580,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "void",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -8229,7 +8607,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -8237,6 +8616,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -8254,6 +8634,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -8280,7 +8661,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     },
                     {
                         "name": "duration",
@@ -8296,7 +8678,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -8304,6 +8687,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -8338,6 +8722,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\TransactionBuilderInterface",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -8364,7 +8749,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "self",
@@ -8372,6 +8758,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\TransactionBuilderInterface",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -8398,7 +8785,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "self",
@@ -8406,6 +8794,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\TransactionBuilderInterface",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -8423,6 +8812,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\TransactionInterface",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -8449,7 +8839,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "",
@@ -8457,6 +8848,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "mixed",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -8489,6 +8881,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -8532,7 +8925,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -8540,6 +8934,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "void",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -8557,6 +8952,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -8598,7 +8994,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -8606,6 +9003,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "void",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -8632,7 +9030,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -8640,6 +9039,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "void",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -8666,7 +9066,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -8674,6 +9075,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "void",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -8700,7 +9102,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -8708,6 +9111,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "void",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -8734,7 +9138,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -8742,6 +9147,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "void",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -8768,7 +9174,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -8776,6 +9183,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "void",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -8802,7 +9210,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -8810,6 +9219,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "void",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -8842,6 +9252,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -8859,6 +9270,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -8885,7 +9297,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     },
                     {
                         "name": "type",
@@ -8901,7 +9314,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     },
                     {
                         "name": "subtype",
@@ -8917,7 +9331,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     },
                     {
                         "name": "action",
@@ -8933,7 +9348,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     },
                     {
                         "name": "timestamp",
@@ -8949,7 +9365,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "\\Elastic\\Apm\\SpanInterface",
@@ -8957,6 +9374,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\SpanInterface",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -8983,7 +9401,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     },
                     {
                         "name": "type",
@@ -8999,7 +9418,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     },
                     {
                         "name": "callback",
@@ -9015,7 +9435,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     },
                     {
                         "name": "subtype",
@@ -9031,7 +9452,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     },
                     {
                         "name": "action",
@@ -9047,7 +9469,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     },
                     {
                         "name": "timestamp",
@@ -9063,7 +9486,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "",
@@ -9071,6 +9495,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "mixed",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -9088,6 +9513,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\SpanInterface",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -9105,6 +9531,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -9131,7 +9558,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -9139,6 +9567,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "void",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -9156,6 +9585,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -9173,6 +9603,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -9216,7 +9647,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "static",
@@ -9224,6 +9656,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "static",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -9250,7 +9683,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "static|null",
@@ -9258,6 +9692,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "static|null",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -9306,6 +9741,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "TValue",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -9323,6 +9759,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "void",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -9340,6 +9777,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "TKey|null",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -9357,6 +9795,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "bool",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -9374,6 +9813,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "void",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -9408,6 +9848,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\Traversable<TKey,TValue>|TValue[]",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -9442,6 +9883,7 @@
                 "phpDoc": null,
                 "sinceVersion": "5.4",
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "mixed",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -9483,7 +9925,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "\\MongoCursorInterface",
@@ -9491,6 +9934,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -9508,6 +9952,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -9525,6 +9970,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -9542,6 +9988,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -9568,7 +10015,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     },
                     {
                         "name": "tags",
@@ -9584,7 +10032,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "\\MongoCursorInterface",
@@ -9592,6 +10041,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -9618,7 +10068,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "\\MongoCursorInterface",
@@ -9626,6 +10077,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -9660,6 +10112,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -9677,6 +10130,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "int",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -9694,6 +10148,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -9726,6 +10181,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -9758,6 +10214,7 @@
                 "phpDoc": null,
                 "sinceVersion": "1.3.0",
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -9775,6 +10232,7 @@
                 "phpDoc": null,
                 "sinceVersion": "1.3.0",
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "object|null",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -9792,6 +10250,7 @@
                 "phpDoc": null,
                 "sinceVersion": "1.3.0",
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -9852,6 +10311,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "int",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -9869,6 +10329,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -9901,6 +10362,7 @@
                 "phpDoc": null,
                 "sinceVersion": "1.17.0",
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -9936,6 +10398,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -9953,6 +10416,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -9970,6 +10434,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -10002,6 +10467,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -10036,6 +10502,7 @@
                 "phpDoc": null,
                 "sinceVersion": "1.3.0",
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "int",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -10053,6 +10520,7 @@
                 "phpDoc": null,
                 "sinceVersion": "1.3.0",
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "int",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -10070,6 +10538,7 @@
                 "phpDoc": null,
                 "sinceVersion": "1.3.0",
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -10116,6 +10585,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\DateTime",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -10133,6 +10603,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\DateTimeImmutable",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -10150,6 +10621,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -10191,7 +10663,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -10199,6 +10672,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -10233,6 +10707,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -10250,6 +10725,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\Int64",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -10267,6 +10743,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\Server",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -10284,6 +10761,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "bool",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -10301,6 +10779,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -10327,7 +10806,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -10335,6 +10815,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -10352,6 +10833,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "array",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -10411,7 +10893,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -10419,6 +10902,7 @@
                 "phpDoc": null,
                 "sinceVersion": "1.3.0",
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "void",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -10445,7 +10929,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -10453,6 +10938,7 @@
                 "phpDoc": null,
                 "sinceVersion": "1.3.0",
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "void",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -10479,7 +10965,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -10487,6 +10974,7 @@
                 "phpDoc": null,
                 "sinceVersion": "1.3.0",
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "void",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -10530,7 +11018,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     },
                     {
                         "name": "domain",
@@ -10546,7 +11035,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     },
                     {
                         "name": "message",
@@ -10562,7 +11052,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -10570,6 +11061,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -10662,7 +11154,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -10670,6 +11163,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -10696,7 +11190,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -10704,6 +11199,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -10730,7 +11226,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -10738,6 +11235,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -10764,7 +11262,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -10772,6 +11271,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -10798,7 +11298,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -10806,6 +11307,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -10832,7 +11334,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -10840,6 +11343,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -10866,7 +11370,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -10874,6 +11379,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -10900,7 +11406,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -10908,6 +11415,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -10934,7 +11442,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -10942,6 +11451,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -10990,6 +11500,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\Iterator|null",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -11040,6 +11551,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -11072,6 +11584,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "bool",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -11089,6 +11602,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\RecursiveIterator|null",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -11123,6 +11637,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": "7.4",
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string|null",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -11140,6 +11655,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": {
                     "8.0": "string"
@@ -11187,7 +11703,8 @@
                         },
                         "defaultType": "",
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -11195,6 +11712,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "void",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -11229,6 +11747,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string|null",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -11257,7 +11776,8 @@
                         },
                         "defaultType": "",
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "",
@@ -11265,6 +11785,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "void",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -11297,6 +11818,7 @@
                 "phpDoc": null,
                 "sinceVersion": "5.4",
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "bool",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -11325,7 +11847,8 @@
                         },
                         "defaultType": "",
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "bool",
@@ -11333,6 +11856,7 @@
                 "phpDoc": null,
                 "sinceVersion": "5.4",
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "bool",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -11361,7 +11885,8 @@
                         },
                         "defaultType": "",
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "int|false",
@@ -11369,6 +11894,7 @@
                 "phpDoc": null,
                 "sinceVersion": "5.4",
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "int|false",
                 "languageLevelTypes": {
                     "7.1": "int|false"
@@ -11399,7 +11925,8 @@
                         },
                         "defaultType": "",
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     },
                     {
                         "name": "name",
@@ -11417,7 +11944,8 @@
                         },
                         "defaultType": "",
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "bool",
@@ -11425,6 +11953,7 @@
                 "phpDoc": null,
                 "sinceVersion": "5.4",
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "bool",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -11453,7 +11982,8 @@
                         },
                         "defaultType": "",
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "string|false",
@@ -11461,6 +11991,7 @@
                 "phpDoc": null,
                 "sinceVersion": "5.4",
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string|false",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -11489,7 +12020,8 @@
                         },
                         "defaultType": "",
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     },
                     {
                         "name": "data",
@@ -11507,7 +12039,8 @@
                         },
                         "defaultType": "",
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "bool",
@@ -11515,6 +12048,7 @@
                 "phpDoc": null,
                 "sinceVersion": "5.4",
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "bool",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -11547,6 +12081,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -11588,7 +12123,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "bool",
@@ -11596,6 +12132,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "bool",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -11622,7 +12159,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     },
                     {
                         "name": "data",
@@ -11638,7 +12176,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "bool",
@@ -11646,6 +12185,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "bool",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -11687,7 +12227,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -11695,6 +12236,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "void",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -11736,7 +12278,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -11744,6 +12287,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "void",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -11770,7 +12314,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "void",
@@ -11778,6 +12323,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "void",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -11795,6 +12341,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "void",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -11836,7 +12383,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "static",
@@ -11844,6 +12392,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "static",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -11870,7 +12419,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "static|null",
@@ -11878,6 +12428,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "static|null",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -11912,6 +12463,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -11944,6 +12496,7 @@
                 "phpDoc": null,
                 "sinceVersion": "7.0",
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -11961,6 +12514,7 @@
                 "phpDoc": null,
                 "sinceVersion": "7.0",
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "int",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -11978,6 +12532,7 @@
                 "phpDoc": null,
                 "sinceVersion": "7.0",
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -11995,6 +12550,7 @@
                 "phpDoc": null,
                 "sinceVersion": "7.0",
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "int",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -12012,6 +12568,7 @@
                 "phpDoc": null,
                 "sinceVersion": "7.0",
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "array",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -12029,6 +12586,7 @@
                 "phpDoc": null,
                 "sinceVersion": "7.0",
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -12046,6 +12604,7 @@
                 "phpDoc": null,
                 "sinceVersion": "7.0",
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "null|\\Throwable",
                 "languageLevelTypes": {
                     "8.0": "Throwable|null"
@@ -12065,6 +12624,7 @@
                 "phpDoc": null,
                 "sinceVersion": "7.0",
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": {
                     "8.0": "string"
@@ -12117,6 +12677,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "static[]",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -12158,7 +12719,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "",
@@ -12166,6 +12728,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "bool",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -12192,7 +12755,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     },
                     {
                         "name": "query",
@@ -12208,7 +12772,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "",
@@ -12216,6 +12781,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "bool",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -12257,7 +12823,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     },
                     {
                         "name": "value",
@@ -12273,7 +12840,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "",
@@ -12281,6 +12849,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "bool",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -12307,7 +12876,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     },
                     {
                         "name": "tpl_vars",
@@ -12323,7 +12893,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "",
@@ -12331,6 +12902,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "bool",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -12348,6 +12920,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -12374,7 +12947,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     },
                     {
                         "name": "tpl_vars",
@@ -12390,7 +12964,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "",
@@ -12398,6 +12973,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -12424,7 +13000,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "",
@@ -12432,6 +13009,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -12473,7 +13051,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "",
@@ -12481,6 +13060,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "bool",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -12507,7 +13087,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     },
                     {
                         "name": "query",
@@ -12523,7 +13104,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "",
@@ -12531,6 +13113,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "bool",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -12572,7 +13155,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     },
                     {
                         "name": "value",
@@ -12588,7 +13172,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "",
@@ -12596,6 +13181,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\Yaf_View_Interface|bool",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -12622,7 +13208,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     },
                     {
                         "name": "tpl_vars",
@@ -12638,7 +13225,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "",
@@ -12646,6 +13234,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "bool",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -12663,6 +13252,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -12689,7 +13279,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     },
                     {
                         "name": "tpl_vars",
@@ -12705,7 +13296,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "",
@@ -12713,6 +13305,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string|bool",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -12739,7 +13332,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "",
@@ -12747,6 +13341,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "bool",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -12788,7 +13383,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "",
@@ -12796,6 +13392,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -12813,6 +13410,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -12830,6 +13428,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -12856,7 +13455,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     },
                     {
                         "name": "poll",
@@ -12872,7 +13472,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "",
@@ -12880,6 +13481,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -12906,7 +13508,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "",
@@ -12914,6 +13517,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -12940,7 +13544,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "",
@@ -12948,6 +13553,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -13049,6 +13655,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "array",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -13066,6 +13673,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "int",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -13107,7 +13715,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "\\mysql_xdevapi\\CrudOperationBindable",
@@ -13115,6 +13724,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\CrudOperationBindable",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -13156,7 +13766,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "\\mysql_xdevapi\\CrudOperationLimitable",
@@ -13164,6 +13775,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\CrudOperationLimitable",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -13205,7 +13817,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "\\mysql_xdevapi\\CrudOperationSkippable",
@@ -13213,6 +13826,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\CrudOperationSkippable",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -13254,7 +13868,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "\\mysql_xdevapi\\CrudOperationSortable",
@@ -13262,6 +13877,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\CrudOperationSortable",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -13294,6 +13910,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "bool",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -13311,6 +13928,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -13328,6 +13946,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\mysql_xdevapi\\Session",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -13360,6 +13979,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "\\Result",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -13392,6 +14012,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": null,
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -13435,7 +14056,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     },
                     {
                         "name": "type",
@@ -13451,7 +14073,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "",
@@ -13459,6 +14082,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "mixed",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -13485,7 +14109,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     },
                     {
                         "name": "type",
@@ -13501,7 +14126,8 @@
                         "languageLevelTypes": null,
                         "defaultType": null,
                         "sinceVersion": null,
-                        "removedVersion": null
+                        "removedVersion": null,
+                        "deprecatedSinceVersion": null
                     }
                 ],
                 "returnType": "",
@@ -13509,6 +14135,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "string",
                 "languageLevelTypes": null,
                 "defaultType": null
@@ -13526,6 +14153,7 @@
                 "phpDoc": null,
                 "sinceVersion": null,
                 "removedVersion": null,
+                "deprecatedSinceVersion": null,
                 "returnTypeFromPhpDoc": "array",
                 "languageLevelTypes": null,
                 "defaultType": null


### PR DESCRIPTION
to extract version-aware deprecation metadata and enhance function/parameter parsing. Add supporting tests for nuanced handling of attributes and PHPDoc. Update JSON schema to store deprecation version data.