### PR TITLE
Scope DatePeriod constructor exception annotation to PHP 8.3+

### DIFF
--- a/date/date_c.php
+++ b/date/date_c.php
@@ -1538,9 +1538,20 @@ class DatePeriod implements IteratorAggregate
      * Creates a new DatePeriod object
      * @param string $isostr String containing the ISO interval.
      * @param int $options Can be set to DatePeriod::EXCLUDE_START_DATE.
+     * @throws Exception when the $isostr cannot be parsed as a valid ISO 8601 period.
+     * @link https://php.net/manual/en/dateperiod.construct.php
+     */
+    #[PhpStormStubsElementAvailable(from: '5.3', to: '8.2')]
+    public function __construct($isostr, $options = 0) {}
+
+    /**
+     * Creates a new DatePeriod object
+     * @param string $isostr String containing the ISO interval.
+     * @param int $options Can be set to DatePeriod::EXCLUDE_START_DATE.
      * @throws DateMalformedPeriodStringException
      * @link https://php.net/manual/en/dateperiod.construct.php
      */
+    #[PhpStormStubsElementAvailable(from: '8.3')]
     public function __construct($isostr, $options = 0) {}
 
     /**


### PR DESCRIPTION
DateMalformedPeriodStringException was introduced in PHP 8.3, but the DatePeriod ISO string constructor stub declared it without version constraints, causing IDEs to incorrectly flag it in earlier PHP versions.