### PR TITLE
Fix return type of `openssl_x509_parse`

### DIFF
--- a/openssl/openssl.php
+++ b/openssl/openssl.php
@@ -282,9 +282,9 @@ function openssl_x509_free(#[LanguageLevelTypeAware(["8.0" => "OpenSSLCertificat
  */
 #[ArrayShape([
     'name' => 'string',
-    'subject' => 'string',
+    'subject' => 'array',
     'hash' => 'string',
-    'issuer' => 'string',
+    'issuer' => 'array',
     'version' => 'int',
     'serialNumber' => 'string',
     'serialNumberHex' => 'string',


### PR DESCRIPTION
`subject` and `issuer` both are `array`

Example from php tests: https://github.com/php/php-src/blob/2f08d44e867b567fafe79b4da3a692d64263f003/ext/openssl/tests/openssl_x509_parse_basic.phpt#L23