### PR TITLE
Add integrity tests for known problems and stubs cache validation

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -42,6 +42,8 @@
         <testsuite name="Structure">
             <file>tests/StubsStructureValidatorTest.php</file>
             <file>tests/PhpVersionsSyncTest.php</file>
+            <file>tests/KnownProblemsIntegrityTest.php</file>
+            <file>tests/StubsCacheIntegrityTest.php</file>
         </testsuite>
         <testsuite name="Unit">
             <directory>tests/Unit</directory>

--- a/tests/Framework/Storage/JsonParsedDataStorage.php
+++ b/tests/Framework/Storage/JsonParsedDataStorage.php
@@ -102,6 +102,22 @@ class JsonParsedDataStorage implements ParsedDataPersistentStorageProvider
         }
     }
 
+    /**
+     * Load entities from the cache file.
+     *
+     * A missing file yields no entities and is not an error: callers decide whether to
+     * regenerate (see `Runner::isStubsCacheComplete()`), and `MultiFileJsonStorage` constructs a
+     * storage per entity type whether or not every file has been written yet.
+     *
+     * A file that *exists* but cannot be read as JSON is a different matter and throws. Returning
+     * no entities there is indistinguishable from a legitimately empty cache, and the
+     * consequences are silent: a truncated `StubsClasses.json` yielded zero classes while the
+     * other four type files loaded normally, so every class-level check iterated an empty list
+     * and reported success. The suite stayed green while validating nothing. This happened —
+     * commit 51b2a776 carried a 2.3 MB prefix of a 20.4 MB file.
+     *
+     * @throws \RuntimeException if the file exists but is empty, unreadable, or not valid JSON
+     */
     public function load(): void
     {
         if ($this->loaded) {
@@ -115,17 +131,18 @@ class JsonParsedDataStorage implements ParsedDataPersistentStorageProvider
         }
 
         $jsonContent = file_get_contents($this->pathToJsonFile);
-        if ($jsonContent === false || trim($jsonContent) === '') {
-            $this->entities = [];
-            $this->loaded = true;
-            return;
+        if ($jsonContent === false) {
+            throw new \RuntimeException($this->corruptCacheMessage('could not be read'));
+        }
+
+        if (trim($jsonContent) === '') {
+            // An empty entity type serialises to "[]", never to an empty file.
+            throw new \RuntimeException($this->corruptCacheMessage('is empty'));
         }
 
         $data = json_decode($jsonContent, true);
         if (!is_array($data)) {
-            $this->entities = [];
-            $this->loaded = true;
-            return;
+            throw new \RuntimeException($this->corruptCacheMessage(sprintf('is not valid JSON (%s)', json_last_error_msg())));
         }
 
         foreach ($data as $entityData) {
@@ -135,5 +152,22 @@ class JsonParsedDataStorage implements ParsedDataPersistentStorageProvider
         }
 
         $this->loaded = true;
+    }
+
+    private function corruptCacheMessage(string $problem): string
+    {
+        $size = @filesize($this->pathToJsonFile);
+
+        return sprintf(
+            "Cache file %s %s (%s bytes).\n"
+            . "It exists, so nothing will regenerate it automatically, and treating it as empty "
+            . "would let checks pass while validating nothing.\n"
+            . "Regenerate with: docker compose -f docker-compose.yml run --rm test_runner php "
+            . "tests/run-stubs-parser.php\n"
+            . "(for a Reflection*.json file, use tests/run-all-reflection-parsers.sh instead)",
+            $this->pathToJsonFile,
+            $problem,
+            $size === false ? 'unknown' : $size
+        );
     }
 }

--- a/tests/KnownProblemsIntegrityTest.php
+++ b/tests/KnownProblemsIntegrityTest.php
@@ -1,0 +1,289 @@
+<?php
+
+namespace StubTests;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use StubTests\Framework\Model\PHPClass;
+use StubTests\Framework\Model\PHPClassLikeObject;
+use StubTests\Framework\Model\PHPInterface;
+use StubTests\Framework\Runner\PhpVersions;
+use StubTests\Framework\Runner\RunnerScope;
+use StubTests\Framework\Validator\KnownProblems\DefaultKnownProblemsProvider;
+use StubTests\Framework\Validator\KnownProblems\EntityType;
+use StubTests\Framework\Validator\KnownProblems\ProblemDefinition;
+
+/**
+ * Guards `DefaultKnownProblemsProvider` against becoming dead config.
+ *
+ * A known problem suppresses a check for a named entity. If that entity is later renamed or
+ * removed from the stubs, the entry stops matching anything — but nothing fails, because a
+ * suppression that never fires looks exactly like a suppression that was not needed. The entry
+ * survives as documentation of a problem that no longer exists at an id that no longer exists,
+ * and the next reader trusts it.
+ *
+ * A typo made when *writing* an entry is already caught: the failure it was meant to suppress
+ * simply stays red. This test covers the other direction — an entry that was correct when
+ * written and has since drifted.
+ *
+ * Scope, stated plainly: this asserts the entity **exists**. It does not assert the suppression
+ * is still **needed** — an entry whose underlying divergence PHP has since fixed keeps passing
+ * here. Detecting that means re-running each affected check with the suppression lifted, which
+ * is a larger piece of work; see T-W4 in `.claude/reviews/REVIEW-2026-08-04-deprecated-since.md`.
+ */
+class KnownProblemsIntegrityTest extends TestCase
+{
+    /**
+     * @return array<string, array{ProblemDefinition, string}>
+     */
+    public static function knownProblemEntityIdProvider(): array
+    {
+        $cases = [];
+
+        foreach ((new DefaultKnownProblemsProvider())->getProblems() as $problem) {
+            // $entityIds, when present, replaces $entityId — which is then only a grouping label
+            // and must not be resolved as an entity in its own right.
+            foreach ($problem->entityIds ?: [$problem->entityId] as $entityId) {
+                $cases[$problem->entityType->value . ' ' . $entityId] = [$problem, $entityId];
+            }
+        }
+
+        return $cases;
+    }
+
+    #[DataProvider('knownProblemEntityIdProvider')]
+    public function testKnownProblemEntityStillExistsInStubs(ProblemDefinition $problem, string $entityId): void
+    {
+        $exists = self::entityExistsInStubs($problem->entityType, $entityId);
+
+        // Some problems describe an entity reflection reports but the stubs deliberately omit —
+        // \TRUE, \FALSE and \NULL are language keywords the runtime lists as constants. Those
+        // must not be read as dead config, so reflection is consulted before failing.
+        if ($exists === false && self::entityExistsInReflection($problem, $entityId)) {
+            $exists = true;
+        }
+
+        if ($exists === null) {
+            // The model cannot answer for this entity kind. Failing would blame the entry for a
+            // framework gap, so the gap is surfaced as a skip instead.
+            self::markTestSkipped(sprintf(
+                "Cannot resolve %s '%s': PHPInterface and PHPEnum do not model properties, and "
+                . "StubInterfaceParser does not parse them. PHP 8.4 permits property declarations "
+                . "in interfaces, so this is a modelling gap, not a stale entry.",
+                $problem->entityType->value,
+                $entityId
+            ));
+        }
+
+        self::assertTrue(
+            $exists,
+            sprintf(
+                "Known problem references %s '%s', which no longer exists in the stubs.\n"
+                . "The suppression can never fire, so it is dead config. Either the entity was "
+                . "renamed/removed and the entry should follow it, or the entry should be deleted.\n"
+                . "Reason recorded on the entry: %s",
+                $problem->entityType->value,
+                $entityId,
+                $problem->reason
+            )
+        );
+    }
+
+    /**
+     * Does the entity appear in the reflection data for any version the problem covers?
+     *
+     * Only the versions in the entry's own range are loaded: a problem scoped to 5.6 says
+     * nothing about 8.6, and loading all 13 caches to answer would be wasted work.
+     */
+    private static function entityExistsInReflection(ProblemDefinition $problem, string $entityId): bool
+    {
+        foreach (PhpVersions::cases() as $version) {
+            if (!$problem->versionRange->includes($version->value)) {
+                continue;
+            }
+
+            $reflection = RunnerScope::get()->getReflection($version->value);
+
+            $found = match ($problem->entityType) {
+                EntityType::FUNCTION => self::hasId($reflection->getFunctions(), $entityId),
+                EntityType::GLOBAL_CONSTANT => self::hasId($reflection->getConstants(), $entityId),
+                EntityType::CLASS_TYPE => $reflection->hasClass($entityId),
+                EntityType::INTERFACE_TYPE => $reflection->hasInterface($entityId),
+                EntityType::ENUM_TYPE => $reflection->hasEnum($entityId),
+                // Members are only cross-checked at the class-like level here; a member entry
+                // whose owner is missing from the stubs is reported against the stubs.
+                default => false,
+            };
+
+            if ($found) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return bool|null True/false when the stubs can answer, null when the model cannot
+     *                   represent the entity kind at all (see the PROPERTY branch).
+     */
+    private static function entityExistsInStubs(EntityType $entityType, string $entityId): ?bool
+    {
+        $stubs = RunnerScope::get()->getStubs();
+
+        return match ($entityType) {
+            EntityType::FUNCTION => self::hasId($stubs->getFunctions(), $entityId),
+            EntityType::GLOBAL_CONSTANT => self::hasId($stubs->getConstants(), $entityId),
+            EntityType::CLASS_TYPE => $stubs->hasClass($entityId),
+            EntityType::INTERFACE_TYPE => $stubs->hasInterface($entityId),
+            EntityType::ENUM_TYPE => $stubs->hasEnum($entityId),
+            EntityType::METHOD => self::hasMember($entityId, 'method'),
+            EntityType::PROPERTY => self::hasMember($entityId, 'property'),
+            EntityType::CLASS_CONSTANT,
+            EntityType::INTERFACE_CONSTANT,
+            EntityType::ENUM_CONSTANT => self::hasMember($entityId, 'constant'),
+        };
+    }
+
+    /**
+     * @param array<mixed> $entities
+     */
+    private static function hasId(array $entities, string $entityId): bool
+    {
+        foreach ($entities as $entity) {
+            if ($entity->getId() === $entityId) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Resolve `\Owner::member` against the class, interface and enum tables.
+     *
+     * Inheritance is followed. Validators resolve a member through the stub hierarchy and then
+     * report it under the id they were asked about, so `\SplTempFileObject::fgetss` is a correct
+     * entry id even though only `\SplFileObject` declares the method. Looking at the declaring
+     * type alone would report every such entry as dead config.
+     */
+    private static function hasMember(string $entityId, string $kind): ?bool
+    {
+        $separator = strpos($entityId, '::');
+        if ($separator === false) {
+            return false;
+        }
+
+        $ownerId = substr($entityId, 0, $separator);
+        $memberName = substr($entityId, $separator + 2);
+
+        $owner = self::findClassLike($ownerId);
+        if ($owner === null) {
+            return false;
+        }
+
+        $sawNonClassOwner = false;
+
+        foreach (self::selfAndAncestors($owner) as $type) {
+            $found = match ($kind) {
+                // Method names are case-insensitive in PHP.
+                'method' => self::hasNamed($type->getMethods(), $memberName, caseInsensitive: true),
+                'constant' => self::hasNamed($type->getConstants(), $memberName),
+                // Since PHP 8.4 an interface may declare properties too, but only PHPClass models
+                // them and StubInterfaceParser never parses them. Reporting false for an
+                // interface would blame the entry for a framework gap, so that case is tracked
+                // and surfaced as "unknown" if nothing else matches.
+                default => $type instanceof PHPClass
+                    ? self::hasNamed($type->getProperties(), ltrim($memberName, '$'))
+                    : self::note($sawNonClassOwner),
+            };
+
+            if ($found) {
+                return true;
+            }
+        }
+
+        return $sawNonClassOwner ? null : false;
+    }
+
+    /**
+     * Flags that a property lookup hit a type the model cannot answer for, and reports "not
+     * found" so the walk continues to the remaining ancestors.
+     */
+    private static function note(bool &$sawNonClassOwner): bool
+    {
+        $sawNonClassOwner = true;
+
+        return false;
+    }
+
+    /**
+     * The type itself plus every ancestor reachable through `extends` and `implements`.
+     *
+     * @return list<PHPClassLikeObject>
+     */
+    private static function selfAndAncestors(PHPClassLikeObject $type): array
+    {
+        $seen = [];
+        $queue = [$type];
+
+        while ($queue !== []) {
+            $current = array_shift($queue);
+            $id = $current->getId() ?? spl_object_hash($current);
+            if (isset($seen[$id])) {
+                continue; // guards against a malformed cyclic hierarchy
+            }
+            $seen[$id] = $current;
+
+            if ($current instanceof PHPClass && $current->getParentClass() !== null) {
+                $queue[] = $current->getParentClass();
+            }
+            if ($current instanceof PHPInterface) {
+                foreach ($current->getParentInterfaces() as $parent) {
+                    $queue[] = $parent;
+                }
+            }
+            foreach ($current->getImplementedInterfaces() as $interface) {
+                // Implemented interfaces may be stored as names rather than resolved objects.
+                $resolved = is_string($interface) ? self::findClassLike($interface) : $interface;
+                if ($resolved !== null) {
+                    $queue[] = $resolved;
+                }
+            }
+        }
+
+        return array_values($seen);
+    }
+
+    private static function findClassLike(string $ownerId): ?PHPClassLikeObject
+    {
+        $stubs = RunnerScope::get()->getStubs();
+
+        foreach ([$stubs->getClasses(), $stubs->getInterfaces(), $stubs->getEnums()] as $table) {
+            foreach ($table as $entity) {
+                if ($entity->getId() === $ownerId) {
+                    return $entity;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<mixed> $members
+     */
+    private static function hasNamed(array $members, string $name, bool $caseInsensitive = false): bool
+    {
+        foreach ($members as $member) {
+            $matches = $caseInsensitive
+                ? strcasecmp($member->getName(), $name) === 0
+                : $member->getName() === $name;
+            if ($matches) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/StubsCacheIntegrityTest.php
+++ b/tests/StubsCacheIntegrityTest.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace StubTests;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use StubTests\Framework\Runner\PhpVersions;
+use StubTests\Framework\Runner\RunnerScope;
+
+/**
+ * Asserts the caches the validators read actually contain data.
+ *
+ * `Runner::isStubsCacheComplete()` only checks that the six cache files exist — not that any of
+ * them holds anything. `JsonParsedDataStorage::load()` now throws on a file it cannot parse, so
+ * the specific failure that motivated this test (a truncated `StubsClasses.json` decoding to
+ * zero classes) can no longer pass silently. This test is the second line: it fails if a cache
+ * ever loads *successfully* but comes back empty or absurdly small.
+ *
+ * That distinction matters because an empty cache does not make the suite red. Every check
+ * iterates the entities it is given; given none, it reports success. A green `General` run is
+ * therefore consistent with validating nothing at all, and only an explicit assertion on the
+ * size of the loaded data can tell the two apart.
+ *
+ * The floors below are deliberately far under the real counts. They are a "did this load at
+ * all" tripwire, not an inventory — tightening them to the current numbers would turn every
+ * legitimate stub addition or removal into a failure.
+ */
+class StubsCacheIntegrityTest extends TestCase
+{
+    /**
+     * Entity type => minimum plausible count. Real counts as of PHP 8.6 support are given for
+     * context; the floors sit roughly an order of magnitude below them.
+     *
+     * @var array<string, array{0: int, 1: int}> [floor, count when written]
+     */
+    private const STUB_FLOORS = [
+        'classes' => [500, 1416],
+        'functions' => [1000, 5177],
+        'interfaces' => [50, 151],
+        'enums' => [5, 18],
+        'constants' => [1000, 8255],
+    ];
+
+    /**
+     * @return array<string, array{string, int, int}>
+     */
+    public static function stubEntityTypeProvider(): array
+    {
+        $cases = [];
+        foreach (self::STUB_FLOORS as $type => [$floor, $observed]) {
+            $cases[$type] = [$type, $floor, $observed];
+        }
+
+        return $cases;
+    }
+
+    #[DataProvider('stubEntityTypeProvider')]
+    public function testStubsCacheHoldsAPlausibleNumberOf(string $type, int $floor, int $observed): void
+    {
+        $stubs = RunnerScope::get()->getStubs();
+
+        $count = match ($type) {
+            'classes' => count($stubs->getClasses()),
+            'functions' => count($stubs->getFunctions()),
+            'interfaces' => count($stubs->getInterfaces()),
+            'enums' => count($stubs->getEnums()),
+            'constants' => count($stubs->getConstants()),
+        };
+
+        self::assertGreaterThanOrEqual(
+            $floor,
+            $count,
+            sprintf(
+                "The stubs cache loaded only %d %s (expected at least %d; there were %d when this "
+                . "floor was set).\nAn undersized cache does not fail any validator — the checks "
+                . "simply iterate nothing and pass — so this is very likely a truncated or "
+                . "partially written tests/cache/Stubs*.json.\nRegenerate with: docker compose -f "
+                . "docker-compose.yml run --rm test_runner php tests/run-stubs-parser.php",
+                $count,
+                $type,
+                $floor,
+                $observed
+            )
+        );
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function phpVersionProvider(): array
+    {
+        $cases = [];
+        foreach (PhpVersions::cases() as $version) {
+            $cases[$version->value] = [$version->value];
+        }
+
+        return $cases;
+    }
+
+    /**
+     * The reflection caches are the other half of every comparison. An empty one makes the
+     * checks for that version vacuous in exactly the same way.
+     *
+     * The floors are much lower than the stub ones and that is expected, not a smell: the
+     * per-version Docker images load a fraction of the extensions the stubs describe. Measured
+     * across all 13 caches the minimum is PHP 5.6 with 156 classes and 1641 functions (the
+     * newest, 8.6, has 313 and 2183), so the floors sit just under the smallest real cache.
+     */
+    #[DataProvider('phpVersionProvider')]
+    public function testReflectionCacheHoldsAPlausibleNumberOfEntities(string $phpVersion): void
+    {
+        $reflection = RunnerScope::get()->getReflection($phpVersion);
+
+        self::assertGreaterThanOrEqual(
+            100,
+            count($reflection->getClasses()),
+            sprintf(
+                'Reflection cache for PHP %s loaded implausibly few classes (smallest real cache '
+                . 'is 5.6 with 156). Regenerate with tests/run-all-reflection-parsers.sh',
+                $phpVersion
+            )
+        );
+        self::assertGreaterThanOrEqual(
+            1000,
+            count($reflection->getFunctions()),
+            sprintf(
+                'Reflection cache for PHP %s loaded implausibly few functions (smallest real '
+                . 'cache is 5.6 with 1641).',
+                $phpVersion
+            )
+        );
+    }
+}


### PR DESCRIPTION
- Introduce `KnownProblemsIntegrityTest` to ensure known problem suppressions reference existing entities in stubs.
- Add `StubsCacheIntegrityTest` to validate the stubs and reflection caches contain plausible data thresholds.
- Update `phpunit.xml.dist` to include new tests in the `Structure` suite.
- Enhance `JsonParsedDataStorage` to throw exceptions for invalid or corrupted cache files to prevent silent test failures.