### PR TITLE
Update ZipArchive::open

### DIFF
--- a/zip/zip.php
+++ b/zip/zip.php
@@ -706,68 +706,71 @@ class ZipArchive implements Countable
      * @param int $flags [optional] <p>
      * The mode to use to open the archive.
      * </p>
-     * <p>
-     * <b>ZipArchive::OVERWRITE</b>
-     * </p>
+	 * <table>
+	 * <tr valign="top">
+	 * <td><b>ZipArchive::OVERWRITE</b></td>
+	 * <td>If archive exists, ignore its current contents. In other words, handle it the same way as an empty archive</td>
+	 * </tr>
+	 * <tr valign="top">
+	 * <td><b>ZipArchive::CREATE</b></td>
+	 * <td>Create the archive if it does not exist</td>
+	 * </tr>
+	 * <tr valign="top">
+	 * <td><b>ZipArchive::RDONLY</b></td>
+	 * <td>Open archive in read only mode. Available as of PHP 7.4.3 and PECL zip 1.17.1, respectively, if built against libzip ≥ 1.0.0</td>
+	 * </tr>
+	 * <tr valign="top">
+	 * <td><b>ZipArchive::EXCL</b></td>
+	 * <td>Error if archive already exists</td>
+	 * </tr>
+	 * <tr valign="top">
+	 * <td><b>ZipArchive::CHECKCONS</b></td>
+	 * <td>Perform additional consistency checks on the archive, and error if they fail</td>
+	 * </tr>
+	 * </table>
      *
      * @return int|bool <i>Error codes</i>
      * <p>
      * Returns <b>TRUE</b> on success, <b>FALSE</b> or the error code on error.
      * </p>
-     * <p>
-     * <b>ZipArchive::ER_EXISTS</b>
-     * </p>
-     * <p>
-     * File already exists.
-     * </p>
-     * <p>
-     * <b>ZipArchive::ER_INCONS</b>
-     * </p>
-     * <p>
-     * Zip archive inconsistent.
-     * </p>
-     * <p>
-     * <b>ZipArchive::ER_INVAL</b>
-     * </p>
-     * <p>
-     * Invalid argument.
-     * </p>
-     * <p>
-     * <b>ZipArchive::ER_MEMORY</b>
-     * </p>
-     * <p>
-     * Malloc failure.
-     * </p>
-     * <p>
-     * <b>ZipArchive::ER_NOENT</b>
-     * </p>
-     * <p>
-     * No such file.
-     * </p>
-     * <p>
-     * <b>ZipArchive::ER_NOZIP</b>
-     * </p>
-     * <p>
-     * Not a zip archive.
-     * </p>
-     * <p>
-     * <b>ZipArchive::ER_OPEN</b>
-     * </p>
-     * <p>
-     * Can't open file.
-     * </p>
-     * <p>
-     * <b>ZipArchive::ER_READ</b>
-     * </p>
-     * <p>
-     * Read error.
-     * </p>
-     * <p>
-     * <b>ZipArchive::ER_SEEK</b>
-     * </p>
-     * <p>
-     * Seek error.
-     * </p>
+	 * <table>
+	 * <tr valign="top">
+	 * <td><b>ZipArchive::ER_EXISTS</b></td>
+	 * <td>File already exists</td>
+	 * </tr>
+	 * <tr valign="top">
+	 * <td><b>ZipArchive::ER_INCONS</b></td>
+	 * <td>Zip archive inconsistent</td>
+	 * </tr>
+	 * <tr valign="top">
+	 * <td><b>ZipArchive::ER_INVAL</b></td>
+	 * <td>Invalid argument</td>
+	 * </tr>
+	 * <tr valign="top">
+	 * <td><b>ZipArchive::ER_MEMORY</b></td>
+	 * <td>Malloc failure</td>
+	 * </tr>
+	 * <tr valign="top">
+	 * <td><b>ZipArchive::ER_NOENT</b></td>
+	 * <td>No such file</td>
+	 * </tr>
+	 * <tr valign="top">
+	 * <td><b>ZipArchive::ER_NOZIP</b></td>
+	 * <td>Not a zip archive</td>
+	 * </tr>
+	 * <tr valign="top"></tr>
+	 * <td><b>ZipArchive::ER_OPEN</b></td>
+	 * <td>Can't open file</td>
+	 * </tr>
+	 * <tr valign="top">
+	 * <td><b>ZipArchive::ER_READ</b></td>
+	 * <td>Read error</td>
+	 * </tr>
+	 * <tr valign="top">
+	 * <td><b>ZipArchive::ER_SEEK</b></td>
+	 * <td>Seek error</td>
+	 * </tr>
+	 * </table>
      */
     #[TentativeType]
     public function open(


### PR DESCRIPTION
Include all flags for the `$flags` paramater with their documentation.  In addition, reformat return error codes into table.

Before:
<img width="554" height="583" alt="Screenshot of rendered existing documentation" src="https://github.com/user-attachments/assets/da000781-c449-43d7-b004-85684ab2269d" />


After:
<img width="591" height="703" alt="Screenshot of rendered updated documentation" src="https://github.com/user-attachments/assets/08402dca-257d-4950-83ed-d84add129566" />
